### PR TITLE
fix(auth): catch bcrypt compare errors and validate token.id (#31)

### DIFF
--- a/lib/__tests__/auth.test.ts
+++ b/lib/__tests__/auth.test.ts
@@ -2,8 +2,14 @@ import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vite
 import bcrypt from 'bcryptjs'
 import { ZodError } from 'zod'
 
+const { logWarn } = vi.hoisted(() => ({ logWarn: vi.fn() }))
+
 vi.mock('@/lib/db', () => ({
   db: { user: { findUnique: vi.fn() } },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: logWarn, info: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }))
 
 // validEnv must mirror the required fields in lib/env.ts EnvSchema.
@@ -99,6 +105,57 @@ describe('authorizeCredentials', () => {
       name: 'Admin',
     })
   })
+
+  it('returns null and warn-logs when bcrypt.compare throws on a malformed hash', async () => {
+    const { db } = await import('@/lib/db')
+    vi.mocked(db.user.findUnique).mockResolvedValue({
+      id: '1',
+      email: 'a@b.com',
+      name: 'Admin',
+      // 60 chars trips bcryptjs past the length short-circuit (returns false for length != 60)
+      // into the salt-version check, which throws Error('Invalid salt version: aa').
+      password: 'a'.repeat(60),
+    } as Awaited<ReturnType<typeof db.user.findUnique>>)
+    const { authorizeCredentials } = await import('@/lib/auth')
+
+    const result = await authorizeCredentials({
+      email: 'a@b.com',
+      password: 'whatever',
+    })
+
+    expect(result).toBeNull()
+    expect(logWarn).toHaveBeenCalledTimes(1)
+    expect(logWarn).toHaveBeenCalledWith(
+      {
+        userId: '1',
+        event: 'auth.bcrypt_compare_error',
+        err: expect.any(Error),
+      },
+      'bcrypt.compare threw on malformed hash',
+    )
+  })
+
+  it('returns null without logging when stored hash has wrong length (bcryptjs short-circuits to false)', async () => {
+    const { db } = await import('@/lib/db')
+    vi.mocked(db.user.findUnique).mockResolvedValue({
+      id: '1',
+      email: 'a@b.com',
+      name: 'Admin',
+      // 59 chars (anything != 60) trips the length short-circuit branch in bcryptjs
+      // which returns false synchronously without entering the salt-version check.
+      // The catch must NOT fire on this path.
+      password: 'a'.repeat(59),
+    } as Awaited<ReturnType<typeof db.user.findUnique>>)
+    const { authorizeCredentials } = await import('@/lib/auth')
+
+    const result = await authorizeCredentials({
+      email: 'a@b.com',
+      password: 'whatever',
+    })
+
+    expect(result).toBeNull()
+    expect(logWarn).not.toHaveBeenCalled()
+  })
 })
 
 describe('authOptions wiring', () => {
@@ -138,6 +195,38 @@ describe('authOptions wiring', () => {
       const secretIssue = issues.find((i) => i.path.includes('NEXTAUTH_SECRET'))
       expect(secretIssue).toBeDefined()
       expect(secretIssue?.code).toBe('too_small')
+    },
+  )
+})
+
+describe('authOptions.callbacks.session', () => {
+  it('returns the session with token.id assigned when token.id is a string', async () => {
+    const { authOptions } = await import('@/lib/auth')
+    const result = authOptions.callbacks!.session!({
+      session: { user: { email: 'a@b.com', name: null, id: '' }, expires: '' },
+      token: { id: 'user-uuid' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result as any).user.id).toBe('user-uuid')
+  })
+
+  it.each([
+    { label: 'undefined', value: undefined },
+    { label: 'a number', value: 42 },
+    { label: 'an object', value: {} },
+    { label: 'an empty string', value: '' },
+  ])(
+    'throws Error("invalid token.id") when token.id is $label',
+    async ({ value }) => {
+      const { authOptions } = await import('@/lib/auth')
+      expect(() =>
+        authOptions.callbacks!.session!({
+          session: { user: { email: 'a@b.com', name: null, id: '' }, expires: '' },
+          token: { id: value },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any),
+      ).toThrow('invalid token.id')
     },
   )
 })

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -4,6 +4,7 @@ import { PrismaAdapter } from '@next-auth/prisma-adapter'
 import bcrypt from 'bcryptjs'
 import { db } from '@/lib/db'
 import { env } from '@/lib/env'
+import { logger } from '@/lib/logger'
 
 // Co-located augmentation: session.user.id is set in the jwt + session callbacks below.
 declare module 'next-auth' {
@@ -27,7 +28,17 @@ export async function authorizeCredentials(
 
   if (!user?.password || !user.email) return null
 
-  const isValid = await bcrypt.compare(credentials.password, user.password)
+  let isValid: boolean
+  try {
+    isValid = await bcrypt.compare(credentials.password, user.password)
+  } catch (err) {
+    logger.warn(
+      { userId: user.id, event: 'auth.bcrypt_compare_error', err },
+      'bcrypt.compare threw on malformed hash',
+    )
+    return null
+  }
+
   return isValid
     ? { id: user.id, email: user.email ?? '', name: user.name }
     : null
@@ -60,7 +71,10 @@ export const authOptions: NextAuthOptions = {
       return token
     },
     session({ session, token }) {
-      if (session.user) session.user.id = (token.id as string) ?? ''
+      if (typeof token.id !== 'string' || token.id.length === 0) {
+        throw new Error('invalid token.id')
+      }
+      if (session.user) session.user.id = token.id
       return session
     },
   },


### PR DESCRIPTION
Closes #31.

`bcrypt.compare` now runs inside a try/catch in `authorizeCredentials`. A malformed `password` column resolves to a normal failed-credentials redirect (302 to `/login?error=CredentialsSignin`) plus one Pino warn line keyed `event: auth.bcrypt_compare_error`, instead of an HTTP 500. The session callback's `(token.id as string) ?? ''` coercion is replaced with a `typeof token.id !== 'string' || token.id.length === 0` guard that throws `Error('invalid token.id')` so a malformed JWT cannot silently produce a session whose `user.id === ''`.

The empty-string clause in the typeof guard was a code-review-time tightening over the original AC (which named only `typeof !== 'string'`). The impl-artifact AC-3 / AC-6 wording was updated to match.

## Test plan
- `pnpm typecheck`, `pnpm lint`, `pnpm test` all clean. 55/55 tests across 8 files; auth spec went from 8 to 15 cases.
- Local smoke (happy path): sign in as admin, 302 to `/`.
- Local smoke (bcrypt-rejection): corrupt the admin hash to `'a'.repeat(60)` via `psql`, attempt sign-in. Got 302 to `/login?error=CredentialsSignin` plus one Pino warn line with `event=auth.bcrypt_compare_error`, `userId=cmox9o5pe0000ijzk9grzpniz`, `err.message='Invalid salt version: aa'`.
- Recovery via direct `UPDATE` with a freshly-bcrypt-hashed `${ADMIN_PASS}` (NOT `pnpm prisma db seed` — `update: {}` makes it a no-op on existing rows).
- Session-callback path: 5 unit tests pin the contract (1 happy + 4 negatives across `undefined` / number / object / empty string).