### PR TITLE
chore(ci): add lint+build, reorder typecheck, concurrency, eslint-cli (#33)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -21,6 +25,16 @@ jobs:
           - 5432:5432
         options: >-
           --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -42,6 +56,12 @@ jobs:
       - name: Generate prisma client
         run: pnpm prisma generate
 
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
       - name: Apply migrations
         env:
           DATABASE_URL: postgresql://tracker:test@localhost:5432/tracker_test
@@ -52,5 +72,24 @@ jobs:
           DATABASE_URL: postgresql://tracker:test@localhost:5432/tracker_test
         run: pnpm test --coverage
 
-      - name: Typecheck
-        run: pnpm typecheck
+      - name: Build
+        # Env block exists ONLY to satisfy lib/env.ts Zod validation at build-time module load.
+        # All values are CI-only placeholders. NEXTAUTH_SECRET is 64 a's (clears min(32) gate);
+        # never copy this shape into staging/prod. Real secrets land via the VPS .env file.
+        env:
+          DATABASE_URL: postgresql://tracker:test@localhost:5432/tracker_test
+          DB_PASS: test
+          REDIS_URL: redis://localhost:6379
+          NEXTAUTH_SECRET: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          NEXTAUTH_URL: http://localhost:3000
+          ADMIN_PASS: testpass123
+          TMDB_API_KEY: test
+          IGDB_CLIENT_ID: test
+          IGDB_CLIENT_SECRET: test
+          STEAM_API_KEY: test
+          STEAM_USER_ID: test
+          QBITTORRENT_HOST: http://localhost:8080
+          QBITTORRENT_USER: admin
+          QBITTORRENT_PASS: test
+          DOWNLOAD_PATH: /downloads
+        run: pnpm build

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,16 @@ const __dirname = dirname(__filename)
 const compat = new FlatCompat({ baseDirectory: __dirname })
 
 const eslintConfig = [
+  {
+    ignores: [
+      '.next/**',
+      'node_modules/**',
+      'public/**',
+      'coverage/**',
+      'next-env.d.ts',
+      '**/*.tsbuildinfo',
+    ],
+  },
   ...compat.extends('next/core-web-vitals', 'next/typescript'),
   {
     rules: {
@@ -26,6 +36,16 @@ const eslintConfig = [
         },
       ],
       'no-console': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+          ignoreRestSiblings: true,
+        },
+      ],
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "stack": "docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "test": "vitest --run --passWithNoTests",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Summary

Restructures `.github/workflows/ci.yml` to enforce ESLint and Next.js build-time errors, fail fast on cheap checks, and cancel stale runs. Folds in three additional fixes per Cuatro's "fix the open items" directive: tightens lint to `--max-warnings=0`, migrates `pnpm lint` from deprecated `next lint` to `eslint . --max-warnings=0`, and resolves the pre-existing `_req` warning at `app/api/ready/route.ts:23` via a config-level underscore-prefix exemption (zero source-file edits).

New CI step order: `checkout → setup → install → prisma generate → Lint → Typecheck → Apply migrations → Run tests → Build`. Top-level `concurrency: { group: ci-${{ github.ref }}, cancel-in-progress: true }` cancels stale runs. New `services: redis` block alongside postgres so the `next build` step has a real Redis to connect to (`lib/redis.ts:11` `lazyConnect: env.NODE_ENV === 'test'` means production-mode build eagerly connects). `Build` step inlines all 15 required env vars from `lib/env.ts` with a clarifying comment that they're CI-only placeholders.

`eslint.config.mjs` gains an `ignores` block (`.next/**`, `node_modules/**`, `public/**`, `coverage/**`, `next-env.d.ts`, `**/*.tsbuildinfo`) to mirror what `next lint` baked in implicitly, plus a `@typescript-eslint/no-unused-vars` rule with the full set of underscore-prefix exemptions (args, vars, caughtErrors, destructuredArray, plus `ignoreRestSiblings: true`).

## Test plan

- [x] `pnpm typecheck` → 0 errors
- [x] `pnpm lint` → 0 output (`eslint . --max-warnings=0` clean)
- [x] `pnpm test` → 58/58 across 8 files
- [x] Local `pnpm build` smoke with full proposed env block exported → `Compiled successfully in 5.8s`, 5/5 static pages
- [x] `bmad-code-review` → ~40 raw findings, 4 patches applied (services: redis, qbittorrent host fix, destructured-array + rest-siblings exemptions, CI-placeholder comment), 5 deferred to `_bmad-output/implementation-artifacts/deferred-work.md`, 16 dismissed as noise / out-of-scope. Acceptance Auditor returned a clean spec audit.
- [ ] CI run on this PR — confirm new step sequence, Build step succeeds, concurrency cancels prior runs on a follow-up push
- [ ] Post-merge: deploy.yml workflow_run fires, SSH script lands on VPS, `curl https://tracker.cuatro.dev/api/health` returns 200 (per `feedback_deploy_live_from_2026_05_09.md`)

Closes #33