### PR TITLE
chore(auth): lock in DB-down, email-normalisation, OAuth-only-user invariants (#32)

### DIFF
--- a/lib/__tests__/auth.test.ts
+++ b/lib/__tests__/auth.test.ts
@@ -74,6 +74,52 @@ describe('authorizeCredentials', () => {
     ).toBeNull()
   })
 
+  it('propagates findUnique rejection so DB-down stays unmasked', async () => {
+    const { db } = await import('@/lib/db')
+    vi.mocked(db.user.findUnique).mockRejectedValue(
+      new Error('Connection refused'),
+    )
+    const { authorizeCredentials } = await import('@/lib/auth')
+
+    await expect(
+      authorizeCredentials({ email: 'a@b.com', password: 'x' }),
+    ).rejects.toThrow()
+    expect(logWarn).not.toHaveBeenCalled()
+  })
+
+  it('normalises email to trim() + toLowerCase() before findUnique', async () => {
+    const { db } = await import('@/lib/db')
+    vi.mocked(db.user.findUnique).mockResolvedValue(null)
+    const { authorizeCredentials } = await import('@/lib/auth')
+
+    await authorizeCredentials({ email: '  A@B.com ', password: 'x' })
+
+    expect(db.user.findUnique).toHaveBeenCalledTimes(1)
+    expect(db.user.findUnique).toHaveBeenCalledWith({
+      where: { email: 'a@b.com' },
+      select: { id: true, email: true, name: true, password: true },
+    })
+  })
+
+  it('returns null when user exists but password column is null (OAuth-only user)', async () => {
+    const { db } = await import('@/lib/db')
+    vi.mocked(db.user.findUnique).mockResolvedValue({
+      id: '1',
+      email: 'a@b.com',
+      name: 'Admin',
+      password: null,
+    } as Awaited<ReturnType<typeof db.user.findUnique>>)
+    const { authorizeCredentials } = await import('@/lib/auth')
+
+    const result = await authorizeCredentials({
+      email: 'a@b.com',
+      password: 'x',
+    })
+
+    expect(result).toBeNull()
+    expect(logWarn).not.toHaveBeenCalled()
+  })
+
   it('returns null when password does not match', async () => {
     const { db } = await import('@/lib/db')
     vi.mocked(db.user.findUnique).mockResolvedValue({


### PR DESCRIPTION
## Summary

Three Vitest cases pin three documented-but-previously-untested invariants of `authorizeCredentials`: DB-down rejection propagation, email `trim()` + `toLowerCase()` normalisation, and the OAuth-only-user (`password: null`) short-circuit. Test-only — zero source change. AC-2 from ECH F17/F19/F20 leans on Story 1.13's existing 59-char `bcryptjs` length-short-circuit case (Option A in the impl-artifact).

## Test plan

- [x] `pnpm typecheck` → 0 errors
- [x] `pnpm lint` → only the pre-existing `_req` warning at `app/api/ready/route.ts` (Story 1.9 carry-over, out of scope)
- [x] `pnpm test lib/__tests__/auth.test.ts` → 18/18 passed
- [x] `pnpm test` → 58/58 across 8 files (auth spec 15 → 18, full suite 55 → 58)
- [x] `bmad-code-review` → 25 raw findings, 1 patch applied (loosened `.rejects.toThrow('Connection refused')` to `.rejects.toThrow()` to decouple from mock-message wording), 4 deferred to `_bmad-output/implementation-artifacts/deferred-work.md`, 14 dismissed as noise / out-of-scope

Closes #32