### PR TITLE
chore(prisma): add debian-openssl-3.0.x to binaryTargets

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary

One-line schema change: `binaryTargets = ["native", "debian-openssl-3.0.x"]` so `pnpm install` produces engines for both Fedora host (rhel-openssl-3.0.x) and the Debian Bookworm dev container.

Without this, the dev container's first DB-touching request fails. NextAuth's credentials provider swallows the Prisma throw and disguises it as a 401, making the bug hard to surface (full diagnostic in `reference_prisma_binary_targets_dev_container.md`).

Closes #79

## Test plan

- [ ] `pnpm prisma generate` on host produces both `libquery_engine-rhel-openssl-3.0.x.so.node` and `libquery_engine-debian-openssl-3.0.x.so.node`
- [ ] Inside dev container: `curl /api/auth/callback/credentials` for admin returns `{"url":"http://localhost:3000"}` (no `error=`)
- [ ] `pnpm typecheck` and `pnpm lint` remain clean (no source-code change)