### PR TITLE
fix(ci): correct workflow_run typo and add deploy concurrency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,3 @@
-# board-smoke-test: temproary marker added to verify the Github Project board's "Pull request merged" workflow.
-# Will be removed by story 1.4's real fix when it lands.
-
 name: Deploy
 
 on:
@@ -9,10 +6,14 @@ on:
     types: [completed]
     branches: [main]
 
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.worklow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
 
     steps:
       - name: Deploy to VPS


### PR DESCRIPTION
Closes #22

Fixes the `worklow_run` typo on `.github/workflows/deploy.yml`'s deploy-job `if:` that has silently disabled auto-deploy since 2026-02-25 (v0.1.1). Adds workflow-level concurrency (`group: deploy-prod`, `cancel-in-progress: false`) so two CI greens in quick succession queue rather than race the SSH session and `docker compose up -d` on the VPS. Adds `head_branch == 'main'` defense-in-depth to the `if:`. Removes the no-op marker comment Story 1.20 Task 6 planted at the top of the file (owned by this story per 1.20's Completion Notes).

**AC-4 audit confirmed during draft:** 17 `workflow_run`-triggered Deploy runs from 2026-02-25T07:56:52Z through 2026-05-03T12:00:12Z, every one `completed | skipped` with 0–2s duration. The `''  == 'success'` falsy-collapse signature confirms `deploy_workflow_typo.md`'s hypothesis. Production stack has been frozen at the v0.1.1 image since the typo landed; this PR re-enables auto-deploy at the code-side. End-to-end runtime verification (AC-2) deferred to end-of-project deploy per `feedback_deploy_deferred_to_end_of_project.md`.

Local verification:
- `pnpm test` 7/7, `pnpm typecheck` clean, `pnpm lint` clean (no application code paths change).
- AC-1 negative grep `grep -rn worklow_run .github/`: empty.
- AC-1 positive grep: corrected `if:` line has both `workflow_run.conclusion` and `workflow_run.head_branch` clauses.
- AC-1 trigger-name match: `ci.yml`'s `name: CI` matches `deploy.yml`'s `workflows: [CI]` exactly.
- AC-3 source-side: `concurrency:` at workflow level (sibling of `on:` and `jobs:`); no nested concurrency in `jobs.deploy:`.
- Marker removal: `grep -n 'board-smoke-test\|temproary'` returns empty.

Delivery file: `docs/delivery/1-4-deploy-yml-typo.md`.