### PR TITLE
Bump caddy-dns/cloudflare to v0.2.4 for cfut_ token format

### DIFF
--- a/docker/Dockerfile.caddy
+++ b/docker/Dockerfile.caddy
@@ -1,6 +1,6 @@
 FROM caddy:2.11.2-builder AS builder
 RUN xcaddy build \
-    --with github.com/caddy-dns/cloudflare@v0.2.1
+    --with github.com/caddy-dns/cloudflare@v0.2.4
 
 FROM caddy:2.11.2-alpine
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy


### PR DESCRIPTION
Cloudflare rolled out a new API Token format prefixed with `cfut_`. The pinned `caddy-dns/cloudflare@v0.2.1` rejects these at validation time with:

\`\`\`
API token 'cfut_...' appears invalid; ensure it's correctly entered and not wrapped in braces nor quotes
\`\`\`

v0.2.4 ships an upgraded `libdns/cloudflare` dependency (per the v0.2.1...v0.2.4 commit log) which handles the new format. Single-line version bump.

## Test plan

- [ ] `docker compose build caddy` succeeds
- [ ] `docker compose up -d --force-recreate caddy` starts cleanly (no token-rejection error)
- [ ] Caddy logs print `certificate obtained successfully` within ~90s of start
- [ ] `curl https://tracker.cuatro.dev/api/health` returns 200