### PR TITLE
Enable self-hosted Mac deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,27 +12,23 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
 
     steps:
-      - name: Deploy to VPS
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.VPS_HOST }}
-          username: ${{ secrets.VPS_USER }}
-          key: ${{ secrets.VPS_SSH_KEY }}
-          script: |
-            cd /opt/cuatro-tracker
-            git pull origin main
-            docker compose up -d --build
-            docker image prune -f
-            for i in 1 2 3 4 5; do
-              if curl -fsS https://tracker.cuatro.dev/api/health > /dev/null; then
-                echo "health check passed in $i/5 attempts"
-                exit 0
-              fi
-              sleep 5
-            done
-            echo "health check FAILED after 5 attempts"
-            exit 1
+      - name: Deploy
+        working-directory: /opt/cuatro-tracker
+        run: |
+          git fetch origin
+          git reset --hard origin/main
+          docker compose up -d --build
+          docker image prune -f
+          for i in 1 2 3 4 5; do
+            if curl -fsS https://tracker.cuatro.dev/api/health > /dev/null; then
+              echo "health check passed in $i/5 attempts"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "health check FAILED after 5 attempts"
+          exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
         .env.example}"
       - "QBITTORRENT_PASS=${QBITTORRENT_PASS:?QBITTORRENT_PASS is required; see
         .env.example}"
+      - "DOWNLOAD_PATH=${DOWNLOAD_PATH:?DOWNLOAD_PATH is required; see
+        .env.example}"
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - SENTRY_DSN=${SENTRY_DSN:-}
       - NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN:-}


### PR DESCRIPTION
Two fixes that unblock first deploy onto the home-hosted Mac (2020 Intel MBP, Sequoia 15.7.2) replacing the original Hetzner CX22 plan.

**`fix(compose)`** — `lib/env.ts` requires `DOWNLOAD_PATH` (`.min(1)`) but the `app` service's `environment:` block didn't propagate it. Compose substituted it fine for the qbittorrent volume mount (`${DOWNLOAD_PATH:?...}:/downloads`), but the app container booted without the var and crashed on Zod validation. `worker` already had it; this brings `app` in line. Surfaced during first live deploy on the Mac.

**`chore(ci)`** — `deploy.yml` switched from `appleboy/ssh-action` on `ubuntu-latest` to `runs-on: self-hosted` running locally on the Mac. No inbound SSH from the public internet, no `VPS_*` secrets, runner polls outbound for jobs. Repo lives at `/opt/cuatro-tracker` on the Mac; the workflow `git reset --hard origin/main`s into that checkout each run.

## Test plan

- [ ] Self-hosted runner installed and registered on the Mac (out of band — `./config.sh` + `./svc.sh install/start`)
- [ ] Merge → CI green on `main` → Deploy workflow triggers automatically
- [ ] `git reset --hard origin/main` lands the merged code in `/opt/cuatro-tracker`
- [ ] `docker compose up -d --build` rebuilds; `app` container boots cleanly (no Zod env errors)
- [ ] Health check `curl https://tracker.cuatro.dev/api/health` returns 200 within the 5-retry window
- [ ] `VPS_HOST` / `VPS_USER` / `VPS_SSH_KEY` secrets can be deleted from repo settings after merge