### PR TITLE
chore(ci): project board smoke test (refs #22)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,6 @@
+# board-smoke-test: temproary marker added to verify the Github Project board's "Pull request merged" workflow.
+# Will be removed by story 1.4's real fix when it lands.
+
 name: Deploy
 
 on:


### PR DESCRIPTION
Smoke test for story 1.20 acceptance criterion AC-7. This PR adds no-op comment marker to deploy.yml so the merge can be observed against issue #22 in the project board.

This is NOT the real fix for story 1.4. The marker wil be removed when 1.4 ships its actual `workflow_run` typo + concurrency fix. Issue #22 will be reopened immediately after this PR merges so 1.4 has a target.

Closes #22 