### PR TITLE
chore(fonts): load four-face web font stack

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -4,5 +4,5 @@
 body {
   background: var(--ground-base);
   color: var(--phosphor-cream);
-  font-family: var(--font-geist-sans), Arial, sans-serif;
+  font-family: var(--font-body);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,11 @@
 import type { Metadata } from 'next'
 import type { Session } from 'next-auth'
-import { Geist, Geist_Mono } from 'next/font/google'
+import {
+  Cormorant_Garamond,
+  EB_Garamond,
+  IBM_Plex_Mono,
+  VT323,
+} from 'next/font/google'
 import Script from 'next/script'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
@@ -8,14 +13,45 @@ import { logger } from '@/lib/logger'
 import { Providers } from './providers'
 import './global.css'
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
+const displaySerif = Cormorant_Garamond({
+  variable: '--font-display',
   subsets: ['latin'],
+  weight: ['500', '600'],
+  style: ['normal'],
+  display: 'swap',
+  fallback: [
+    'Editorial New',
+    'Cormorant Garamond Display',
+    'EB Garamond',
+    'Georgia',
+    'serif',
+  ],
 })
 
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
+const bodySerif = EB_Garamond({
+  variable: '--font-body',
   subsets: ['latin'],
+  weight: ['400', '500', '600'],
+  style: ['normal'],
+  display: 'swap',
+  fallback: ['Georgia', 'serif'],
+})
+
+const monoSans = IBM_Plex_Mono({
+  variable: '--font-mono',
+  subsets: ['latin'],
+  weight: ['400', '600'],
+  style: ['normal'],
+  display: 'swap',
+  fallback: ['ui-monospace', 'Menlo', 'monospace'],
+})
+
+const bitmapFace = VT323({
+  variable: '--font-bitmap',
+  subsets: ['latin'],
+  weight: ['400'],
+  display: 'swap',
+  fallback: ['ui-monospace', 'monospace'],
 })
 
 export const metadata: Metadata = {
@@ -42,7 +78,10 @@ export default async function RootLayout({
   const showUmami = Boolean(session) && Boolean(umamiId)
 
   return (
-    <html lang="en">
+    <html
+      lang="en"
+      className={`${displaySerif.variable} ${bodySerif.variable} ${monoSans.variable} ${bitmapFace.variable}`}
+    >
       <head>
         {showUmami && (
           <Script
@@ -52,9 +91,7 @@ export default async function RootLayout({
           />
         )}
       </head>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         <Providers>{children}</Providers>
       </body>
     </html>


### PR DESCRIPTION
## Summary

Loads PP Editorial New stand-in (Cormorant Garamond), EB Garamond, IBM Plex Mono, and VT323 via `next/font/google`, exposed as `--font-display`, `--font-body`, `--font-mono`, `--font-bitmap` to align with the 2026-04-26 login bundle. Replaces the Story 2.1 `--font-geist-sans` placeholder in `app/global.css` body rule. className stack moves to `<html>`; `antialiased` stays on `<body>`. No new tokens in `app/tokens.css`; `@theme { --font-* }` deliberately skipped (dynamic next/font values don't fit static `@theme`).

VT323 globally loaded per Open Item #2; route-scoping deferred. Tabular numerics use Tailwind v4's built-in `tabular-nums` utility; zero new CSS.

Closes #62

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean
- [ ] `pnpm build` produces 5/5 static pages, no font warnings
- [ ] `/login` renders body text in EB Garamond serif (not Arial), no FOUT on hero
- [ ] DevTools Network: four font payloads on first paint
- [ ] DevTools Elements: `<html>` class carries four `__variable_*` entries
- [ ] Lighthouse Performance: "Avoid invisible text during font load" passes