### PR TITLE
Fix app healthcheck IPv6 resolution mismatch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3000/api/health"]
       interval: 10s
       start_period: 20s
       timeout: 5s


### PR DESCRIPTION
BusyBox `wget` on Alpine resolves `localhost` to IPv6 `::1` first. Next.js standalone binds only IPv4 (`http://0.0.0.0:3000`), so the probe hits `[::1]:3000`, nothing listens there, connection refused. Healthcheck reports unhealthy → caddy's `depends_on: app healthy` blocks → site never comes up.

Verified on the running container before the fix:
- `wget http://localhost:3000/api/health` → `Connecting to localhost:3000 ([::1]:3000)` → `Connection refused`
- `wget http://127.0.0.1:3000/api/health` → returns the 95-byte health JSON

Fix: pin the healthcheck target to `127.0.0.1`. Single-character change.

## Test plan

- [ ] `docker compose up -d` brings `app` to `health=healthy` within the start_period+retries window
- [ ] `caddy` proceeds to start once `app` is healthy
- [ ] `curl https://tracker.cuatro.dev/api/health` returns 200