### PR TITLE
fix(auth): assert NEXTAUTH_SECRET via lib/env at module load (#29)

### DIFF
--- a/lib/__tests__/auth.test.ts
+++ b/lib/__tests__/auth.test.ts
@@ -1,61 +1,96 @@
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
 import bcrypt from 'bcryptjs'
+import { ZodError } from 'zod'
 
 vi.mock('@/lib/db', () => ({
   db: { user: { findUnique: vi.fn() } },
 }))
 
-import { db } from '@/lib/db'
-import { authorizeCredentials } from '@/lib/auth'
+// validEnv must mirror the required fields in lib/env.ts EnvSchema.
+// Drift here means env validation fires inside vi.resetModules() and tests
+// fail for the wrong reason. Update both files together.
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(64),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+}
 
-const findUnique = vi.mocked(db.user.findUnique)
-
-// bcrypt is slow - pre-hash once with minimal rounds for the whole suite
 let validHash: string
+// bcrypt is slow, pre-hash once with minimal rounds for the whole suite
 beforeAll(async () => {
   validHash = await bcrypt.hash('correct', 4)
 })
 
-beforeEach(() => vi.clearAllMocks())
+beforeEach(() => {
+  vi.resetModules()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
 
 describe('authorizeCredentials', () => {
   it('returns null when credentials are undefined', async () => {
+    const { authorizeCredentials } = await import('@/lib/auth')
     expect(await authorizeCredentials(undefined)).toBeNull()
   })
 
   it('returns null when email or password are empty', async () => {
-    expect(await authorizeCredentials({ email: '', password: 'x' })).toBeNull()
+    const { authorizeCredentials } = await import('@/lib/auth')
+    expect(
+      await authorizeCredentials({ email: '', password: 'x' }),
+    ).toBeNull()
     expect(
       await authorizeCredentials({ email: 'a@b.com', password: '' }),
     ).toBeNull()
   })
 
   it('returns null when user does not exist', async () => {
-    findUnique.mockResolvedValue(null)
+    const { db } = await import('@/lib/db')
+    vi.mocked(db.user.findUnique).mockResolvedValue(null)
+    const { authorizeCredentials } = await import('@/lib/auth')
     expect(
       await authorizeCredentials({ email: 'a@b.com', password: 'x' }),
     ).toBeNull()
   })
 
   it('returns null when password does not match', async () => {
-    findUnique.mockResolvedValue({
+    const { db } = await import('@/lib/db')
+    vi.mocked(db.user.findUnique).mockResolvedValue({
       id: '1',
       email: 'a@b.com',
       name: 'Admin',
       password: validHash,
     } as Awaited<ReturnType<typeof db.user.findUnique>>)
+    const { authorizeCredentials } = await import('@/lib/auth')
     expect(
       await authorizeCredentials({ email: 'a@b.com', password: 'wrong' }),
     ).toBeNull()
   })
 
   it('returns the user object when credentials are valid', async () => {
-    findUnique.mockResolvedValue({
+    const { db } = await import('@/lib/db')
+    vi.mocked(db.user.findUnique).mockResolvedValue({
       id: '1',
       email: 'a@b.com',
       name: 'Admin',
       password: validHash,
     } as Awaited<ReturnType<typeof db.user.findUnique>>)
+    const { authorizeCredentials } = await import('@/lib/auth')
     expect(
       await authorizeCredentials({ email: 'a@b.com', password: 'correct' }),
     ).toEqual({
@@ -64,4 +99,45 @@ describe('authorizeCredentials', () => {
       name: 'Admin',
     })
   })
+})
+
+describe('authOptions wiring', () => {
+  it('reads secret from the validated env, not raw process.env', async () => {
+    // Sentinel value distinct from validEnv.NEXTAUTH_SECRET so the assertion
+    // proves authOptions.secret flowed through @/lib/env, not the raw stubbed
+    // process.env that NextAuth would read on its own if `secret:` were unwired.
+    const sentinel = 's'.repeat(40)
+    vi.doMock('@/lib/env', () => ({
+      env: { NEXTAUTH_SECRET: sentinel },
+    }))
+
+    const { authOptions } = await import('@/lib/auth')
+    expect(authOptions.secret).toBe(sentinel)
+    expect(authOptions.secret).not.toBe(validEnv.NEXTAUTH_SECRET)
+
+    vi.doUnmock('@/lib/env')
+  })
+
+  it.each([
+    { label: 'empty string', value: '' },
+    { label: 'short string', value: 'short' },
+  ])(
+    'throws ZodError at module-load when NEXTAUTH_SECRET is $label',
+    async ({ value }) => {
+      vi.stubEnv('NEXTAUTH_SECRET', value)
+
+      let caught: unknown
+      try {
+        await import('@/lib/auth')
+      } catch (err) {
+        caught = err
+      }
+
+      expect(caught).toBeInstanceOf(ZodError)
+      const issues = (caught as ZodError).issues
+      const secretIssue = issues.find((i) => i.path.includes('NEXTAUTH_SECRET'))
+      expect(secretIssue).toBeDefined()
+      expect(secretIssue?.code).toBe('too_small')
+    },
+  )
 })

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -3,6 +3,7 @@ import CredentialsProvider from 'next-auth/providers/credentials'
 import { PrismaAdapter } from '@next-auth/prisma-adapter'
 import bcrypt from 'bcryptjs'
 import { db } from '@/lib/db'
+import { env } from '@/lib/env'
 
 // Co-located augmentation: session.user.id is set in the jwt + session callbacks below.
 declare module 'next-auth' {
@@ -39,6 +40,7 @@ export async function authorizeCredentials(
  */
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(db),
+  secret: env.NEXTAUTH_SECRET,
   session: { strategy: 'jwt' },
   providers: [
     CredentialsProvider({

--- a/middleware.ts
+++ b/middleware.ts
@@ -14,8 +14,10 @@ export function attachRequestId(req: NextRequest): NextResponse {
 }
 
 // withAuth reads the JWT cookie and redirects to pages.signIn when missing.
-// If NEXTAUTH_SECRET is wrong or missing, all JWTs fail to verify
-// and every authenticated user gets redirected to /login in a loop.
+// NEXTAUTH_SECRET is wired in lib/auth.ts via lib/env.ts. Production
+// `next build` catches a misconfigured deploy at build time. In dev under
+// `next dev --turbopack`, auth routes compile on first /api/auth/* request
+// so the Zod summary surfaces then, not at process startup.
 export default withAuth(
   function middleware(req) {
     return attachRequestId(req)


### PR DESCRIPTION
Wires `secret: env.NEXTAUTH_SECRET` into `authOptions` so the NextAuth handler reads the Zod-validated value rather than raw `process.env`. Importing `lib/auth.ts` now pulls `lib/env.ts` into the auth route's module-load chain. Production `next build` catches a missing or short secret at build time. Under `next dev --turbopack`, the auth route compiles on first `/api/auth/*` hit and surfaces the Zod summary then. The middleware comment is rewritten to make that dev/prod asymmetry explicit.

`lib/__tests__/auth.test.ts` is migrated from a static top-of-file `import { authorizeCredentials } from '@/lib/auth'` to the env-stub-and-`await import` pattern from `env.test.ts`. Without that change the suite would fail to load in CI (CI sets only `DATABASE_URL`). New cases under `describe('authOptions wiring')`: a `vi.doMock('@/lib/env')` + sentinel proves `secret:` flows through the validated `env` and not raw `process.env`; an `it.each` over `{ empty string, short string }` proves the import throws a `ZodError` whose first issue has `code: 'too_small'` and `path: ['NEXTAUTH_SECRET']`.

## Test plan

- [ ] `pnpm typecheck` and `pnpm lint` clean.
- [ ] `pnpm test` 48/48 across 8 files (auth spec gains 3 cases over the post-1.10 baseline of 45).
- [ ] `pnpm dev` happy path with full `.env`: `/login` 200, `/api/health` 200, `/api/ready` 200, `/dashboard` 307. Sign in with seeded admin (`admin@tracker.local` plus `${ADMIN_PASS}`), session sticks across reload.
- [ ] Boot-failure dev smoke: temporarily set `NEXTAUTH_SECRET=""` in `.env`, restart `pnpm dev`, hit `/api/auth/session`. Expect HTTP 500 with `_NEXT_DATA_` body `"name":"ZodError"` and `"path":["NEXTAUTH_SECRET"]`. Dev terminal prints `Invalid environment variables: - NEXTAUTH_SECRET: Too small: expected string to have >=32 characters` plus the Zod stack with frames at `lib/env.ts`, `lib/auth.ts`, `app/api/auth/[...nextauth]/route.ts`. Restore.

Closes #29.