### PR TITLE
Fix app service running worker entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile
+      target: runner
     environment:
       - "DATABASE_URL=postgresql://tracker:${DB_PASS:?DB_PASS is required; see
         .env.example}@postgres:5432/tracker"


### PR DESCRIPTION
The Dockerfile's stage order is `base → deps → builder → runner → worker`. Multi-stage builds with no `--target` default to the **last** stage, so `docker compose build app` (which has no `target:` set) produced the worker image, and the app container ran `tsx worker.ts` instead of `node server.js`.

Symptom on the Mac: `docker compose logs app` shows only `worker.ready` / `redis.connect` / `redis.ready` and then nothing — no Next.js startup, no HTTP server, healthcheck on `/api/health` times out → caddy can't start its `depends_on: app healthy` chain.

Fix: pin `target: runner` on the app service, mirroring the explicit `target: worker` on the worker service.

## Test plan

- [ ] `docker compose build app` produces an image whose CMD is `["node", "server.js"]`, not `tsx worker.ts`
- [ ] `docker compose up -d` brings `app` to healthy within the 70 s start_period+retries window
- [ ] `curl https://tracker.cuatro.dev/api/health` returns 200
- [ ] Worker service still works (`docker compose logs worker` shows `worker.ready`)