### PR TITLE
feat(framedcover): implement FramedCover molecule with 5 per-medium chrome variants

### DIFF
--- a/app/(dev)/dev/frames/page.tsx
+++ b/app/(dev)/dev/frames/page.tsx
@@ -1,0 +1,106 @@
+import { notFound } from 'next/navigation'
+import { FramedCover, MEDIA, MEDIUMS, SIZES } from '@/components/molecules/FramedCover'
+import type { Medium } from '@/components/molecules/FramedCover'
+import { env } from '@/lib/env'
+
+/* Visual fixture for Story 2.6 (FramedCover atom).
+ * Dev-only route. Renders the 5×4 grid Cuatro reviews against the bundle's
+ * Cuatro Tracker Frames.html prototype side-by-side. Production build excludes
+ * this route via the NODE_ENV gate (notFound() triggers a static 404 page in
+ * production; only the dev server renders the fixture).
+ */
+
+export default function FramesFixturePage() {
+  if (env.NODE_ENV !== 'development') {
+    notFound()
+  }
+
+  return (
+    <main className='min-h-screen bg-[var(--ground-base)] py-16 px-12 text-[var(--phosphor-cream)]'>
+      <header className='mx-auto mb-12 max-w-[1440px]'>
+        <p className='m-0 mb-3 font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-[var(--phosphor-cream-dim)]'>
+          Phase 0 · Frames asset family
+        </p>
+        <h1 className='m-0 mb-3 font-serif text-[52px] font-semibold italic leading-[1.05]'>
+          Cuatro Tracker · FramedCover
+        </h1>
+        <p className='m-0 max-w-[720px] text-[17px] leading-[1.4] text-[var(--phosphor-cream-dim)]'>
+          Five per-medium chromes × three sizes plus the ≤48px collapsed state. Dev-only fixture. Hover or keyboard-focus any cell to ramp the per-medium glow.
+        </p>
+      </header>
+      <div
+        className='mx-auto grid max-w-[1440px] items-end justify-start gap-x-8 gap-y-16'
+        style={{ gridTemplateColumns: '160px 88px 240px 544px 56px' }}
+      >
+        <ColumnHeader />
+        {MEDIUMS.map((medium) => (
+          <Row key={medium} medium={medium} />
+        ))}
+      </div>
+    </main>
+  )
+}
+
+function ColumnHeader() {
+  return (
+    <>
+      <span />
+      <ColLabel>thumb</ColLabel>
+      <ColLabel>card</ColLabel>
+      <ColLabel>hero</ColLabel>
+      <ColLabel>≤48px</ColLabel>
+    </>
+  )
+}
+
+function ColLabel({ children }: { children: string }) {
+  return (
+    <span className='font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-[var(--phosphor-cream-dim)]'>
+      {children}
+    </span>
+  )
+}
+
+function Row({ medium }: { medium: Medium }) {
+  const cfg = MEDIA[medium]
+  const placeholder = medium === 'games' ? '/dev/cover-placeholder-3x4.svg' : '/dev/cover-placeholder-2x3.svg'
+  return (
+    <>
+      <RowLabel name={cfg.name} chrome={cfg.chrome} />
+      {SIZES.map((size) => (
+        <Cell key={`${medium}-${size}`}>
+          <button
+            type='button'
+            className='cursor-pointer border-0 bg-transparent p-0'
+            aria-label={`${cfg.name} ${cfg.chrome} at ${size} size, focus to ramp glow`}
+          >
+            <FramedCover medium={medium} size={size} src={placeholder} alt={`${cfg.name} placeholder cover`} />
+          </button>
+        </Cell>
+      ))}
+      <Cell>
+        <button
+          type='button'
+          className='cursor-pointer border-0 bg-transparent p-0'
+          style={{ width: 32 }}
+          aria-label={`${cfg.name} ${cfg.chrome} collapsed at 32px width, focus to ramp glow`}
+        >
+          <FramedCover medium={medium} size='thumb' src={placeholder} alt={`${cfg.name} placeholder cover`} />
+        </button>
+      </Cell>
+    </>
+  )
+}
+
+function RowLabel({ name, chrome }: { name: string; chrome: string }) {
+  return (
+    <div className='flex flex-col gap-1'>
+      <span className='font-serif text-[22px] font-semibold italic text-[var(--phosphor-cream)]'>{name}</span>
+      <span className='font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--phosphor-cream-dim)]'>{chrome}</span>
+    </div>
+  )
+}
+
+function Cell({ children }: { children: React.ReactNode }) {
+  return <div className='flex items-end justify-start'>{children}</div>
+}

--- a/app/global.css
+++ b/app/global.css
@@ -26,3 +26,78 @@ body {
     pointer-events: none;
   }
 }
+
+/* FramedCover (Story 2.6, design-system.md §0.2 + 09-frames.md).
+   The outer `.fc` carries a container-query context so the ≤48px collapse rule
+   is rendered-width-driven (per 09-frames.md §4) rather than prop-driven.
+   Per-medium hover/focus glow rides on data-medium so the CSS is one ruleset. */
+.fc {
+  container-type: inline-size;
+  container-name: framed-cover;
+  display: block;
+  position: relative;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: default;
+  outline: 0;
+  transition: box-shadow 150ms ease-out;
+  --fc-glow: none;
+}
+
+.fc:hover,
+.fc:focus-visible,
+.fc:focus-within {
+  box-shadow: var(--fc-glow, none);
+}
+
+.fc[data-medium='movies'] { --fc-glow: var(--frame-stroke-movies-glow); }
+.fc[data-medium='tv']     { --fc-glow: var(--frame-stroke-tv-glow); }
+.fc[data-medium='anime']  { --fc-glow: var(--frame-stroke-anime-glow); }
+.fc[data-medium='manga']  { --fc-glow: var(--frame-stroke-manga-glow); }
+.fc[data-medium='games']  { --fc-glow: var(--frame-stroke-games-glow); }
+
+.fc-chrome-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.fc-cover-cutout {
+  position: absolute;
+  overflow: hidden;
+  background: #3A2C4E;
+}
+
+.fc-cover-cutout > img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+/* ≤48px container-query collapse: hide all non-outer chrome detail, force the
+   outer stroke to 1px, and reset the TV inner cutout radius to 0 so the
+   collapsed state is a plain rectangular frame (per 09-frames.md §4). */
+@container framed-cover (max-width: 48px) {
+  .fc-chrome-spine,
+  .fc-chrome-banner,
+  .fc-chrome-sprocket-hole,
+  .fc-chrome-registration-mark,
+  .fc-chrome-marquee-glow,
+  .fc-chrome-inner-depth {
+    display: none;
+  }
+  .fc-chrome-outer-stroke {
+    stroke-width: 1px;
+  }
+  .fc-cover-cutout {
+    border-radius: 0 !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fc { transition: none; }
+}

--- a/components/molecules/FramedCover/FramedCover.tsx
+++ b/components/molecules/FramedCover/FramedCover.tsx
@@ -1,0 +1,64 @@
+import Image from 'next/image'
+import { CHROME_BY_MEDIUM } from './chrome'
+import { MEDIA, tvInnerRadius } from './media-registry'
+import type { Medium, Size } from './media-registry'
+
+export type FramedCoverProps = {
+  medium: Medium
+  size: Size
+  src: string
+  alt: string
+}
+
+/* FramedCover (Story 2.6, design-system.md §0.2 + 09-frames.md).
+ * Renders a cover image wrapped in per-medium chrome (VHS clamshell, CRT bezel,
+ * 35mm slide mount, magazine plate, arcade marquee). Dimensions, strokes, and
+ * per-medium quirks come from `media-registry.ts` (the typed port of the bundle's
+ * MEDIA registry). Hover/focus glow rides on the parent's `:hover` / `:focus-visible`
+ * via the per-medium CSS variable mapped in `app/global.css`. The ≤48px rendered-width
+ * collapse rule fires via a CSS container query on the same outer container.
+ *
+ * Sizing strategy: `width: 100%` + `max-width: outerW` + `aspect-ratio: outerW/outerH`.
+ * The outer container defaults to the bundle's per-size outerW; a constraining parent
+ * (e.g. width: 32px) shrinks the FC and triggers the container query collapse rule.
+ * The cover cutout uses percentage positioning so the chrome SVG and cutout stay
+ * aligned regardless of the rendered size.
+ *
+ * This is a Server Component by design: no client state, no event handlers, no
+ * effects. The visible interaction (hover glow) is pure CSS.
+ */
+export function FramedCover({ medium, size, src, alt }: FramedCoverProps) {
+  const cfg = MEDIA[medium]
+  const dims = cfg.sizes[size]
+  const { outerW, outerH, padL, padT, innerW, innerH } = dims
+  const Chrome = CHROME_BY_MEDIUM[medium]
+  const innerR = medium === 'tv' ? tvInnerRadius(size) : 0
+
+  const leftPct = (padL / outerW) * 100
+  const topPct = (padT / outerH) * 100
+  const widthPct = (innerW / outerW) * 100
+  const heightPct = (innerH / outerH) * 100
+
+  return (
+    <div
+      className='fc'
+      data-medium={medium}
+      data-size={size}
+      style={{ width: outerW, maxWidth: '100%', aspectRatio: `${outerW} / ${outerH}` }}
+    >
+      <div
+        className='fc-cover-cutout'
+        style={{
+          left: `${leftPct}%`,
+          top: `${topPct}%`,
+          width: `${widthPct}%`,
+          height: `${heightPct}%`,
+          borderRadius: innerR,
+        }}
+      >
+        <Image src={src} alt={alt} width={innerW} height={innerH} unoptimized />
+      </div>
+      <Chrome size={size} dims={dims} hex={cfg.strokeHex} />
+    </div>
+  )
+}

--- a/components/molecules/FramedCover/__tests__/media-registry.test.ts
+++ b/components/molecules/FramedCover/__tests__/media-registry.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MEDIA,
+  MEDIUMS,
+  SIZES,
+  coverAspectHeightMultiplier,
+  tvInnerRadius,
+} from '@/components/molecules/FramedCover/media-registry'
+import type { Medium, Size } from '@/components/molecules/FramedCover/media-registry'
+
+describe('media-registry shape', () => {
+  it('enumerates all 5 mediums', () => {
+    expect(MEDIUMS).toEqual(['movies', 'tv', 'anime', 'manga', 'games'])
+    expect(Object.keys(MEDIA).sort()).toEqual([...MEDIUMS].sort())
+  })
+
+  it('enumerates 3 sizes', () => {
+    expect(SIZES).toEqual(['thumb', 'card', 'hero'])
+  })
+
+  it('every medium carries name, chrome, aspect, sizes, and stroke metadata', () => {
+    for (const medium of MEDIUMS) {
+      const cfg = MEDIA[medium]
+      expect(typeof cfg.name).toBe('string')
+      expect(typeof cfg.chrome).toBe('string')
+      expect(typeof cfg.aspect).toBe('string')
+      expect(typeof cfg.strokeHex).toBe('string')
+      expect(cfg.strokeHex.startsWith('#')).toBe(true)
+      expect(typeof cfg.strokeVar).toBe('string')
+      expect(typeof cfg.glowVar).toBe('string')
+    }
+  })
+
+  it('every medium has all 3 size variants with the bundle dimensions', () => {
+    for (const medium of MEDIUMS) {
+      for (const size of SIZES) {
+        const dims = MEDIA[medium].sizes[size]
+        expect(dims.outerW, `${medium}/${size} outerW`).toBeGreaterThan(0)
+        expect(dims.outerH, `${medium}/${size} outerH`).toBeGreaterThan(0)
+        expect(dims.innerW, `${medium}/${size} innerW`).toBeGreaterThan(0)
+        expect(dims.innerH, `${medium}/${size} innerH`).toBeGreaterThan(0)
+        expect(dims.strokeW, `${medium}/${size} strokeW`).toBeGreaterThan(0)
+        // Inner cutout always fits within outer dimensions
+        expect(dims.innerW + dims.padL + dims.padR).toBe(dims.outerW)
+        expect(dims.innerH + dims.padT + dims.padB).toBe(dims.outerH)
+      }
+    }
+  })
+
+  it('stroke widths follow the per-size ramp (thumb 1px / card 2-3px / hero 4-5px)', () => {
+    for (const medium of MEDIUMS) {
+      const sizes = MEDIA[medium].sizes
+      expect(sizes.thumb.strokeW, `${medium} thumb stroke`).toBe(1)
+      expect(sizes.card.strokeW, `${medium} card stroke`).toBeGreaterThanOrEqual(2)
+      expect(sizes.card.strokeW, `${medium} card stroke`).toBeLessThanOrEqual(3)
+      expect(sizes.hero.strokeW, `${medium} hero stroke`).toBeGreaterThanOrEqual(4)
+      expect(sizes.hero.strokeW, `${medium} hero stroke`).toBeLessThanOrEqual(5)
+    }
+  })
+
+  it('bundle-locked dimensions match the prompt + bundle source', () => {
+    // Movies: 12px left spine padding at card / 24px at hero
+    expect(MEDIA.movies.sizes.card.padL).toBe(12)
+    expect(MEDIA.movies.sizes.hero.padL).toBe(24)
+    expect(MEDIA.movies.sizes.card.outerW).toBe(212)
+    expect(MEDIA.movies.sizes.hero.outerW).toBe(520)
+    // TV: uniform 6px / 12px padding
+    expect(MEDIA.tv.sizes.card.padL).toBe(6)
+    expect(MEDIA.tv.sizes.hero.padL).toBe(12)
+    // Anime: uniform 12px / 24px padding
+    expect(MEDIA.anime.sizes.card.padL).toBe(12)
+    expect(MEDIA.anime.sizes.hero.padL).toBe(24)
+    // Games: 24px / 56px top banner padding
+    expect(MEDIA.games.sizes.card.padT).toBe(24)
+    expect(MEDIA.games.sizes.hero.padT).toBe(56)
+    // Games is 3:4 aspect (innerW=480, innerH=640 at hero)
+    expect(MEDIA.games.sizes.hero.innerH).toBe(640)
+  })
+
+  it('typed `as const` so consumers see literal types (compile-time readonly check)', () => {
+    type MoviesCfg = (typeof MEDIA)['movies']
+    type ReadonlyName = MoviesCfg['name']
+    const _check: ReadonlyName extends string ? true : false = true
+    expect(_check).toBe(true)
+  })
+})
+
+describe('tvInnerRadius', () => {
+  it.each<[Size, number]>([
+    ['thumb', 0],
+    ['card', 4],
+    ['hero', 10],
+  ])('returns %s = %i', (size, expected) => {
+    expect(tvInnerRadius(size)).toBe(expected)
+  })
+})
+
+describe('coverAspectHeightMultiplier', () => {
+  it.each<[Medium, number]>([
+    ['movies', 3 / 2],
+    ['tv', 3 / 2],
+    ['anime', 3 / 2],
+    ['manga', 3 / 2],
+    ['games', 4 / 3],
+  ])('returns %s = %f', (medium, expected) => {
+    expect(coverAspectHeightMultiplier(medium)).toBeCloseTo(expected, 5)
+  })
+})

--- a/components/molecules/FramedCover/chrome/ChromeAnime.tsx
+++ b/components/molecules/FramedCover/chrome/ChromeAnime.tsx
@@ -1,0 +1,54 @@
+import type { MediaDims, Size } from '../media-registry'
+
+type ChromeProps = {
+  size: Size
+  dims: MediaDims
+  hex: string
+}
+
+/* Anime 35mm slide mount chrome.
+ * Outer rect stroke + (card / hero) sprocket holes cut along top + bottom.
+ * Holes fill the page substrate var(--ground-base) so era-tinted timelines
+ * see-through correctly.
+ * Ported from bundle framed-cover.jsx lines 169-199.
+ */
+export function ChromeAnime({ size, dims, hex }: ChromeProps) {
+  const { outerW, outerH, padL, padT, padB, innerW, innerH, strokeW } = dims
+  const holeCount = size === 'card' ? 6 : size === 'hero' ? 12 : 0
+  const holeW = size === 'card' ? 4 : 8
+  const holeH = size === 'card' ? 6 : 12
+  const holeStrokeW = size === 'hero' ? 2 : 1
+  const segment = holeCount > 0 ? innerW / holeCount : 0
+  return (
+    <svg
+      className='fc-chrome-svg'
+      viewBox={`0 0 ${outerW} ${outerH}`}
+      preserveAspectRatio='none'
+      aria-hidden='true'
+    >
+      <rect
+        x={strokeW / 2}
+        y={strokeW / 2}
+        width={outerW - strokeW}
+        height={outerH - strokeW}
+        fill='none'
+        stroke={hex}
+        strokeWidth={strokeW}
+        className='fc-chrome-outer-stroke'
+      />
+      {holeCount > 0 &&
+        Array.from({ length: holeCount }).map((_, i) => {
+          const cx = padL + segment * (i + 0.5)
+          const x = cx - holeW / 2
+          const topY = (padT - holeH) / 2
+          const botY = padT + innerH + (padB - holeH) / 2
+          return (
+            <g key={`sprocket-${i}`} className='fc-chrome-sprocket-hole'>
+              <rect x={x} y={topY} width={holeW} height={holeH} fill='var(--ground-base)' stroke={hex} strokeWidth={holeStrokeW} />
+              <rect x={x} y={botY} width={holeW} height={holeH} fill='var(--ground-base)' stroke={hex} strokeWidth={holeStrokeW} />
+            </g>
+          )
+        })}
+    </svg>
+  )
+}

--- a/components/molecules/FramedCover/chrome/ChromeGames.tsx
+++ b/components/molecules/FramedCover/chrome/ChromeGames.tsx
@@ -1,0 +1,63 @@
+import type { MediaDims, Size } from '../media-registry'
+
+type ChromeProps = {
+  size: Size
+  dims: MediaDims
+  hex: string
+}
+
+/* Games arcade marquee chrome.
+ * Outer rect stroke + (card / hero) banner bottom edge + (hero only)
+ * interior #7B5CFF glow at 6% opacity inside the banner area + 2 side
+ * trim posts + 9 decorative bulb dots.
+ * Per 09-frames.md §3.5: this is the ONE place a chrome carries colored
+ * interior light; the synth-purple hex is hard-coded intentionally.
+ * Ported from bundle framed-cover.jsx lines 232-278.
+ */
+export function ChromeGames({ size, dims, hex }: ChromeProps) {
+  const { outerW, outerH, padL, padR, padT, innerW, strokeW } = dims
+  const bannerInnerStroke = size === 'hero' ? 2 : 1
+  return (
+    <svg
+      className='fc-chrome-svg'
+      viewBox={`0 0 ${outerW} ${outerH}`}
+      preserveAspectRatio='none'
+      aria-hidden='true'
+    >
+      <rect
+        x={strokeW / 2}
+        y={strokeW / 2}
+        width={outerW - strokeW}
+        height={outerH - strokeW}
+        fill='none'
+        stroke={hex}
+        strokeWidth={strokeW}
+        className='fc-chrome-outer-stroke'
+      />
+      {size !== 'thumb' && (
+        <>
+          <line
+            x1={strokeW}
+            y1={padT}
+            x2={outerW - strokeW}
+            y2={padT}
+            stroke={hex}
+            strokeWidth={bannerInnerStroke}
+            className='fc-chrome-banner'
+          />
+          {size === 'hero' && (
+            <g className='fc-chrome-marquee-glow'>
+              <rect x={strokeW} y={strokeW} width={outerW - 2 * strokeW} height={padT - strokeW} fill='#7B5CFF' opacity={0.06} />
+              <line x1={padL} y1={strokeW} x2={padL} y2={padT} stroke={hex} strokeWidth={1} />
+              <line x1={outerW - padR} y1={strokeW} x2={outerW - padR} y2={padT} stroke={hex} strokeWidth={1} />
+              {Array.from({ length: 9 }).map((_, i) => {
+                const cx = padL + (innerW / 10) * (i + 1)
+                return <circle key={`bulb-${i}`} cx={cx} cy={padT / 2} r={2} fill='#7B5CFF' opacity={0.35} />
+              })}
+            </g>
+          )}
+        </>
+      )}
+    </svg>
+  )
+}

--- a/components/molecules/FramedCover/chrome/ChromeManga.tsx
+++ b/components/molecules/FramedCover/chrome/ChromeManga.tsx
@@ -1,0 +1,56 @@
+import type { MediaDims, Size } from '../media-registry'
+
+type ChromeProps = {
+  size: Size
+  dims: MediaDims
+  hex: string
+}
+
+/* Manga magazine plate chrome.
+ * Outer rect stroke + (card / hero) corner `+` registration marks at all 4
+ * corners. Mark size + inset + stroke scale per size.
+ * Ported from bundle framed-cover.jsx lines 201-230.
+ */
+export function ChromeManga({ size, dims, hex }: ChromeProps) {
+  const { outerW, outerH, strokeW } = dims
+  const markSize = size === 'card' ? 6 : size === 'hero' ? 12 : 0
+  const markInset = size === 'card' ? 2 : 4
+  const markStrokeW = size === 'hero' ? 1.5 : 1
+
+  function renderMark(cx: number, cy: number, key: string) {
+    return (
+      <g key={key} className='fc-chrome-registration-mark'>
+        <line x1={cx - markSize / 2} y1={cy} x2={cx + markSize / 2} y2={cy} stroke={hex} strokeWidth={markStrokeW} />
+        <line x1={cx} y1={cy - markSize / 2} x2={cx} y2={cy + markSize / 2} stroke={hex} strokeWidth={markStrokeW} />
+      </g>
+    )
+  }
+
+  return (
+    <svg
+      className='fc-chrome-svg'
+      viewBox={`0 0 ${outerW} ${outerH}`}
+      preserveAspectRatio='none'
+      aria-hidden='true'
+    >
+      <rect
+        x={strokeW / 2}
+        y={strokeW / 2}
+        width={outerW - strokeW}
+        height={outerH - strokeW}
+        fill='none'
+        stroke={hex}
+        strokeWidth={strokeW}
+        className='fc-chrome-outer-stroke'
+      />
+      {markSize > 0 && (
+        <>
+          {renderMark(markInset + markSize / 2, markInset + markSize / 2, 'tl')}
+          {renderMark(outerW - markInset - markSize / 2, markInset + markSize / 2, 'tr')}
+          {renderMark(markInset + markSize / 2, outerH - markInset - markSize / 2, 'bl')}
+          {renderMark(outerW - markInset - markSize / 2, outerH - markInset - markSize / 2, 'br')}
+        </>
+      )}
+    </svg>
+  )
+}

--- a/components/molecules/FramedCover/chrome/ChromeMovies.tsx
+++ b/components/molecules/FramedCover/chrome/ChromeMovies.tsx
@@ -1,0 +1,67 @@
+import type { MediaDims, Size } from '../media-registry'
+
+type ChromeProps = {
+  size: Size
+  dims: MediaDims
+  hex: string
+}
+
+/* Movies VHS clamshell chrome.
+ * Outer rect stroke + (card) vertical spine demarcation hairline + (hero)
+ * 2px spine demarcation, 1px horizontal label-split at midpoint,
+ * decorative IBM Plex Mono spine label rotated -90deg.
+ * Ported from bundle framed-cover.jsx lines 100-139.
+ */
+export function ChromeMovies({ size, dims, hex }: ChromeProps) {
+  const { outerW, outerH, padL, strokeW } = dims
+  return (
+    <svg
+      className='fc-chrome-svg'
+      viewBox={`0 0 ${outerW} ${outerH}`}
+      preserveAspectRatio='none'
+      aria-hidden='true'
+    >
+      <rect
+        x={strokeW / 2}
+        y={strokeW / 2}
+        width={outerW - strokeW}
+        height={outerH - strokeW}
+        fill='none'
+        stroke={hex}
+        strokeWidth={strokeW}
+        className='fc-chrome-outer-stroke'
+      />
+      {size === 'card' && (
+        <line
+          x1={padL - 0.5}
+          y1={strokeW}
+          x2={padL - 0.5}
+          y2={outerH - strokeW}
+          stroke={hex}
+          strokeWidth={1}
+          className='fc-chrome-spine'
+        />
+      )}
+      {size === 'hero' && (
+        <g className='fc-chrome-spine'>
+          <line x1={padL - 1} y1={strokeW} x2={padL - 1} y2={outerH - strokeW} stroke={hex} strokeWidth={2} />
+          <line x1={strokeW} y1={outerH / 2} x2={padL - 2} y2={outerH / 2} stroke={hex} strokeWidth={1} />
+          <text
+            x={padL / 2 + 1}
+            y={outerH / 2 - 80}
+            fontFamily='IBM Plex Mono, monospace'
+            fontSize={11}
+            fontWeight={500}
+            letterSpacing={2.6}
+            fill={hex}
+            opacity={0.65}
+            textAnchor='middle'
+            transform={`rotate(-90 ${padL / 2 + 1} ${outerH / 2 - 80})`}
+          >
+            CUATRO · 1996
+          </text>
+        </g>
+      )}
+    </svg>
+  )
+}

--- a/components/molecules/FramedCover/chrome/ChromeTv.tsx
+++ b/components/molecules/FramedCover/chrome/ChromeTv.tsx
@@ -1,0 +1,51 @@
+import type { MediaDims, Size } from '../media-registry'
+import { tvInnerRadius } from '../media-registry'
+
+type ChromeProps = {
+  size: Size
+  dims: MediaDims
+  hex: string
+}
+
+/* TV CRT bezel chrome.
+ * Outer rect stroke + (card / hero) inner-edge depth hairline inset 1px
+ * from the cover well, with rounded corners matching the TV inner radius.
+ * Ported from bundle framed-cover.jsx lines 141-167.
+ */
+export function ChromeTv({ size, dims, hex }: ChromeProps) {
+  const { outerW, outerH, padL, padT, innerW, innerH, strokeW } = dims
+  const innerR = tvInnerRadius(size)
+  return (
+    <svg
+      className='fc-chrome-svg'
+      viewBox={`0 0 ${outerW} ${outerH}`}
+      preserveAspectRatio='none'
+      aria-hidden='true'
+    >
+      <rect
+        x={strokeW / 2}
+        y={strokeW / 2}
+        width={outerW - strokeW}
+        height={outerH - strokeW}
+        fill='none'
+        stroke={hex}
+        strokeWidth={strokeW}
+        className='fc-chrome-outer-stroke'
+      />
+      {size !== 'thumb' && (
+        <rect
+          x={padL + 1}
+          y={padT + 1}
+          width={innerW - 2}
+          height={innerH - 2}
+          rx={Math.max(0, innerR - 1)}
+          ry={Math.max(0, innerR - 1)}
+          fill='none'
+          stroke='rgba(0,0,0,0.72)'
+          strokeWidth={size === 'hero' ? 2 : 1}
+          className='fc-chrome-inner-depth'
+        />
+      )}
+    </svg>
+  )
+}

--- a/components/molecules/FramedCover/chrome/index.ts
+++ b/components/molecules/FramedCover/chrome/index.ts
@@ -1,0 +1,19 @@
+import type { JSX } from 'react'
+import type { Medium, MediaDims, Size } from '../media-registry'
+import { ChromeAnime } from './ChromeAnime'
+import { ChromeGames } from './ChromeGames'
+import { ChromeManga } from './ChromeManga'
+import { ChromeMovies } from './ChromeMovies'
+import { ChromeTv } from './ChromeTv'
+
+export type ChromeComponent = (props: { size: Size; dims: MediaDims; hex: string }) => JSX.Element
+
+export const CHROME_BY_MEDIUM: Record<Medium, ChromeComponent> = {
+  movies: ChromeMovies,
+  tv: ChromeTv,
+  anime: ChromeAnime,
+  manga: ChromeManga,
+  games: ChromeGames,
+}
+
+export { ChromeAnime, ChromeGames, ChromeManga, ChromeMovies, ChromeTv }

--- a/components/molecules/FramedCover/index.ts
+++ b/components/molecules/FramedCover/index.ts
@@ -1,0 +1,4 @@
+export { FramedCover } from './FramedCover'
+export type { FramedCoverProps } from './FramedCover'
+export { MEDIA, MEDIUMS, SIZES, tvInnerRadius, coverAspectHeightMultiplier } from './media-registry'
+export type { Medium, Size, MediaDims, MediaConfig } from './media-registry'

--- a/components/molecules/FramedCover/media-registry.ts
+++ b/components/molecules/FramedCover/media-registry.ts
@@ -1,0 +1,110 @@
+/* Source: _bmad-output/design-bundles/cuatro-tracker-2026-04-26/09-frames/
+ *         cuatro-tracker/project/framed-cover.jsx (MEDIA constant, lines 7-78).
+ * Story 2.6 ports the bundle's MEDIA shape into a typed `as const` registry.
+ * Per-size dimensions are LOCKED here; consumers read them via the typed
+ * accessors below. Any change to a dimension must also update
+ * `docs/design-prompts/09-frames.md` §3 (the design-prompt source-of-truth).
+ *
+ * Field divergence vs the bundle: the bundle's MEDIA carries `glow`
+ * (e.g. `var(--frame-glow-movies)`) and `glowStr` (the human-readable spec
+ * string) per medium. The actual token in `cuatro-tracker/app/tokens.css`
+ * lines 99-103 is named `--frame-stroke-<medium>-glow` (with the `-glow`
+ * suffix, matching the LED token convention). This registry uses `glowVar`
+ * pointing at the canonical token; the bundle's `glow` and `glowStr` fields
+ * are dropped to avoid having two ways to spell the same thing.
+ */
+
+export const MEDIA = {
+  movies: {
+    name: 'Movies',
+    chrome: 'VHS clamshell',
+    aspect: '2:3 TMDB poster',
+    sizes: {
+      thumb: { outerW: 72, outerH: 104, padL: 4, padR: 4, padT: 4, padB: 4, innerW: 64, innerH: 96, strokeW: 1 },
+      card: { outerW: 212, outerH: 304, padL: 12, padR: 8, padT: 8, padB: 8, innerW: 192, innerH: 288, strokeW: 2 },
+      hero: { outerW: 520, outerH: 752, padL: 24, padR: 16, padT: 16, padB: 16, innerW: 480, innerH: 720, strokeW: 4 },
+    },
+    strokeHex: '#B5AC9D',
+    strokeVar: 'var(--frame-stroke-movies)',
+    glowVar: 'var(--frame-stroke-movies-glow)',
+  },
+  tv: {
+    name: 'TV',
+    chrome: 'CRT bezel',
+    aspect: '2:3 TMDB poster',
+    sizes: {
+      thumb: { outerW: 72, outerH: 104, padL: 4, padR: 4, padT: 4, padB: 4, innerW: 64, innerH: 96, strokeW: 1 },
+      card: { outerW: 204, outerH: 300, padL: 6, padR: 6, padT: 6, padB: 6, innerW: 192, innerH: 288, strokeW: 3 },
+      hero: { outerW: 504, outerH: 744, padL: 12, padR: 12, padT: 12, padB: 12, innerW: 480, innerH: 720, strokeW: 5 },
+    },
+    strokeHex: '#7A7468',
+    strokeVar: 'var(--frame-stroke-tv)',
+    glowVar: 'var(--frame-stroke-tv-glow)',
+  },
+  anime: {
+    name: 'Anime',
+    chrome: '35mm slide mount',
+    aspect: '2:3 AniList cover',
+    sizes: {
+      thumb: { outerW: 76, outerH: 108, padL: 6, padR: 6, padT: 6, padB: 6, innerW: 64, innerH: 96, strokeW: 1 },
+      card: { outerW: 216, outerH: 312, padL: 12, padR: 12, padT: 12, padB: 12, innerW: 192, innerH: 288, strokeW: 2 },
+      hero: { outerW: 528, outerH: 768, padL: 24, padR: 24, padT: 24, padB: 24, innerW: 480, innerH: 720, strokeW: 4 },
+    },
+    strokeHex: '#9D8C66',
+    strokeVar: 'var(--frame-stroke-anime)',
+    glowVar: 'var(--frame-stroke-anime-glow)',
+  },
+  manga: {
+    name: 'Manga',
+    chrome: 'Magazine plate',
+    aspect: '2:3 AniList cover',
+    sizes: {
+      thumb: { outerW: 72, outerH: 104, padL: 4, padR: 4, padT: 4, padB: 4, innerW: 64, innerH: 96, strokeW: 1 },
+      card: { outerW: 208, outerH: 304, padL: 8, padR: 8, padT: 8, padB: 8, innerW: 192, innerH: 288, strokeW: 2 },
+      hero: { outerW: 512, outerH: 752, padL: 16, padR: 16, padT: 16, padB: 16, innerW: 480, innerH: 720, strokeW: 4 },
+    },
+    strokeHex: '#B5AC9D',
+    strokeVar: 'var(--frame-stroke-manga)',
+    glowVar: 'var(--frame-stroke-manga-glow)',
+  },
+  games: {
+    name: 'Games',
+    chrome: 'Arcade marquee',
+    aspect: '3:4 IGDB box art',
+    sizes: {
+      thumb: { outerW: 72, outerH: 97, padL: 4, padR: 4, padT: 8, padB: 4, innerW: 64, innerH: 85, strokeW: 1 },
+      card: { outerW: 208, outerH: 288, padL: 8, padR: 8, padT: 24, padB: 8, innerW: 192, innerH: 256, strokeW: 2 },
+      hero: { outerW: 512, outerH: 712, padL: 16, padR: 16, padT: 56, padB: 16, innerW: 480, innerH: 640, strokeW: 4 },
+    },
+    strokeHex: '#5C4677',
+    strokeVar: 'var(--frame-stroke-games)',
+    glowVar: 'var(--frame-stroke-games-glow)',
+  },
+} as const
+
+export type Medium = keyof typeof MEDIA
+export type Size = 'thumb' | 'card' | 'hero'
+export type MediaDims = (typeof MEDIA)[Medium]['sizes'][Size]
+export type MediaConfig = (typeof MEDIA)[Medium]
+
+export const MEDIUMS: readonly Medium[] = ['movies', 'tv', 'anime', 'manga', 'games'] as const
+export const SIZES: readonly Size[] = ['thumb', 'card', 'hero'] as const
+
+/* TV is the only medium whose inner cutout receives rounded corners
+ * (per design-system §0.4, the inner CRT screen area is the lone
+ * exception to the 0-radius rule). Returns the radius in px.
+ */
+export function tvInnerRadius(size: Size): number {
+  if (size === 'hero') return 10
+  if (size === 'card') return 4
+  return 0
+}
+
+/* Aspect ratio for the placeholder cover image per medium.
+ * Movies/TV/Anime/Manga at 2:3 (height = 1.5×width).
+ * Games at 3:4 (height ≈ 1.333×width per IGDB box art convention).
+ */
+export function coverAspectHeightMultiplier(medium: Medium): number {
+  if (medium === 'games') return 4 / 3
+  return 3 / 2
+}

--- a/public/dev/cover-placeholder-2x3.svg
+++ b/public/dev/cover-placeholder-2x3.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 480 720' preserveAspectRatio='xMidYMid slice' role='img' aria-label='Placeholder cover'>
+  <rect width='480' height='720' fill='#3A2C4E'/>
+  <text x='240' y='420' text-anchor='middle' font-family='Cormorant Garamond, EB Garamond, serif' font-style='italic' font-weight='600' font-size='320' fill='#EFE6D4' opacity='0.88'>?</text>
+</svg>

--- a/public/dev/cover-placeholder-3x4.svg
+++ b/public/dev/cover-placeholder-3x4.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 480 640' preserveAspectRatio='xMidYMid slice' role='img' aria-label='Placeholder cover'>
+  <rect width='480' height='640' fill='#3A2C4E'/>
+  <text x='240' y='380' text-anchor='middle' font-family='Cormorant Garamond, EB Garamond, serif' font-style='italic' font-weight='600' font-size='300' fill='#EFE6D4' opacity='0.88'>?</text>
+</svg>


### PR DESCRIPTION
## Summary

Ports the 09-frames claude.ai/design bundle into a typed Server Component at `cuatro-tracker/components/molecules/FramedCover/`. Five per-medium chromes (VHS clamshell for movies, CRT bezel for TV, 35mm slide mount for anime, magazine plate for manga, arcade marquee for games), each at three sizes (thumb / card / hero) plus a ≤48px container-query collapse. Hover/focus glow rides on per-`data-medium` CSS variables mapped to the existing `--frame-stroke-<medium>-glow` tokens from Story 2.1.

Closes #66.

## Test plan

- [x] Static gates inside dev container: `pnpm typecheck`, `pnpm lint`, `pnpm build` all clean.
- [x] Pure-function unit tests: 15/15 pass for the typed MEDIA registry shape, dimension math, and `tvInnerRadius` lookup.
- [x] Visual fixture at `/dev/frames` (dev-only via `env.NODE_ENV` gate). Cuatro confirmed the 5×4 grid renders correctly, hover glow ramps per medium, and the collapsed-state column collapses to a 1px outer stroke.
- [x] bmad-code-review: 2 layers (Edge Case Hunter + Acceptance Auditor) ran against the diff; ~46 raw findings triaged to 6 patches, 10 deferrals (logged in `_bmad-output/implementation-artifacts/deferred-work.md`), 4 dismissals, ~26 positive confirmations. Acceptance Auditor verdict after patches: AC-1 / AC-2 / AC-3 / AC-4 hold.
- [ ] Production deploy verification skipped per `feedback_deploy_live_from_2026_05_09.md` (VPS migration window still active).

## Notes

- Tier placement: `components/molecules/` (NOT `components/atoms/` as the epic AC title implies). Brainstorm direction §4, the component inventory, and `09-frames.md` §7 all classify `FramedCover` as a Molecule. See impl-artifact AC-1 reframing note for the 3-source consensus rationale.
- The bundle's `MaskDefs` block is intentionally not ported (per-medium chrome SVGs are pixel-precise; masks redundant). See impl-artifact Open Item #4.
- `<Image unoptimized>` is baked into the atom for Story 2.6's placeholder SVG usage; real raster consumers (Epic 6+ TMDB / AniList / IGDB) will need a different strategy. Logged as deferred-work.
- Pre-existing BullMQ worker test failures (`lib/jobs/__tests__/worker.test.ts`) are unrelated to this story (commit `d3150c2`); not introduced by this PR.

Impl-artifact: `_bmad-output/implementation-artifacts/2-6-implement-framedcover-atom-with-5-per-medium-chrome-variants.md`.
Bundle: `_bmad-output/design-bundles/cuatro-tracker-2026-04-26/09-frames/cuatro-tracker/`.
Design prompt: `docs/design-prompts/09-frames.md`.