### PR TITLE
chore(ready): /api/ready readiness route with db+redis checks (#27)

### DIFF
--- a/app/api/ready/__tests__/route.test.ts
+++ b/app/api/ready/__tests__/route.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/db', () => ({
+  db: { $queryRaw: vi.fn() },
+}))
+vi.mock('@/lib/redis', () => ({
+  redis: { ping: vi.fn() },
+}))
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+import { GET } from '@/app/api/ready/route'
+import { db } from '@/lib/db'
+import { redis } from '@/lib/redis'
+import { logger } from '@/lib/logger'
+
+function makeReq() {
+  return new NextRequest('http://localhost:3000/api/ready')
+}
+
+describe('GET /api/ready', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 200 when both DB and Redis are reachable', async () => {
+    vi.mocked(db.$queryRaw).mockResolvedValueOnce([{ '?column?': 1 }] as never)
+    vi.mocked(redis.ping).mockResolvedValueOnce('PONG' as never)
+
+    const response = await GET(makeReq())
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toMatch(/application\/json/)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+
+    const body = await response.json()
+    expect(body.status).toBe('ok')
+    expect(body.db).toBe('ok')
+    expect(body.redis).toBe('ok')
+    expect(typeof body.uptime).toBe('number')
+    expect(body.uptime).toBeGreaterThanOrEqual(0)
+    expect(typeof body.timestamp).toBe('string')
+    expect(Number.isNaN(new Date(body.timestamp).getTime())).toBe(false)
+
+    expect(vi.mocked(logger.error)).not.toHaveBeenCalled()
+  })
+
+  it('returns 503 with db: fail when the DB check rejects', async () => {
+    vi.mocked(db.$queryRaw).mockRejectedValueOnce(
+      new Error('connection refused'),
+    )
+    vi.mocked(redis.ping).mockResolvedValueOnce('PONG' as never)
+
+    const response = await GET(makeReq())
+
+    expect(response.status).toBe(503)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+
+    const body = await response.json()
+    expect(body.status).toBe('degraded')
+    expect(body.db.startsWith('fail:')).toBe(true)
+    expect(body.db).toContain('connection refused')
+    expect(body.redis).toBe('ok')
+
+    expect(vi.mocked(logger.error)).toHaveBeenCalledTimes(1)
+    const [logArg] = vi.mocked(logger.error).mock.calls[0]
+    expect((logArg as { event: string }).event).toBe('ready.check.fail')
+  })
+
+  it('returns 503 with redis: fail when the Redis check rejects', async () => {
+    vi.mocked(db.$queryRaw).mockResolvedValueOnce([{ '?column?': 1 }] as never)
+    vi.mocked(redis.ping).mockRejectedValueOnce(new Error('redis down'))
+
+    const response = await GET(makeReq())
+
+    expect(response.status).toBe(503)
+
+    const body = await response.json()
+    expect(body.status).toBe('degraded')
+    expect(body.db).toBe('ok')
+    expect(body.redis.startsWith('fail:')).toBe(true)
+    expect(body.redis).toContain('redis down')
+  })
+
+  it('returns 503 with both fields failing when both checks reject', async () => {
+    vi.mocked(db.$queryRaw).mockRejectedValueOnce(new Error('db gone'))
+    vi.mocked(redis.ping).mockRejectedValueOnce(new Error('redis gone'))
+
+    const response = await GET(makeReq())
+
+    expect(response.status).toBe(503)
+
+    const body = await response.json()
+    expect(body.status).toBe('degraded')
+    expect(body.db.startsWith('fail:')).toBe(true)
+    expect(body.db).toContain('db gone')
+    expect(body.redis.startsWith('fail:')).toBe(true)
+    expect(body.redis).toContain('redis gone')
+  })
+
+  it('treats a check that exceeds 1000ms as failed (timeout)', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(db.$queryRaw).mockReturnValueOnce(
+        new Promise(() => {}) as never,
+      )
+      vi.mocked(redis.ping).mockResolvedValueOnce('PONG' as never)
+
+      const promise = GET(makeReq())
+      await vi.advanceTimersByTimeAsync(1000)
+      const response = await promise
+
+      expect(response.status).toBe(503)
+      const body = await response.json()
+      expect(body.db).toMatch(/db timeout after 1000ms/)
+      expect(body.redis).toBe('ok')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/app/api/ready/route.ts
+++ b/app/api/ready/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { db } from '@/lib/db'
+import { redis } from '@/lib/redis'
+import { logger } from '@/lib/logger'
+import { withRequest } from '@/lib/request-context'
+
+export const dynamic = 'force-dynamic'
+
+const TIMEOUT_MS = 1000
+
+function withTimeout<T>(p: Promise<T>, label: string): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error(`${label} timeout after ${TIMEOUT_MS}ms`)),
+        TIMEOUT_MS,
+      ),
+    ),
+  ])
+}
+
+async function handler(_req: NextRequest) {
+  const [dbRes, redisRes] = await Promise.allSettled([
+    withTimeout(db.$queryRaw`SELECT 1`, 'db'),
+    withTimeout(redis.ping(), 'redis'),
+  ])
+
+  const dbOk = dbRes.status === 'fulfilled'
+  const redisOk = redisRes.status === 'fulfilled'
+  const allOk = dbOk && redisOk
+
+  const body = {
+    status: allOk ? 'ok' : 'degraded',
+    db: dbOk
+      ? 'ok'
+      : `fail: ${(dbRes as PromiseRejectedResult).reason?.message ?? 'unknown'}`,
+    redis: redisOk
+      ? 'ok'
+      : `fail: ${(redisRes as PromiseRejectedResult).reason?.message ?? 'unknown'}`,
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString(),
+  }
+
+  if (!allOk) {
+    logger.error({ event: 'ready.check.fail', body }, 'readiness check failed')
+  }
+
+  return NextResponse.json(body, {
+    status: allOk ? 200 : 503,
+    headers: { 'Cache-Control': 'no-store' },
+  })
+}
+
+export const GET = withRequest(handler)

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,4 +1,5 @@
 import pino, { type DestinationStream, type LoggerOptions } from 'pino'
+import pretty from 'pino-pretty'
 import { env } from '@/lib/env'
 import { getRequestId } from './request-context'
 
@@ -33,14 +34,11 @@ export function createLogger(destination?: DestinationStream) {
     return pino(baseOptions(), destination)
   }
 
-  const options: LoggerOptions = {
-    ...baseOptions(),
-    transport:
-      env.NODE_ENV === 'production'
-        ? undefined
-        : { target: 'pino-pretty', options: { colorize: true } },
+  if (env.NODE_ENV === 'production') {
+    return pino(baseOptions())
   }
-  return pino(options)
+
+  return pino(baseOptions(), pretty({ colorize: true }))
 }
 
 export const logger = createLogger()


### PR DESCRIPTION
## Summary

- Adds `app/api/ready/route.ts` (Story 1.9): public unauthenticated readiness probe that pings Postgres (`SELECT 1`) and Redis (`PING`) in parallel via `Promise.allSettled`, with a 1000ms per-check `Promise.race` timeout. Returns `200 { status: 'ok', db: 'ok', redis: 'ok', uptime, timestamp }` when both pass; `503 { status: 'degraded', db: 'fail: ...' | 'ok', redis: 'fail: ...' | 'ok', uptime, timestamp }` on any failure. `Cache-Control: no-store`. Failures logged at `error` level via Pino with `event: 'ready.check.fail'` and `requestId` propagated through `withRequest` AsyncLocalStorage.
- Adds `app/api/ready/__tests__/route.test.ts` covering five paths: happy, db-fails, redis-fails, both-fail, timeout (fake timers).
- **Drive-by fix to `lib/logger.ts`** (Story 1.7 territory): swap `pino-pretty` from `transport:` to in-process `pretty()` stream. The original `transport:` config spawns a worker via `thread-stream`; Turbopack rewrites the worker module path to `/ROOT/...` and the worker fails to load, crashing the dev server the first time anything logs. `/api/health` is silent so it never tripped the worker, but `/api/ready` exercises Pino during the negative path (`redis.reconnecting`/`redis.error` events when Redis is down) and the crash blocked verification of this story end-to-end. In-process `pretty()` stream avoids the worker thread entirely, preserves pretty dev output, keeps JSON in production (`env.NODE_ENV === 'production'` short-circuits to no stream), and the existing `createLogger(destination?)` test factory branch is unaffected since it bypasses both branches.

## Test plan

- [x] `pnpm typecheck` passes.
- [x] `pnpm lint` passes.
- [x] `pnpm test app/api/ready/__tests__/route.test.ts` — all 5 cases pass.
- [x] `pnpm test` — full suite green (auth, env, logger, redis, middleware, health, ready).
- [ ] `pnpm dev`, then `curl -i http://localhost:3000/api/ready` with infra up: 200, `Cache-Control: no-store`, body `{ status: 'ok', db: 'ok', redis: 'ok', uptime, timestamp }`.
- [ ] AC-4 auth-bypass: same curl with no `Cookie` header returns 200, not 302.
- [ ] Negative-path runtime: stop postgres → 503 with `db: 'fail: ...'`. Restart. Stop redis → 503 with `redis: 'fail: ...'`. Both stopped → 503 both fields fail. Restart both.
- [ ] During the negative path, dev terminal shows pretty `event: 'ready.check.fail'` log lines with `requestId: <uuid>`. Dev server does NOT crash with `Cannot find module '/ROOT/.../thread-stream/lib/worker.js'` (regression check for the Turbopack worker fix).

Closes #27.

Story 1.19 (Uptime Kuma monitor) is the consumer that will rely on this 200/503 contract; do not change the status mapping after that lands.