### PR TITLE
chore(compose): fail fast on missing required env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # PostgreSQL
 DATABASE_URL="postgresql://tracker:password@localhost:5432/tracker"
-DB_PASS="your-progress-password"
+DB_PASS="your-postgres-password"
 
 # Redis
 REDIS_URL="redis://localhost:6379"
@@ -24,10 +24,10 @@ IGDB_CLIENT_SECRET=""
 STEAM_API_KEY=""
 STEAM_USER_ID=""
 
-# qBittorent (internal Docker network = do not expose externally)
+# qBittorrent (internal Docker network = do not expose externally)
 QBITTORRENT_HOST="http://qbittorrent:8080"
 QBITTORRENT_USER="admin"
 QBITTORRENT_PASS=""
 
-# Host path for qBittorent downlods volume
+# Host path for qBittorrent downloads volume
 DOWNLOAD_PATH="/your/download/path"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,14 +12,14 @@ services:
     environment:
       - POSTGRES_DB=tracker
       - POSTGRES_USER=tracker
-      - POSTGRES_PASSWORD=${DB_PASS}
+      - "POSTGRES_PASSWORD=${DB_PASS:?DB_PASS is required; see .env.example}"
     ports:
       - "5432:5432"
     volumes:
       - pg_dev_data:/var/lib/postgresql/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "tracker", "-d", "tracker"]
+      test: [ "CMD", "pg_isready", "-U", "tracker", "-d", "tracker" ]
       interval: 5s
       timeout: 3s
       retries: 5
@@ -32,7 +32,7 @@ services:
       - redis_dev_data:/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: [ "CMD", "redis-cli", "ping" ]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
       context: .
       dockerfile: docker/Dockerfile.caddy
     ports:
-      - '80:80'
-      - '443:443'
-      - '443:443/udp'
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
     environment:
       CLOUDFLARE_API_TOKEN: ${CLOUDFLARE_API_TOKEN}
     volumes:
@@ -23,31 +23,43 @@ services:
       dockerfile: docker/Dockerfile
       target: builder
     working_dir: /app
-    command: ['pnpm', 'prisma', 'migrate', 'deploy']
+    command: [ "pnpm", "prisma", "migrate", "deploy" ]
     environment:
-      DATABASE_URL: postgresql://tracker:${DB_PASS}@postgres:5432/tracker
+      DATABASE_URL: postgresql://tracker:${DB_PASS:?DB_PASS is required; see
+        .env.example}@postgres:5432/tracker
     depends_on:
       postgres:
         condition: service_healthy
-    restart: 'no'
+    restart: "no"
 
   app:
     build:
       context: .
       dockerfile: docker/Dockerfile
     environment:
-      - DATABASE_URL=postgresql://tracker:${DB_PASS}@postgres:5432/tracker
+      - "DATABASE_URL=postgresql://tracker:${DB_PASS:?DB_PASS is required; see
+        .env.example}@postgres:5432/tracker"
       - REDIS_URL=redis://redis:6379
-      - NEXTAUTH_SECRET=${NEXTAUTH_SECRET}
-      - NEXTAUTH_URL=${NEXTAUTH_URL}
-      - TMDB_API_KEY=${TMDB_API_KEY}
-      - IGDB_CLIENT_ID=${IGDB_CLIENT_ID}
-      - IGDB_CLIENT_SECRET=${IGDB_CLIENT_SECRET}
-      - STEAM_API_KEY=${STEAM_API_KEY}
-      - STEAM_USER_ID=${STEAM_USER_ID}
+      - "NEXTAUTH_SECRET=${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required; see
+        .env.example}"
+      - "NEXTAUTH_URL=${NEXTAUTH_URL:?NEXTAUTH_URL is required; see
+        .env.example}"
+      - "ADMIN_PASS=${ADMIN_PASS:?ADMIN_PASS is required; see .env.example}"
+      - "TMDB_API_KEY=${TMDB_API_KEY:?TMDB_API_KEY is required; see
+        .env.example}"
+      - "IGDB_CLIENT_ID=${IGDB_CLIENT_ID:?IGDB_CLIENT_ID is required; see
+        .env.example}"
+      - "IGDB_CLIENT_SECRET=${IGDB_CLIENT_SECRET:?IGDB_CLIENT_SECRET is
+        required; see .env.example}"
+      - "STEAM_API_KEY=${STEAM_API_KEY:?STEAM_API_KEY is required; see
+        .env.example}"
+      - "STEAM_USER_ID=${STEAM_USER_ID:?STEAM_USER_ID is required; see
+        .env.example}"
       - QBITTORRENT_HOST=http://qbittorrent:8080
-      - QBITTORRENT_USER=${QBITTORRENT_USER}
-      - QBITTORRENT_PASS=${QBITTORRENT_PASS}
+      - "QBITTORRENT_USER=${QBITTORRENT_USER:?QBITTORRENT_USER is required; see
+        .env.example}"
+      - "QBITTORRENT_PASS=${QBITTORRENT_PASS:?QBITTORRENT_PASS is required; see
+        .env.example}"
     depends_on:
       migrate:
         condition: service_completed_successfully
@@ -58,16 +70,16 @@ services:
   postgres:
     image: postgres:16-alpine
     ports:
-      - '5432:5432'
+      - "5432:5432"
     environment:
       - POSTGRES_DB=tracker
       - POSTGRES_USER=tracker
-      - POSTGRES_PASSWORD=${DB_PASS}
+      - POSTGRES_PASSWORD=${DB_PASS:?DB_PASS is required; see .env.example}
     volumes:
       - pg_data:/var/lib/postgresql/data
     restart: unless-stopped
     healthcheck:
-      test: ['CMD', 'pg_isready', '-U', 'tracker', '-d', 'tracker']
+      test: [ "CMD", "pg_isready", "-U", "tracker", "-d", "tracker" ]
       interval: 5s
       timeout: 3s
       retries: 5
@@ -78,7 +90,7 @@ services:
       - redis_data:/data
     restart: unless-stopped
     healthcheck:
-      test: ['CMD', 'redis-cli', 'ping']
+      test: [ "CMD", "redis-cli", "ping" ]
       interval: 5s
       timeout: 3s
       retries: 5
@@ -91,7 +103,8 @@ services:
       - PGID=1000
     volumes:
       - qb_config:/config
-      - ${DOWNLOAD_PATH:-/tmp/downloads}:/downloads
+      - "${DOWNLOAD_PATH:?DOWNLOAD_PATH is required; see
+        .env.example}:/downloads"
     restart: unless-stopped
     # Internal only - never expose port 8080 externally
 


### PR DESCRIPTION
Closes #20

Migrates every required `${VAR}` interpolation in `docker-compose.yml` and `docker-compose.dev.yml` to `${VAR:?<message>}` so compose refuses to start when a required var is missing or empty. Plumbs `ADMIN_PASS` through the `app` service env list (was absent — would have silently broken `lib/env.ts` validation post-1.1). Flips `${DOWNLOAD_PATH:-/tmp/downloads}` to `:?` so a missing host path refuses to mount instead of silently using a tmpfs that vanishes on restart. Fixes three `.env.example` typos that the new error messages cite.

Local verification:
- `pnpm test` 7/7 passed, `pnpm typecheck` clean, `pnpm lint` clean (no code-path delta vs main).
- AC-5 smoke (compose config with blanked required vars): exit 1 + authored "<VAR> is required; see .env.example" stderr.
- AC-2 grep (every `${VAR}` is `:?`-protected or the intentional optional `${CLOUDFLARE_API_TOKEN}`): clean after a one-character fix on `docker-compose.yml:77` (colon dropped during apply, force-push landed `eac11ab`).
- AC-3 grep (no `${VAR:-default}` defaults anywhere): clean.

Delivery file: `docs/delivery/1-2-compose-fail-fast.md`.

Note for Completion Notes: the AC-2 verify command's exclusion list should add `DATABASE_URL` to `NODE_ENV / CLOUDFLARE_API_TOKEN / REDIS_URL / QBITTORRENT_HOST` — it's constructed in compose from `${DB_PASS:?...}` rather than interpolated, so it doesn't need its own `:?`. Doc-level nit, not an AC violation.