### PR TITLE
fix(seed): complete env migration missed in #44

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -5,7 +5,7 @@ import { env } from '@/lib/env'
 const prisma = new PrismaClient()
 
 async function main() {
-  const hash = await bcrypt.hash(process.env.ADMIN_PASS ?? 'changeme', 12)
+  const hash = await bcrypt.hash(env.ADMIN_PASS ?? 'changeme', 12)
 
   await prisma.user.upsert({
     where: { email: 'admin@tracker.local' },


### PR DESCRIPTION
Closes #19

Follow-up to #44. The PR landed the `import { env } from '@/lib/env'` line in `prisma/seed.ts` but missed renaming the actual usage on line 8 — it still read `process.env.ADMIN_PASS`. AC-2 of story 1.1 (single source of truth for env access) was therefore not satisfied at merge time.

`pnpm lint` did not catch this because `next lint`'s default scope excludes `prisma/`. Logged in workspace memory at `reference_next_lint_default_scope.md` so the lint coverage gap is addressed in story 1.15 (CI lint config).

This PR is one line:

```diff
-  const hash = await bcrypt.hash(process.env.ADMIN_PASS ?? 'changeme', 12)
+  const hash = await bcrypt.hash(env.ADMIN_PASS ?? 'changeme', 12)
```

Local verification: `pnpm test` 2/2, `pnpm typecheck` clean, `pnpm lint` clean, `grep -rn "process\.env\." app lib middleware.ts prisma` returns zero hits.