### PR TITLE
Bake Caddyfile into image to avoid /opt bind-mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     environment:
       CLOUDFLARE_API_TOKEN: ${CLOUDFLARE_API_TOKEN}
     volumes:
-      - ./docker/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
     depends_on:

--- a/docker/Dockerfile.caddy
+++ b/docker/Dockerfile.caddy
@@ -4,3 +4,4 @@ RUN xcaddy build \
 
 FROM caddy:2.11.2-alpine
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+COPY docker/Caddyfile /etc/caddy/Caddyfile


### PR DESCRIPTION
Docker Desktop on macOS doesn't share `/opt` to containers by default — the bind-mount `./docker/Caddyfile:/etc/caddy/Caddyfile:ro` resolves to `/opt/cuatro-tracker/docker/Caddyfile` on the home-Mac deploy and fails with `mounts denied`. Can't move the repo under `/Users` without surgery on the runbook + deploy.yml paths.

Cleaner fix: bake the Caddyfile into the Caddy image at build time and drop the bind-mount. Production posture is also better — image is a sealed artifact, no host coupling.

Trade-off: Caddyfile edits now require `docker compose build caddy`. Acceptable for a personal tracker where Caddyfile changes are rare (TLS automation + one vhost; no per-deploy churn).

## Test plan

- [ ] `docker compose build caddy` succeeds
- [ ] `docker compose exec caddy cat /etc/caddy/Caddyfile` shows the expected content (DNS-01 + reverse_proxy app:3000)
- [ ] `docker compose up -d caddy` starts cleanly without `mounts denied`
- [ ] Caddy obtains the TLS cert via Cloudflare DNS-01 within ~90s
- [ ] `curl https://tracker.cuatro.dev/api/health` returns 200