### PR TITLE
fix(seed): drop changeme fallback and propagate seed exit code

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -5,7 +5,7 @@ import { env } from '@/lib/env'
 const prisma = new PrismaClient()
 
 async function main() {
-  const hash = await bcrypt.hash(env.ADMIN_PASS ?? 'changeme', 12)
+  const hash = await bcrypt.hash(env.ADMIN_PASS, 12)
 
   await prisma.user.upsert({
     where: { email: 'admin@tracker.local' },
@@ -21,5 +21,14 @@ async function main() {
 }
 
 main()
-  .catch(console.error)
-  .finally(() => prisma.$disconnect())
+  .catch((err) => {
+    console.error('Seed failed: ', err)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    try {
+      await prisma.$disconnect()
+    } catch (err) {
+      console.error('Prisma disconnect failed: ', err)
+    }
+  })


### PR DESCRIPTION
Closes #23

Drops the `?? 'changeme'` fallback on the bcrypt hash call (env schema's `min(8)` already enforces presence at module-load), expands the implicit `.catch(console.error)` shorthand into an explicit handler that logs the failure and sets `process.exitCode = 1`, and wraps `prisma.$disconnect()` inside an async finally with its own try/catch so a disconnect error is logged without overriding the exit code Node accepted from the catch handler.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Source-side: no `changeme` literal in `prisma/seed.ts`; `bcrypt.hash(env.ADMIN_PASS, 12)` present
- [x] Source-side: env schema still has `ADMIN_PASS: z.string().min(8)`
- [x] Source-side: finally block has `try { await prisma.$disconnect() } catch (...)` shape
- [x] Vacuous AC-4: no seed step in `ci.yml` or `deploy.yml`
- [x] Runtime: `unset ADMIN_PASS && pnpm prisma db seed` → non-zero exit (Zod schema throws at module-load)
- [x] Runtime: forced Prisma failure inside `main()` → `Seed failed:` stderr + exit 1
- [x] Runtime: happy-path `ADMIN_PASS=test1234 pnpm prisma db seed` → exit 0, admin row exists