### PR TITLE
chore(db): phase 2 schema constraint hardening (#30)

### DIFF
--- a/prisma/migrations/20260508133713_phase2_constraint_hardening/migration.sql
+++ b/prisma/migrations/20260508133713_phase2_constraint_hardening/migration.sql
@@ -1,0 +1,76 @@
+-- Achievement composite unique (Prisma-generated from @@unique).
+-- Backfill must run BEFORE the index is created, so the duplicate-removal
+-- block sits above the CREATE UNIQUE INDEX statement.
+DO $$
+DECLARE removed INTEGER;
+BEGIN
+  WITH ranked AS (
+    SELECT "id", ROW_NUMBER() OVER (
+      PARTITION BY "game_id", "steam_api_name" ORDER BY "id"
+    ) AS rn
+    FROM "Achievement"
+  )
+  DELETE FROM "Achievement" WHERE "id" IN (SELECT "id" FROM ranked WHERE rn > 1);
+  GET DIAGNOSTICS removed = ROW_COUNT;
+  RAISE NOTICE 'Removed Achievement duplicates: % rows', removed;
+END $$;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Achievement_game_id_steam_api_name_key" ON "Achievement"("game_id", "steam_api_name");
+
+-- UserEntry.user_rating CHECK 1-10 (NULL allowed)
+DO $$
+DECLARE repaired INTEGER;
+BEGIN
+  UPDATE "UserEntry" SET "user_rating" = NULL
+    WHERE "user_rating" IS NOT NULL
+      AND ("user_rating" < 1 OR "user_rating" > 10 OR "user_rating" <> "user_rating");
+  GET DIAGNOSTICS repaired = ROW_COUNT;
+  RAISE NOTICE 'Repaired UserEntry.user_rating: % rows', repaired;
+END $$;
+
+ALTER TABLE "UserEntry" ADD CONSTRAINT "UserEntry_user_rating_check"
+  CHECK ("user_rating" IS NULL OR ("user_rating" >= 1 AND "user_rating" <= 10));
+
+-- UserEntry.progress CHECK >= 0
+DO $$
+DECLARE repaired INTEGER;
+BEGIN
+  UPDATE "UserEntry" SET "progress" = 0 WHERE "progress" < 0;
+  GET DIAGNOSTICS repaired = ROW_COUNT;
+  RAISE NOTICE 'Repaired UserEntry.progress: % rows', repaired;
+END $$;
+
+ALTER TABLE "UserEntry" ADD CONSTRAINT "UserEntry_progress_check"
+  CHECK ("progress" >= 0);
+
+-- MergeSuggestion source_id <> target_id CHECK
+DO $$
+DECLARE removed INTEGER;
+BEGIN
+  DELETE FROM "MergeSuggestion" WHERE "source_id" = "target_id";
+  GET DIAGNOSTICS removed = ROW_COUNT;
+  RAISE NOTICE 'Removed MergeSuggestion self-references: % rows', removed;
+END $$;
+
+ALTER TABLE "MergeSuggestion" ADD CONSTRAINT "MergeSuggestion_source_target_check"
+  CHECK ("source_id" <> "target_id");
+
+-- MergeSuggestion.confidence CHECK 0-1
+DO $$
+DECLARE removed INTEGER;
+BEGIN
+  DELETE FROM "MergeSuggestion"
+    WHERE "confidence" < 0 OR "confidence" > 1 OR "confidence" <> "confidence";
+  GET DIAGNOSTICS removed = ROW_COUNT;
+  RAISE NOTICE 'Removed MergeSuggestion out-of-range confidence: % rows', removed;
+END $$;
+
+ALTER TABLE "MergeSuggestion" ADD CONSTRAINT "MergeSuggestion_confidence_check"
+  CHECK ("confidence" >= 0 AND "confidence" <= 1);
+
+-- User.email: replace full unique index with partial unique (WHERE email IS NOT NULL).
+-- Postgres default unique already permits multiple NULLs; the partial form is
+-- explicit about the invariant and produces a smaller index.
+DROP INDEX "User_email_key";
+CREATE UNIQUE INDEX "User_email_key" ON "User" ("email") WHERE "email" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,17 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+// ! Constraints below are enforced in raw SQL inside
+// ! prisma/migrations/20260508133713_phase2_constraint_hardening/migration.sql
+// ! and CANNOT be expressed in the Prisma DSL. Do not let `prisma migrate dev`
+// ! "fix" them - review the diff before applying any future migration that
+// ! touches these columns.
+// !   - User.email partial unique index (WHERE email IS NOT NULL)
+// !   - UserEntry.user_rating CHECK BETWEEN 1 AND 10 (NULL allowed)
+// !   - UserEntry.progress CHECK >= 0
+// !   - MergeSuggestion CHECK source_id <> target_id
+// !   - MergeSuggestion.confidence CHECK BETWEEN 0 AND 1
+
 // ---- Auth (NextAuth v4 Prisma adapter) ----
 
 model Account {
@@ -140,6 +151,7 @@ model Achievement {
   unlocked_at    DateTime?
 
   @@index([game_id])
+  @@unique([game_id, steam_api_name])
 }
 
 model MergeSuggestion {


### PR DESCRIPTION
Closes #30

Adds a Prisma migration that ships six DB-level invariants the application logic implicitly depends on. Five live in raw SQL because the Prisma 6 DSL can't express CHECK constraints or partial unique indexes (`User.email` partial unique, `UserEntry.user_rating` 1-10 CHECK, `UserEntry.progress >= 0` CHECK, `MergeSuggestion.source_id <> target_id` CHECK, `MergeSuggestion.confidence` 0-1 CHECK). The sixth, `Achievement (game_id, steam_api_name)` composite unique, is mirrored in `schema.prisma` via `@@unique`. Every CHECK constraint is preceded by an idempotent backfill block with a `RAISE NOTICE` audit line. A `// !` warning block at the top of `schema.prisma` lists the five raw-SQL-only constraints + the migration filename so future `prisma migrate dev` proposals don't accidentally drop the partial unique or the CHECKs.

No application code, no env vars, no dependencies, no tests added. The route-handler 400 mapping for these constraint violations is deferred to Stories 7.x and 9.x where the consuming routes will land.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` (only pre-existing `_req` warning at `app/api/ready/route.ts:23:24`)
- [x] `pnpm test` 48/48 across 8 files
- [x] `pnpm prisma migrate deploy` applied the migration
- [x] `\d` inspections confirm all six constraints landed with the expected names and predicates
- [x] Six manual psql rejection probes fired with expected SQLSTATE (`23505` for unique violations, `23514` for CHECK violations) and constraint names
- [x] `pnpm prisma migrate reset --force --skip-seed` replayed all three migrations cleanly from a clean DB; `pnpm prisma db seed` re-created the admin
- [x] `bmad-code-review` pass (Blind Hunter / Edge Case Hunter / Acceptance Auditor) — 30 raw findings, 28 dismissed as noise, 2 actionable patches applied (`<timestamp>` placeholder fix in schema comment + NaN guards on user_rating and confidence backfill WHEREs)