### PR TITLE
chore(health): /api/health liveness route

### DIFF
--- a/app/api/health/__tests__/route.test.ts
+++ b/app/api/health/__tests__/route.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { GET } from '@/app/api/health/route'
+
+describe('GET /api/health', () => {
+  it('returns 200 with status, version, uptime, and ISO 8601 timestamp', async () => {
+    const response = await GET()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toMatch(/application\/json/)
+
+    const body = await response.json()
+
+    expect(body.status).toBe('ok')
+    expect(typeof body.version).toBe('string')
+    expect(body.version.length).toBeGreaterThan(0)
+    expect(typeof body.uptime).toBe('number')
+    expect(body.uptime).toBeGreaterThanOrEqual(0)
+    expect(typeof body.timestamp).toBe('string')
+    expect(Number.isNaN(new Date(body.timestamp).getTime())).toBe(false)
+  })
+
+  it('sets Cache-Control: no-store', async () => {
+    const response = await GET()
+    expect(response.headers.get('cache-control')).toBe('no-store')
+  })
+})

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server'
+import packageJson from '@/package.json'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      status: 'ok',
+      version: packageJson.version,
+      uptime: process.uptime(),
+      timestamp: new Date().toISOString(),
+    },
+    {
+      status: 200,
+      headers: { 'Cache-Control': 'no-store' },
+    },
+  )
+}


### PR DESCRIPTION
Closes #26

Adds the project's first non-NextAuth route handler. `GET /api/health` returns 200 with `{ status, version, uptime, timestamp }` and `Cache-Control: no-store`. The route does no DB call, no Redis call, and no external HTTP call — it answers the single question "is the Node process alive and serving HTTP", which is the contract Caddy's upstream check (Story 1.21), the post-deploy smoke test (Story 1.16), the Docker `HEALTHCHECK` (Story 1.17), and Uptime Kuma (Story 1.19) all need.

## Notable choices (in delivery's Reasoning)

- **Direct JSON import for version** (`import packageJson from '@/package.json'`) — works because `tsconfig.json` already has `resolveJsonModule: true`. Cleaner than the `assert { type: 'json' }` syntax (deprecated) or the env-var-injection path (category error: `version` is a build-time constant, not user-configurable runtime config).
- **No `withRequest` wrapper.** Story 1.6 marked /health as a future consumer, but the handler emits zero log lines and does no I/O — wrapping in ALS scope adds no observable benefit. Story 1.9 (`/api/ready`) is the canonical first consumer because it logs dependency-failure errors. Wrapping /health "for consistency" would be cargo-culting.
- **`export const dynamic = 'force-dynamic'`** prevents Next.js from statically rendering at build time, which would freeze `process.uptime()` to the build server's uptime.
- **AC-2 satisfied by inspection** — `middleware.ts:36` matcher already excludes `/api/health` (was wired in original auth scaffolding before /health existed). Note: this also means the middleware does NOT run for /health responses, so there's no `X-Request-Id` header on the response. Story 1.16's smoke test should not assert on it for this path.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` 15/15 pass (auth: 5, env: 2, middleware: 3, logger: 2, redis: 1, health: 2)
- [x] Local cURL: `GET http://localhost:3000/api/health` returns 200 with `Cache-Control: no-store`, `Content-Type: application/json`, body `{ status: 'ok', version: '0.1.0', uptime: <number>, timestamp: <ISO 8601> }`
- [x] AC-2 closure: same curl with no `Cookie` header returns 200, NOT 302 to /login

## Deferred

- AC-3 production p95 < 200ms verification → end-of-project deploy
- AC-4 Caddy/CDN cache header verification → end-of-project deploy (Story 1.21 hardens Caddyfile)
- AC-5 cross-cutting consumers (Story 1.16 smoke, 1.17 HEALTHCHECK, 1.21 Caddy upstream) → those stories
- CHANGELOG → end-of-phase batch