### PR TITLE
feat(motion): add BootSequence molecule with 10-frame timeline + reduced-motion + key skip (#67)

### DIFF
--- a/app/(dev)/dev/boot/BootFixtureClient.tsx
+++ b/app/(dev)/dev/boot/BootFixtureClient.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { BootSequence } from '@/components/molecules/BootSequence'
+
+type Mode = 'default' | 'no-welcome' | 'reduced-forced' | 'reduced-os'
+
+const FIXTURE_TOTAL_DURATION_MS = 4000
+
+const MODES: { key: Mode; label: string; description: string }[] = [
+  {
+    key: 'default',
+    label: 'Animation (full timeline + welcome)',
+    description: `Forces non-reduced and slows the timeline to ${FIXTURE_TOTAL_DURATION_MS}ms so each frame is observable. Welcome flash at the end. onComplete fires at the end of frame 10.`,
+  },
+  {
+    key: 'no-welcome',
+    label: 'Animation (no welcome)',
+    description: `Forces non-reduced and slows the timeline to ${FIXTURE_TOTAL_DURATION_MS}ms. Stops at frame 9 (READY.) with no welcome flash. onComplete fires at the end of frame 9.`,
+  },
+  {
+    key: 'reduced-forced',
+    label: 'Reduced-motion (forced)',
+    description: 'Bypasses matchMedia; renders static READY. and fires onComplete on first paint.',
+  },
+  {
+    key: 'reduced-os',
+    label: 'OS setting (no override)',
+    description: 'Honors the actual matchMedia value. If your OS has reduced-motion ON, this matches mode 3; if OFF, plays the full animation at the default 1200ms cadence.',
+  },
+]
+
+export function BootFixtureClient() {
+  const search = useSearchParams()
+  const urlReduced = search?.get('reduced') === 'true'
+  const [mode, setMode] = useState<Mode>(urlReduced ? 'reduced-forced' : 'default')
+  const [runCount, setRunCount] = useState(0)
+  const [completedAt, setCompletedAt] = useState<number | null>(null)
+
+  useEffect(() => {
+    setMode(urlReduced ? 'reduced-forced' : 'default')
+  }, [urlReduced])
+
+  const replay = useCallback((next: Mode) => {
+    setCompletedAt(null)
+    setMode(next)
+    setRunCount((n) => n + 1)
+  }, [])
+
+  const onComplete = useCallback(() => {
+    setCompletedAt(performance.now())
+  }, [])
+
+  const props = useMemo(() => {
+    switch (mode) {
+      case 'default':
+        return {
+          showWelcome: true,
+          onComplete,
+          reducedMotionOverride: false,
+          totalDuration: FIXTURE_TOTAL_DURATION_MS,
+        }
+      case 'no-welcome':
+        return {
+          showWelcome: false,
+          onComplete,
+          reducedMotionOverride: false,
+          totalDuration: FIXTURE_TOTAL_DURATION_MS,
+        }
+      case 'reduced-forced':
+        return { showWelcome: true, onComplete, reducedMotionOverride: true }
+      case 'reduced-os':
+      default:
+        return { showWelcome: true, onComplete }
+    }
+  }, [mode, onComplete])
+
+  return (
+    <main className='min-h-screen bg-[var(--ground-base)] text-[var(--phosphor-cream)]'>
+      <header className='mx-auto max-w-[1200px] px-12 pt-16'>
+        <p className='m-0 mb-3 font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-[var(--phosphor-cream-dim)]'>
+          Story 2.7 · BootSequence molecule
+        </p>
+        <h1 className='m-0 mb-3 font-serif text-[44px] font-semibold italic leading-[1.05]'>
+          Cuatro Tracker · BootSequence
+        </h1>
+        <p className='m-0 mb-2 font-mono text-[13px] leading-[1.55] text-[var(--phosphor-cream-dim)]'>
+          Dev-only fixture. Pick a mode, watch the 10-frame timeline. Press any key during playback to verify the keyboard-skip path. Toggle OS reduced-motion in system settings to verify the matchMedia branch.
+        </p>
+      </header>
+
+      <section className='mx-auto mt-10 max-w-[1200px] px-12'>
+        <div className='flex flex-wrap gap-3'>
+          {MODES.map((m) => {
+            const active = mode === m.key
+            return (
+              <button
+                key={m.key}
+                type='button'
+                onClick={() => replay(m.key)}
+                aria-pressed={active}
+                className={`rounded-none border-2 px-4 py-2 font-mono text-[12px] uppercase tracking-[0.14em] transition-colors ${
+                  active
+                    ? 'border-[var(--phosphor-cream)] bg-[var(--phosphor-cream)] text-[var(--ground-base)]'
+                    : 'border-[var(--phosphor-cream-dim)] bg-transparent text-[var(--phosphor-cream-dim)] hover:border-[var(--phosphor-cream)] hover:text-[var(--phosphor-cream)]'
+                }`}
+              >
+                {m.label}
+              </button>
+            )
+          })}
+        </div>
+        <p className='mt-3 font-mono text-[12px] text-[var(--phosphor-cream-dim)]'>
+          {MODES.find((m) => m.key === mode)?.description}
+        </p>
+      </section>
+
+      <section className='mx-auto mt-10 max-w-[1200px] px-12 pb-16'>
+        <div className='relative mx-auto aspect-[4/3] w-full max-w-[720px] overflow-hidden border-2 border-[var(--phosphor-cream-dim)] bg-[var(--ground-base)]'>
+          <BootSequence key={`${mode}-${runCount}`} {...props} />
+          <div className='pointer-events-none absolute left-3 top-3 z-10 font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--phosphor-cream-dim)]'>
+            run #{runCount + 1} · {completedAt !== null ? `complete @ ${Math.round(completedAt)}ms` : 'in progress'}
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/(dev)/dev/boot/page.tsx
+++ b/app/(dev)/dev/boot/page.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from 'react'
+import { notFound } from 'next/navigation'
+import { env } from '@/lib/env'
+import { BootFixtureClient } from './BootFixtureClient'
+
+/* Visual fixture for Story 2.7 (BootSequence molecule).
+ * Dev-only route. Renders four mounts of BootSequence (default, no-welcome,
+ * reduced-motion forced, reduced-motion OS-current) with a replay key bump per
+ * AC-1/2/3 verification. Production build excludes this route via the NODE_ENV
+ * gate; notFound() triggers a static 404. */
+
+export default function BootFixturePage() {
+  if (env.NODE_ENV !== 'development') {
+    notFound()
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <BootFixtureClient />
+    </Suspense>
+  )
+}

--- a/app/global.css
+++ b/app/global.css
@@ -101,3 +101,92 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .fc { transition: none; }
 }
+
+/* BootSequence (Story 2.7). 10-frame login boot animation. Mirrors the bundle's
+   login-styles.css boot section (lines 142-189, 314-356). VT323 bitmap face only.
+   Reduced-motion users skip the timeline and see a static READY. frame; the
+   welcome flash never renders for them, so the @keyframes is gated by a media
+   query as defense in depth. */
+.bs {
+  position: absolute;
+  inset: 0;
+  background: var(--ground-base);
+  z-index: 8;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 38px 46px 42px;
+  color: var(--phosphor-cream);
+}
+
+.bs-header {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-bitmap);
+  font-size: 30px;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  text-shadow: 0 0 8px rgba(239, 230, 212, 0.4);
+}
+.bs-label { padding: 0 8px; }
+.bs-blocks { display: inline-flex; gap: 1px; text-shadow: none; }
+.bs-blocks span { display: inline-block; }
+.bs-b1 { color: var(--rb-green); }
+.bs-b2 { color: var(--rb-yellow); }
+.bs-b3 { color: var(--rb-orange); }
+
+.bs-version {
+  margin-top: 10px;
+  font-family: var(--font-bitmap);
+  font-size: 20px;
+  letter-spacing: 0.04em;
+  color: var(--phosphor-cream);
+}
+
+.bs-copyright {
+  margin-top: 4px;
+  font-family: var(--font-bitmap);
+  font-size: 16px;
+  letter-spacing: 0.04em;
+  color: var(--phosphor-cream-dim);
+}
+
+.bs-progress {
+  margin-top: 28px;
+  font-family: var(--font-bitmap);
+  font-size: 22px;
+  color: var(--phosphor-cream);
+  letter-spacing: 2px;
+  white-space: pre;
+  font-variant-numeric: tabular-nums;
+}
+
+.bs-ready {
+  margin-top: 18px;
+  font-family: var(--font-bitmap);
+  font-size: 22px;
+  letter-spacing: 0.04em;
+  color: var(--phosphor-cream);
+}
+
+.bs-welcome {
+  margin-top: 12px;
+  font-family: var(--font-bitmap);
+  font-size: 26px;
+  letter-spacing: 0.04em;
+  color: var(--phosphor-cream);
+  text-shadow:
+    0 0 12px rgba(239, 230, 212, 0.7),
+    0 0 6px rgba(239, 230, 212, 0.4);
+  animation: bs-welcome-pulse 600ms ease-out;
+}
+
+@keyframes bs-welcome-pulse {
+  0% { opacity: 0; text-shadow: 0 0 0 transparent; }
+  20% { opacity: 1; text-shadow: 0 0 16px rgba(239, 230, 212, 0.95); }
+  100% { opacity: 1; text-shadow: 0 0 6px rgba(239, 230, 212, 0.4); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bs-welcome { animation: none; }
+}

--- a/components/molecules/BootSequence/BootSequence.tsx
+++ b/components/molecules/BootSequence/BootSequence.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import gsap from 'gsap'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  BOOT_COPYRIGHT_LINE,
+  BOOT_FINAL_FRAME_NO_WELCOME,
+  BOOT_FINAL_FRAME_WITH_WELCOME,
+  BOOT_FRAMES,
+  BOOT_HEADER_LABEL,
+  BOOT_READY_LINE,
+  BOOT_VERSION_LINE,
+  BOOT_WELCOME_LINE,
+  finalCallbackMs,
+  progressBar,
+  safeTotalDurationMs,
+  scaleFrames,
+} from './boot-frames'
+
+export type BootSequenceProps = {
+  showWelcome?: boolean
+  onComplete: () => void
+  totalDuration?: number
+  reducedMotionOverride?: boolean
+}
+
+const MODIFIER_ONLY_KEYS = new Set(['Shift', 'Control', 'Alt', 'Meta', 'CapsLock'])
+
+function readInitialReducedMotion(override?: boolean): boolean {
+  if (typeof override === 'boolean') return override
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+function usePrefersReducedMotion(
+  override: boolean | undefined,
+  initial: boolean
+): boolean {
+  const [reduced, setReduced] = useState<boolean>(initial)
+
+  useEffect(() => {
+    if (typeof override === 'boolean') {
+      setReduced(override)
+      return
+    }
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+    setReduced(mql.matches)
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches)
+    mql.addEventListener('change', onChange)
+    return () => mql.removeEventListener('change', onChange)
+  }, [override])
+
+  return reduced
+}
+
+export function BootSequence({
+  showWelcome = true,
+  onComplete,
+  totalDuration,
+  reducedMotionOverride,
+}: BootSequenceProps) {
+  const initialReduced = readInitialReducedMotion(reducedMotionOverride)
+  const reduced = usePrefersReducedMotion(reducedMotionOverride, initialReduced)
+  const [currentFrame, setCurrentFrame] = useState<number>(() =>
+    initialReduced ? BOOT_FINAL_FRAME_NO_WELCOME : 1
+  )
+  const completedRef = useRef(false)
+  const timelineRef = useRef<gsap.core.Timeline | null>(null)
+  const totalMs = safeTotalDurationMs(totalDuration)
+
+  const fireComplete = useCallback(() => {
+    if (completedRef.current) return
+    completedRef.current = true
+    onComplete()
+  }, [onComplete])
+
+  useEffect(() => {
+    if (!reduced) return
+    setCurrentFrame(BOOT_FINAL_FRAME_NO_WELCOME)
+    const raf = requestAnimationFrame(() => fireComplete())
+    return () => cancelAnimationFrame(raf)
+  }, [reduced, fireComplete])
+
+  useEffect(() => {
+    if (reduced) return
+    const scaled = scaleFrames(BOOT_FRAMES, totalMs)
+    const lastFrame = showWelcome ? BOOT_FINAL_FRAME_WITH_WELCOME : BOOT_FINAL_FRAME_NO_WELCOME
+    const tl = gsap.timeline()
+    timelineRef.current = tl
+    for (const frame of scaled) {
+      if (frame.index > lastFrame) break
+      tl.call(
+        () => setCurrentFrame(frame.index),
+        undefined,
+        frame.startMs / 1000
+      )
+    }
+    tl.call(fireComplete, undefined, finalCallbackMs(showWelcome, totalMs) / 1000)
+    return () => {
+      tl.kill()
+      timelineRef.current = null
+    }
+  }, [reduced, showWelcome, totalMs, fireComplete])
+
+  useEffect(() => {
+    if (reduced) return
+    let rafId: number | null = null
+    const handler = (e: KeyboardEvent) => {
+      if (e.repeat) return
+      if (e.isComposing) return
+      if (MODIFIER_ONLY_KEYS.has(e.key)) return
+      const finalFrame = showWelcome ? BOOT_FINAL_FRAME_WITH_WELCOME : BOOT_FINAL_FRAME_NO_WELCOME
+      timelineRef.current?.kill()
+      timelineRef.current = null
+      setCurrentFrame(finalFrame)
+      if (rafId !== null) cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(() => fireComplete())
+    }
+    window.addEventListener('keydown', handler)
+    return () => {
+      window.removeEventListener('keydown', handler)
+      if (rafId !== null) cancelAnimationFrame(rafId)
+    }
+  }, [reduced, showWelcome, fireComplete])
+
+  const showHeader = currentFrame >= 2
+  const showVersion = currentFrame >= 3
+  const showCopyright = currentFrame >= 4
+  const showProgress = currentFrame >= 5
+  const showReady = currentFrame >= 9
+  const showWelcomeLine = currentFrame >= 10 && showWelcome
+
+  return (
+    <div
+      className='bs'
+      role='status'
+      aria-live='polite'
+      aria-label='System boot sequence'
+      data-frame={currentFrame}
+    >
+      {showHeader && (
+        <div className='bs-header' aria-hidden='true'>
+          <span className='bs-blocks'>
+            <span className='bs-b1'>▓</span>
+            <span className='bs-b2'>▓</span>
+            <span className='bs-b3'>▓</span>
+          </span>
+          <span className='bs-label'>{BOOT_HEADER_LABEL}</span>
+          <span className='bs-blocks'>
+            <span className='bs-b3'>▓</span>
+            <span className='bs-b2'>▓</span>
+            <span className='bs-b1'>▓</span>
+          </span>
+        </div>
+      )}
+      {showVersion && <div className='bs-version'>{BOOT_VERSION_LINE}</div>}
+      {showCopyright && <div className='bs-copyright'>{BOOT_COPYRIGHT_LINE}</div>}
+      {showProgress && <div className='bs-progress'>{`[${progressBar(currentFrame)}]`}</div>}
+      {showReady && <div className='bs-ready'>{BOOT_READY_LINE}</div>}
+      {showWelcomeLine && <div className='bs-welcome'>{BOOT_WELCOME_LINE}</div>}
+    </div>
+  )
+}

--- a/components/molecules/BootSequence/__tests__/BootSequence.test.tsx
+++ b/components/molecules/BootSequence/__tests__/BootSequence.test.tsx
@@ -1,0 +1,127 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BootSequence } from '../BootSequence'
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+function renderBoot(props: Partial<Parameters<typeof BootSequence>[0]> = {}) {
+  const onComplete = props.onComplete ?? vi.fn()
+  const utils = render(
+    <BootSequence onComplete={onComplete} showWelcome={props.showWelcome} totalDuration={props.totalDuration} reducedMotionOverride={props.reducedMotionOverride} />
+  )
+  return { onComplete, ...utils }
+}
+
+describe('BootSequence rendering (non-reduced)', () => {
+  it('renders the boot container with role=status', () => {
+    renderBoot({ reducedMotionOverride: false })
+    const container = screen.getByRole('status', { name: /system boot sequence/i })
+    expect(container).toBeInTheDocument()
+    expect(container).toHaveClass('bs')
+  })
+
+  it('starts at frame 1 (power-on; no header yet)', () => {
+    renderBoot({ reducedMotionOverride: false })
+    const container = screen.getByRole('status')
+    expect(container).toHaveAttribute('data-frame', '1')
+    expect(screen.queryByText('CUATRO TRACKER')).not.toBeInTheDocument()
+  })
+})
+
+describe('BootSequence reduced-motion branch (AC-2)', () => {
+  it('renders the static READY. frame and never the welcome line', () => {
+    renderBoot({ reducedMotionOverride: true })
+    expect(screen.getByText('CUATRO TRACKER')).toBeInTheDocument()
+    expect(screen.getByText('VERSION 0.2.0')).toBeInTheDocument()
+    expect(screen.getByText('READY.')).toBeInTheDocument()
+    expect(screen.queryByText('> WELCOME, CUATRO')).not.toBeInTheDocument()
+  })
+
+  it('renders data-frame=9 (final non-welcome frame)', () => {
+    renderBoot({ reducedMotionOverride: true })
+    expect(screen.getByRole('status')).toHaveAttribute('data-frame', '9')
+  })
+
+  it('calls onComplete within one requestAnimationFrame tick', async () => {
+    const onComplete = vi.fn()
+    renderBoot({ reducedMotionOverride: true, onComplete })
+    await act(async () => {
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+    })
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders a fully-filled progress bar (20 cells)', () => {
+    renderBoot({ reducedMotionOverride: true })
+    const progress = screen.getByText(/^\[█{20}\]$/)
+    expect(progress).toBeInTheDocument()
+  })
+})
+
+describe('BootSequence keyboard skip (AC-3)', () => {
+  it('completes the boot and calls onComplete when any key is pressed', async () => {
+    const onComplete = vi.fn()
+    renderBoot({ reducedMotionOverride: false, onComplete })
+    expect(onComplete).not.toHaveBeenCalled()
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+    })
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('jumps to the final frame on key press (frame 10 with welcome)', async () => {
+    renderBoot({ reducedMotionOverride: false, showWelcome: true })
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Space' }))
+    })
+    expect(screen.getByRole('status')).toHaveAttribute('data-frame', '10')
+    expect(screen.getByText('> WELCOME, CUATRO')).toBeInTheDocument()
+  })
+
+  it('jumps to frame 9 on key press when showWelcome is false', async () => {
+    renderBoot({ reducedMotionOverride: false, showWelcome: false })
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+    expect(screen.getByRole('status')).toHaveAttribute('data-frame', '9')
+    expect(screen.queryByText('> WELCOME, CUATRO')).not.toBeInTheDocument()
+  })
+})
+
+describe('BootSequence cleanup on unmount (AC-4)', () => {
+  it('does not call onComplete after the component unmounts mid-animation', async () => {
+    const onComplete = vi.fn()
+    const { unmount } = renderBoot({ reducedMotionOverride: false, onComplete })
+    expect(onComplete).not.toHaveBeenCalled()
+    unmount()
+    await new Promise((resolve) => setTimeout(resolve, 1300))
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  it('removes the keydown listener after unmount', async () => {
+    const onComplete = vi.fn()
+    const { unmount } = renderBoot({ reducedMotionOverride: false, onComplete })
+    unmount()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+})
+
+describe('BootSequence onComplete fires once (AC-1)', () => {
+  it('only fires onComplete once even if multiple key presses queue up', async () => {
+    const onComplete = vi.fn()
+    renderBoot({ reducedMotionOverride: false, onComplete })
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }))
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'b' }))
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'c' }))
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+    })
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+})

--- a/components/molecules/BootSequence/__tests__/boot-frames.test.ts
+++ b/components/molecules/BootSequence/__tests__/boot-frames.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BOOT_FINAL_FRAME_NO_WELCOME,
+  BOOT_FINAL_FRAME_WITH_WELCOME,
+  BOOT_FRAMES,
+  BOOT_PROGRESS_CELLS_TOTAL,
+  BOOT_TOTAL_MS,
+  finalCallbackMs,
+  progressBar,
+  progressFill,
+  scaleFrames,
+} from '../boot-frames'
+
+describe('BOOT_FRAMES registry', () => {
+  it('has 10 frames numbered 1 through 10', () => {
+    expect(BOOT_FRAMES).toHaveLength(10)
+    expect(BOOT_FRAMES.map((f) => f.index)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  })
+
+  it('preserves the bundle 01-login.md §5 timing exactly', () => {
+    const expected = [0, 80, 200, 280, 400, 460, 600, 740, 880, 960]
+    expect(BOOT_FRAMES.map((f) => f.startMs)).toEqual(expected)
+  })
+
+  it('startMs values are strictly monotonic', () => {
+    for (let i = 1; i < BOOT_FRAMES.length; i++) {
+      expect(BOOT_FRAMES[i].startMs).toBeGreaterThan(BOOT_FRAMES[i - 1].startMs)
+    }
+  })
+
+  it('labels match the bundle frame names', () => {
+    expect(BOOT_FRAMES.map((f) => f.label)).toEqual([
+      'power-on',
+      'header-reveal',
+      'version-line',
+      'copyright-line',
+      'progress-empty',
+      'progress-25',
+      'progress-50',
+      'progress-75',
+      'progress-100',
+      'welcome-flash',
+    ])
+  })
+
+  it('exports the final-frame constants the AC binds against', () => {
+    expect(BOOT_FINAL_FRAME_WITH_WELCOME).toBe(10)
+    expect(BOOT_FINAL_FRAME_NO_WELCOME).toBe(9)
+    expect(BOOT_TOTAL_MS).toBe(1200)
+    expect(BOOT_PROGRESS_CELLS_TOTAL).toBe(20)
+  })
+})
+
+describe('scaleFrames', () => {
+  it('returns identical timings when totalDurationMs equals BOOT_TOTAL_MS', () => {
+    const scaled = scaleFrames(BOOT_FRAMES, BOOT_TOTAL_MS)
+    expect(scaled.map((f) => f.startMs)).toEqual(BOOT_FRAMES.map((f) => f.startMs))
+  })
+
+  it('scales proportionally for a 2x totalDurationMs', () => {
+    const scaled = scaleFrames(BOOT_FRAMES, BOOT_TOTAL_MS * 2)
+    for (let i = 0; i < scaled.length; i++) {
+      expect(scaled[i].startMs).toBe(BOOT_FRAMES[i].startMs * 2)
+    }
+  })
+
+  it('scales proportionally for a 0.5x totalDurationMs', () => {
+    const scaled = scaleFrames(BOOT_FRAMES, BOOT_TOTAL_MS / 2)
+    for (let i = 0; i < scaled.length; i++) {
+      expect(scaled[i].startMs).toBe(BOOT_FRAMES[i].startMs / 2)
+    }
+  })
+
+  it('preserves index and label after scaling', () => {
+    const scaled = scaleFrames(BOOT_FRAMES, 600)
+    expect(scaled.map((f) => f.index)).toEqual(BOOT_FRAMES.map((f) => f.index))
+    expect(scaled.map((f) => f.label)).toEqual(BOOT_FRAMES.map((f) => f.label))
+  })
+
+  it('does not mutate the source registry', () => {
+    const snapshot = BOOT_FRAMES.map((f) => f.startMs)
+    scaleFrames(BOOT_FRAMES, 3000)
+    expect(BOOT_FRAMES.map((f) => f.startMs)).toEqual(snapshot)
+  })
+
+  it('falls back to BOOT_TOTAL_MS when totalDurationMs is invalid', () => {
+    expect(scaleFrames(BOOT_FRAMES, 0).map((f) => f.startMs)).toEqual(
+      BOOT_FRAMES.map((f) => f.startMs)
+    )
+    expect(scaleFrames(BOOT_FRAMES, -500).map((f) => f.startMs)).toEqual(
+      BOOT_FRAMES.map((f) => f.startMs)
+    )
+    expect(scaleFrames(BOOT_FRAMES, Number.NaN).map((f) => f.startMs)).toEqual(
+      BOOT_FRAMES.map((f) => f.startMs)
+    )
+    expect(scaleFrames(BOOT_FRAMES, Number.POSITIVE_INFINITY).map((f) => f.startMs)).toEqual(
+      BOOT_FRAMES.map((f) => f.startMs)
+    )
+  })
+})
+
+describe('finalCallbackMs', () => {
+  it('returns the full totalDurationMs (end of frame 10) when showWelcome is true', () => {
+    expect(finalCallbackMs(true, BOOT_TOTAL_MS)).toBe(BOOT_TOTAL_MS)
+    expect(finalCallbackMs(true, 2400)).toBe(2400)
+  })
+
+  it('returns frame 10 startMs (= end of frame 9 display window, scaled) when showWelcome is false', () => {
+    expect(finalCallbackMs(false, BOOT_TOTAL_MS)).toBe(960)
+    expect(finalCallbackMs(false, BOOT_TOTAL_MS * 2)).toBe(1920)
+  })
+
+  it('falls back to BOOT_TOTAL_MS when totalDurationMs is invalid', () => {
+    expect(finalCallbackMs(true, 0)).toBe(BOOT_TOTAL_MS)
+    expect(finalCallbackMs(true, -100)).toBe(BOOT_TOTAL_MS)
+    expect(finalCallbackMs(true, Number.NaN)).toBe(BOOT_TOTAL_MS)
+    expect(finalCallbackMs(true, Number.POSITIVE_INFINITY)).toBe(BOOT_TOTAL_MS)
+  })
+})
+
+describe('progressFill', () => {
+  it('returns 0 for frames 1-5 (no fill cells until frame 6)', () => {
+    expect(progressFill(1)).toBe(0)
+    expect(progressFill(2)).toBe(0)
+    expect(progressFill(3)).toBe(0)
+    expect(progressFill(4)).toBe(0)
+    expect(progressFill(5)).toBe(0)
+  })
+
+  it('returns 5/10/15/20 for frames 6/7/8/9 per the bundle threshold', () => {
+    expect(progressFill(6)).toBe(5)
+    expect(progressFill(7)).toBe(10)
+    expect(progressFill(8)).toBe(15)
+    expect(progressFill(9)).toBe(20)
+  })
+
+  it('returns 20 for frame 10 (full)', () => {
+    expect(progressFill(10)).toBe(20)
+  })
+})
+
+describe('progressBar', () => {
+  it('returns 20 spaces for frame ≤ 5', () => {
+    const bar = progressBar(5)
+    expect(bar).toHaveLength(20)
+    expect(bar).toBe(' '.repeat(20))
+  })
+
+  it('returns 5 filled + 15 empty for frame 6', () => {
+    const bar = progressBar(6)
+    expect(bar).toHaveLength(20)
+    expect(bar).toBe('█'.repeat(5) + ' '.repeat(15))
+  })
+
+  it('returns 20 filled for frame 9 and frame 10', () => {
+    expect(progressBar(9)).toBe('█'.repeat(20))
+    expect(progressBar(10)).toBe('█'.repeat(20))
+  })
+})

--- a/components/molecules/BootSequence/boot-frames.ts
+++ b/components/molecules/BootSequence/boot-frames.ts
@@ -1,0 +1,76 @@
+export type BootFrameLabel =
+  | 'power-on'
+  | 'header-reveal'
+  | 'version-line'
+  | 'copyright-line'
+  | 'progress-empty'
+  | 'progress-25'
+  | 'progress-50'
+  | 'progress-75'
+  | 'progress-100'
+  | 'welcome-flash'
+
+export type BootFrame = {
+  readonly index: number
+  readonly startMs: number
+  readonly label: BootFrameLabel
+}
+
+export const BOOT_FRAMES = [
+  { index: 1, startMs: 0, label: 'power-on' },
+  { index: 2, startMs: 80, label: 'header-reveal' },
+  { index: 3, startMs: 200, label: 'version-line' },
+  { index: 4, startMs: 280, label: 'copyright-line' },
+  { index: 5, startMs: 400, label: 'progress-empty' },
+  { index: 6, startMs: 460, label: 'progress-25' },
+  { index: 7, startMs: 600, label: 'progress-50' },
+  { index: 8, startMs: 740, label: 'progress-75' },
+  { index: 9, startMs: 880, label: 'progress-100' },
+  { index: 10, startMs: 960, label: 'welcome-flash' },
+] as const satisfies readonly BootFrame[]
+
+export const BOOT_TOTAL_MS = 1200
+export const BOOT_FINAL_FRAME_WITH_WELCOME = 10
+export const BOOT_FINAL_FRAME_NO_WELCOME = 9
+export const BOOT_PROGRESS_CELLS_TOTAL = 20
+
+export function safeTotalDurationMs(totalDurationMs: number | undefined): number {
+  if (totalDurationMs === undefined) return BOOT_TOTAL_MS
+  if (!Number.isFinite(totalDurationMs) || totalDurationMs <= 0) return BOOT_TOTAL_MS
+  return totalDurationMs
+}
+
+export function scaleFrames(
+  frames: readonly BootFrame[],
+  totalDurationMs: number
+): readonly BootFrame[] {
+  const safe = safeTotalDurationMs(totalDurationMs)
+  const ratio = safe / BOOT_TOTAL_MS
+  return frames.map((f) => ({ ...f, startMs: f.startMs * ratio }))
+}
+
+export function finalCallbackMs(showWelcome: boolean, totalDurationMs: number): number {
+  const safe = safeTotalDurationMs(totalDurationMs)
+  if (showWelcome) return safe
+  const ratio = safe / BOOT_TOTAL_MS
+  return BOOT_FRAMES[BOOT_FINAL_FRAME_NO_WELCOME].startMs * ratio
+}
+
+export function progressFill(frame: number): number {
+  if (frame >= 9) return 20
+  if (frame >= 8) return 15
+  if (frame >= 7) return 10
+  if (frame >= 6) return 5
+  return 0
+}
+
+export function progressBar(frame: number): string {
+  const fill = progressFill(frame)
+  return '█'.repeat(fill) + ' '.repeat(BOOT_PROGRESS_CELLS_TOTAL - fill)
+}
+
+export const BOOT_HEADER_LABEL = 'CUATRO TRACKER'
+export const BOOT_VERSION_LINE = 'VERSION 0.2.0'
+export const BOOT_COPYRIGHT_LINE = '(C) CUATRO DEVELOPMENT STUDIO, 2026. ALL RIGHTS RESERVED.'
+export const BOOT_READY_LINE = 'READY.'
+export const BOOT_WELCOME_LINE = '> WELCOME, CUATRO'

--- a/components/molecules/BootSequence/index.ts
+++ b/components/molecules/BootSequence/index.ts
@@ -1,0 +1,14 @@
+export { BootSequence } from './BootSequence'
+export type { BootSequenceProps } from './BootSequence'
+export {
+  BOOT_FRAMES,
+  BOOT_TOTAL_MS,
+  BOOT_FINAL_FRAME_WITH_WELCOME,
+  BOOT_FINAL_FRAME_NO_WELCOME,
+  BOOT_PROGRESS_CELLS_TOTAL,
+  scaleFrames,
+  finalCallbackMs,
+  progressFill,
+  progressBar,
+} from './boot-frames'
+export type { BootFrame, BootFrameLabel } from './boot-frames'

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.4",
     "@tailwindcss/postcss": "^4.0.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/bcryptjs": "^2.4.6",
     "@types/node": "^22",
     "@types/react": "^19",
@@ -50,6 +53,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9",
     "eslint-config-next": "^15.1.6",
+    "jsdom": "^29.1.1",
     "prisma": "^6.19.2",
     "tailwindcss": "^4.0.0",
     "tsx": "^4.19.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,15 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.0.0
         version: 4.2.2
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/bcryptjs':
         specifier: ^2.4.6
         version: 2.4.6
@@ -92,13 +101,16 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0))
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0))
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: ^15.1.6
         version: 15.5.13(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       prisma:
         specifier: ^6.19.2
         version: 6.19.2(magicast@0.3.5)(typescript@5.9.3)
@@ -113,9 +125,12 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.4
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -124,6 +139,21 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -199,6 +229,46 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -402,6 +472,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@fastify/otel@0.18.0':
     resolution: {integrity: sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==}
@@ -1429,8 +1508,40 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/bcryptjs@2.4.6':
     resolution: {integrity: sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==}
@@ -1781,12 +1892,19 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1868,6 +1986,9 @@ packages:
 
   bcryptjs@2.4.3:
     resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -2012,11 +2133,22 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -2050,6 +2182,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -2076,6 +2211,10 @@ packages:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -2086,6 +2225,12 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -2120,6 +2265,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
@@ -2495,6 +2644,10 @@ packages:
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -2524,6 +2677,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -2606,6 +2763,9 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
@@ -2702,6 +2862,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2873,6 +3042,10 @@ packages:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -2886,6 +3059,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -2901,6 +3077,10 @@ packages:
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -3094,6 +3274,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3202,6 +3385,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@3.8.0:
     resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
 
@@ -3255,6 +3442,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -3266,6 +3456,10 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
@@ -3335,6 +3529,10 @@ packages:
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3496,6 +3694,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -3531,6 +3733,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
@@ -3621,12 +3826,27 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.30:
+    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
+
+  tldts@7.0.30:
+    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -3680,6 +3900,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -3774,12 +3998,20 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
 
   webpack-sources@3.4.1:
     resolution: {integrity: sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==}
@@ -3794,6 +4026,14 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -3839,6 +4079,13 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -3876,12 +4123,34 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3986,6 +4255,34 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emnapi/core@1.9.0':
     dependencies:
@@ -4126,6 +4423,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.0': {}
 
   '@fastify/otel@0.18.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -5082,10 +5381,46 @@ snapshots:
       '@tanstack/query-core': 5.91.0
       react: 19.2.4
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/bcryptjs@2.4.6': {}
 
@@ -5296,7 +5631,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -5311,7 +5646,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)
+      vitest: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5488,9 +5823,15 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -5590,6 +5931,10 @@ snapshots:
   baseline-browser-mapping@2.10.29: {}
 
   bcryptjs@2.4.3: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   brace-expansion@1.1.12:
     dependencies:
@@ -5747,9 +6092,23 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -5779,6 +6138,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
@@ -5801,6 +6162,8 @@ snapshots:
 
   denque@2.1.0: {}
 
+  dequal@2.0.3: {}
+
   destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
@@ -5808,6 +6171,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dotenv@16.6.1: {}
 
@@ -5840,6 +6207,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@8.0.0: {}
 
   es-abstract@1.24.1:
     dependencies:
@@ -6379,6 +6748,12 @@ snapshots:
 
   help-me@5.0.0: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   https-proxy-agent@5.0.1:
@@ -6412,6 +6787,8 @@ snapshots:
       module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -6509,6 +6886,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-reference@1.2.1:
     dependencies:
@@ -6614,6 +6993,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.6
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -6738,6 +7143,8 @@ snapshots:
 
   luxon@3.7.2: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -6754,6 +7161,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdn-data@2.27.1: {}
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -6764,6 +7173,8 @@ snapshots:
       picomatch: 2.3.1
 
   mime-db@1.54.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -6968,6 +7379,10 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -7083,6 +7498,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-format@3.8.0: {}
 
   prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3):
@@ -7131,11 +7552,18 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@17.0.2: {}
+
   react@19.2.4: {}
 
   readdirp@4.1.2: {}
 
   real-require@0.2.0: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   redis-errors@1.2.0: {}
 
@@ -7248,6 +7676,10 @@ snapshots:
       is-regex: 1.2.1
 
   safe-stable-stringify@2.5.0: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -7495,6 +7927,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   strip-json-comments@5.0.3: {}
@@ -7519,6 +7955,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tailwindcss@4.2.2: {}
 
@@ -7568,11 +8006,25 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.0.30: {}
+
+  tldts@7.0.30:
+    dependencies:
+      tldts-core: 7.0.30
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.30
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -7643,6 +8095,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici@7.25.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -7719,7 +8173,7 @@ snapshots:
       terser: 5.47.1
       tsx: 4.21.0
 
-  vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0):
+  vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -7746,6 +8200,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
+      jsdom: 29.1.1
     transitivePeerDependencies:
       - jiti
       - less
@@ -7760,12 +8215,18 @@ snapshots:
       - tsx
       - yaml
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   watchpack@2.5.1:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.1: {}
 
   webpack-sources@3.4.1: {}
 
@@ -7808,6 +8269,16 @@ snapshots:
       - lightningcss
       - postcss
       - uglify-js
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -7879,6 +8350,10 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,23 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@testing-library/react'
+import { afterEach, vi } from 'vitest'
+
+afterEach(() => {
+  cleanup()
+})
+
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(() => false),
+    }),
+  })
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,22 @@
-import { defineConfig } from 'vitest/config';
-import { resolve } from 'path';
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
 
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
+    setupFiles: ['./tests/setup.ts'],
+    environmentMatchGlobs: [
+      ['components/**/*.test.tsx', 'jsdom'],
+      ['app/**/*.test.tsx', 'jsdom'],
+    ],
+  },
+  esbuild: {
+    jsx: 'automatic',
   },
   resolve: {
     alias: {
       '@': resolve(__dirname, '.'),
     },
   },
-});
+})


### PR DESCRIPTION
## Summary

Implements `BootSequence` molecule per Story 2.7. Plays the 10-frame login boot animation (`01-login.md` §5) with prop-driven welcome flash, reduced-motion fallback (static `READY.` frame), keyboard skip (any non-modifier key), and explicit `timeline.kill()` cleanup on unmount + skip. Companion typed frames registry at `boot-frames.ts` exposes the canonical timing (0/80/200/280/400/460/600/740/880/960 ms) and helpers. Dev fixture at `/dev/boot` renders four modes (full animation slowed to 4000ms for visibility, no-welcome variant, forced reduced-motion, OS-honoring).

Test stack lands in this story (deferred from Story 2.6 OI #2): `jsdom` + `@testing-library/react` + `@testing-library/jest-dom` + `@testing-library/user-event` installed; `tests/setup.ts` wires cleanup + matchMedia polyfill; `vitest.config.ts` adds `environmentMatchGlobs` (jsdom for `.test.tsx`) + `esbuild.jsx: 'automatic'` (required for React 19 JSX runtime). 32 new tests pass (20 frames registry + 12 component DOM-rendering).

Closes #67

## Test plan

- [x] `pnpm typecheck` clean inside dev container
- [x] `pnpm lint` clean inside dev container
- [x] `pnpm vitest run components/molecules/BootSequence` — 32/32 pass
- [x] `pnpm build` clean (route `/dev/boot` bundles at 30.5kB First Load)
- [x] Visual fixture at `/dev/boot` (modes 1-4) verified by Cuatro
- [x] `bmad-code-review` complete (Edge Case Hunter + Acceptance Auditor; Blind Hunter skipped per Story 2.5/2.6 precedent): 8 patches applied (incl. AC-1 off-by-one fix + modifier-key/IME/repeat filter + bundle font-size + header text-shadow), 9 deferred (logged in `_bmad-output/implementation-artifacts/deferred-work.md`), 3 decision-needed resolved with Cuatro at recommendation