### PR TITLE
fix(middleware): segment-anchor matcher lookahead (#28)

### DIFF
--- a/__tests__/middleware-matcher.test.ts
+++ b/__tests__/middleware-matcher.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { config } from '@/middleware'
+
+const matcher = new RegExp(`^${config.matcher[0]}$`)
+
+type Case = { path: string; expected: 'gate' | 'bypass' }
+
+const cases: Case[] = [
+  { path: '/login', expected: 'bypass' },
+  { path: '/login/', expected: 'bypass' },
+  { path: '/login/foo', expected: 'bypass' },
+  { path: '/loginz', expected: 'gate' },
+  { path: '/login-but-different', expected: 'gate' },
+
+  { path: '/api/auth', expected: 'bypass' },
+  { path: '/api/auth/callback/credentials', expected: 'bypass' },
+  { path: '/api/auth/session', expected: 'bypass' },
+  { path: '/api/authentication', expected: 'gate' },
+
+  { path: '/api/health', expected: 'bypass' },
+  { path: '/api/healthcheck', expected: 'gate' },
+  { path: '/api/health-check', expected: 'gate' },
+
+  { path: '/api/ready', expected: 'bypass' },
+  { path: '/api/readiness', expected: 'gate' },
+
+  { path: '/_next/static/chunks/main.js', expected: 'bypass' },
+  { path: '/_next/image', expected: 'bypass' },
+
+  { path: '/favicon.ico', expected: 'bypass' },
+  { path: '/faviconxico', expected: 'gate' },
+  { path: '/robots.txt', expected: 'bypass' },
+  { path: '/robotsxtxt', expected: 'gate' },
+  { path: '/sitemap.xml', expected: 'bypass' },
+  { path: '/manifest.webmanifest', expected: 'bypass' },
+
+  { path: '/dashboard', expected: 'gate' },
+  { path: '/timeline', expected: 'gate' },
+  { path: '/api/media', expected: 'gate' },
+]
+
+describe('middleware matcher', () => {
+  it.each(cases)('$path -> $expected', ({ path, expected }) => {
+    const matched = matcher.test(path)
+    expect(matched).toBe(expected === 'gate')
+  })
+})

--- a/middleware.ts
+++ b/middleware.ts
@@ -25,15 +25,18 @@ export default withAuth(
   },
 )
 
+// ! Each excluded prefix MUST end in (?:/|$) so it anchors to a path-segment
+// ! boundary. Bare prefixes over-match: (?!login) excludes /loginz too, which
+// ! silently bypasses auth. Same rule applies whenever a new exclusion lands.
+// ! Filenames (favicon.ico, robots.txt, sitemap.xml, manifest.webmanifest)
+// ! escape the dot so /faviconxico does not match.
+// ! The matcher entry MUST be a string literal: Next.js statically parses
+// ! config.matcher at build time and silently drops the route if it sees a
+// ! const reference. The unit test reads config.matcher[0] at runtime to keep
+// ! the regex single-sourced.
 export const config = {
-  // Protect every route except:
-  //    /login          - the sign-in page itself
-  //    /api/auth       - NextAuth internal endpoints (session, csrf, providers)
-  //    /_next/static   - JS/CSS bundles
-  //    /_next/image    - image optimisation
-  //    /favicon
   matcher: [
-    '/((?!login|api/auth|api/health|api/ready|_next/static|_next/image|favicon\\.ico).*)',
+    '/((?!login(?:/|$)|api/auth(?:/|$)|api/health(?:/|$)|api/ready(?:/|$)|_next/static|_next/image|favicon\\.ico|robots\\.txt|sitemap\\.xml|manifest\\.webmanifest).*)',
   ],
   // ! AsyncLocalStorage requires the Node runtime;
   // ! Edge breaks ALS-based requestId propagation in route handlers.


### PR DESCRIPTION
Anchors each excluded prefix in the auth middleware matcher to a path-segment boundary with `(?:/|$)`, escapes the dots in static-asset filenames, and explicitly excludes `robots.txt`, `sitemap.xml`, `manifest.webmanifest`. Bare prefixes were over-matching: `/loginz` and `/api/healthcheck` were silently bypassing auth because the lookahead did not require a segment break.

The matcher entry stays as a string literal because Next.js statically parses `config.matcher` at build time. The new Vitest spec imports the runtime `config` export and reads `config.matcher[0]` so test and production hit the same string.

## Test plan

- [ ] `pnpm typecheck` and `pnpm lint` clean.
- [ ] `pnpm test` 45/45 across 8 files (new spec adds 25 cases).
- [ ] `pnpm dev` smoke matrix:
  - `/login` 200, `/loginz` 307, `/login/foo` 404 (bypass)
  - `/api/health` 200, `/api/healthcheck` 307
  - `/api/ready` 200 or 503, `/api/readiness` 307
  - `/favicon.ico` 200, `/faviconxico` 307
  - `/robots.txt` 404 (bypass), `/dashboard` 307

Closes #28.