### PR TITLE
feat(motion + status): ChannelFlipTransition wrapper + PhosphorLED/PhosphorBar atoms

### DIFF
--- a/app/(dev)/dev/flip/FlipFixtureClient.tsx
+++ b/app/(dev)/dev/flip/FlipFixtureClient.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { useChannelFlipNavigate } from '@/components/molecules/ChannelFlipTransition'
+
+type Mode = 'animated-slow' | 'animated-default' | 'reduced-forced' | 'os-setting'
+
+const SLOW_TOTAL_MS = 3000
+
+const MODES: { key: Mode; label: string; description: string }[] = [
+  {
+    key: 'animated-slow',
+    label: 'Animation (forced non-reduced, 3000ms)',
+    description: `Forces non-reduced and slows the transition to ${SLOW_TOTAL_MS}ms so each phase lasts 1s (band sweep 1s, hold black 1s, fade back 1s).`,
+  },
+  {
+    key: 'animated-default',
+    label: 'Animation (forced non-reduced, 600ms default)',
+    description: 'Forces non-reduced at the canonical 600ms total (200/200/200 phases).',
+  },
+  {
+    key: 'reduced-forced',
+    label: 'Reduced-motion (forced)',
+    description: 'Bypasses matchMedia; instant route change with no overlay.',
+  },
+  {
+    key: 'os-setting',
+    label: 'OS setting (no override)',
+    description: 'Honors the actual matchMedia value. If your OS has reduced-motion ON, this is an instant route change; if OFF, plays at the default 600ms cadence.',
+  },
+]
+
+export function FlipFixtureClient() {
+  const [mode, setMode] = useState<Mode>('animated-slow')
+  const [completedAt, setCompletedAt] = useState<number | null>(null)
+  const [runCount, setRunCount] = useState(0)
+
+  const hookOptions = useMemo(() => {
+    switch (mode) {
+      case 'animated-slow':
+        return { reducedMotionOverride: false, totalDuration: SLOW_TOTAL_MS }
+      case 'animated-default':
+        return { reducedMotionOverride: false }
+      case 'reduced-forced':
+        return { reducedMotionOverride: true }
+      case 'os-setting':
+      default:
+        return {}
+    }
+  }, [mode])
+
+  const { navigate, overlay } = useChannelFlipNavigate(hookOptions)
+
+  const playInPlace = useCallback(async () => {
+    setCompletedAt(null)
+    setRunCount((n) => n + 1)
+    const start = performance.now()
+    await navigate('/dev/flip')
+    setCompletedAt(performance.now() - start)
+  }, [navigate])
+
+  const navigateToBoot = useCallback(async () => {
+    setCompletedAt(null)
+    setRunCount((n) => n + 1)
+    await navigate('/dev/boot')
+  }, [navigate])
+
+  return (
+    <main className='min-h-screen bg-[var(--ground-base)] text-[var(--phosphor-cream)]'>
+      <header className='mx-auto max-w-[1200px] px-12 pt-16'>
+        <p className='m-0 mb-3 font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-[var(--phosphor-cream-dim)]'>
+          Story 2.8 · ChannelFlipTransition wrapper
+        </p>
+        <h1 className='m-0 mb-3 font-serif text-[44px] font-semibold italic leading-[1.05]'>
+          Cuatro Tracker · ChannelFlipTransition
+        </h1>
+        <p className='m-0 mb-2 font-mono text-[13px] leading-[1.55] text-[var(--phosphor-cream-dim)]'>
+          Dev-only fixture. Pick a mode, click the Play-in-place button to watch the band sweep over a sample frame. The Real-navigate button exercises the full programmatic-navigate path against another dev fixture (/dev/boot).
+        </p>
+      </header>
+
+      <section className='mx-auto mt-10 max-w-[1200px] px-12'>
+        <div className='flex flex-wrap gap-3'>
+          {MODES.map((m) => {
+            const active = mode === m.key
+            return (
+              <button
+                key={m.key}
+                type='button'
+                onClick={() => setMode(m.key)}
+                aria-pressed={active}
+                className={`rounded-none border-2 px-4 py-2 font-mono text-[12px] uppercase tracking-[0.14em] transition-colors ${
+                  active
+                    ? 'border-[var(--phosphor-cream)] bg-[var(--phosphor-cream)] text-[var(--ground-base)]'
+                    : 'border-[var(--phosphor-cream-dim)] bg-transparent text-[var(--phosphor-cream-dim)] hover:border-[var(--phosphor-cream)] hover:text-[var(--phosphor-cream)]'
+                }`}
+              >
+                {m.label}
+              </button>
+            )
+          })}
+        </div>
+        <p className='mt-3 font-mono text-[12px] text-[var(--phosphor-cream-dim)]'>
+          {MODES.find((m) => m.key === mode)?.description}
+        </p>
+      </section>
+
+      <section className='mx-auto mt-10 max-w-[1200px] px-12'>
+        <div className='flex flex-wrap gap-3'>
+          <button
+            type='button'
+            onClick={playInPlace}
+            className='rounded-none border-2 border-[var(--phosphor-cream)] bg-transparent px-5 py-3 font-mono text-[12px] uppercase tracking-[0.14em] text-[var(--phosphor-cream)] hover:bg-[var(--phosphor-cream)] hover:text-[var(--ground-base)]'
+          >
+            Play in place (navigate to this same page)
+          </button>
+          <button
+            type='button'
+            onClick={navigateToBoot}
+            className='rounded-none border-2 border-[var(--phosphor-cream-dim)] bg-transparent px-5 py-3 font-mono text-[12px] uppercase tracking-[0.14em] text-[var(--phosphor-cream-dim)] hover:border-[var(--phosphor-cream)] hover:text-[var(--phosphor-cream)]'
+          >
+            Real navigate to /dev/boot
+          </button>
+        </div>
+        <p className='mt-3 font-mono text-[12px] text-[var(--phosphor-cream-dim)]'>
+          run #{runCount + 1} · {completedAt !== null ? `complete @ ${Math.round(completedAt)}ms` : 'idle'}
+        </p>
+      </section>
+
+      <section className='mx-auto mt-10 max-w-[1200px] px-12 pb-16'>
+        <div className='relative mx-auto aspect-[4/3] w-full max-w-[720px] overflow-hidden border-2 border-[var(--phosphor-cream-dim)] bg-[var(--ground-card)]'>
+          <div className='absolute inset-0 grid place-items-center'>
+            <div className='text-center'>
+              <p className='m-0 font-serif text-[32px] italic text-[var(--phosphor-cream)]'>
+                Sample chrome behind the flip
+              </p>
+              <p className='m-0 mt-2 font-mono text-[12px] uppercase tracking-[0.18em] text-[var(--phosphor-cream-dim)]'>
+                Watch the phosphor band sweep over this surface
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {overlay}
+    </main>
+  )
+}

--- a/app/(dev)/dev/flip/page.tsx
+++ b/app/(dev)/dev/flip/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import { notFound } from 'next/navigation'
+import { env } from '@/lib/env'
+import { FlipFixtureClient } from './FlipFixtureClient'
+
+export default function FlipFixturePage() {
+  if (env.NODE_ENV !== 'development') {
+    notFound()
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <FlipFixtureClient />
+    </Suspense>
+  )
+}

--- a/app/(dev)/dev/status/page.tsx
+++ b/app/(dev)/dev/status/page.tsx
@@ -1,0 +1,125 @@
+import { notFound } from 'next/navigation'
+import { env } from '@/lib/env'
+import { PhosphorLED, type PhosphorLEDStatus } from '@/components/atoms/PhosphorLED'
+import { PhosphorBar } from '@/components/atoms/PhosphorBar'
+
+const STATUSES: { status: PhosphorLEDStatus; label: string }[] = [
+  { status: 'completed', label: 'Completed' },
+  { status: 'in-progress', label: 'In progress' },
+  { status: 'backlog', label: 'In backlog' },
+  { status: 'dropped', label: 'Dropped' },
+  { status: 'on-hold', label: 'On hold' },
+]
+
+const SIZES = [8, 12, 16] as const
+
+const BAR_SAMPLES: { value: number; max: number; label: string }[] = [
+  { value: 0, max: 100, label: '0% progress' },
+  { value: 25, max: 100, label: '25% progress' },
+  { value: 50, max: 100, label: '50% progress' },
+  { value: 75, max: 100, label: '75% progress' },
+  { value: 100, max: 100, label: '100% progress' },
+  { value: -10, max: 100, label: 'value < 0 clamps to 0' },
+  { value: 200, max: 100, label: 'value > max clamps to max' },
+  { value: 10, max: 0, label: 'max = 0 renders empty' },
+  { value: 3, max: 12, label: 'chapters read' },
+]
+
+export default function StatusFixturePage() {
+  if (env.NODE_ENV !== 'development') {
+    notFound()
+  }
+
+  return (
+    <main className='min-h-screen bg-[var(--ground-base)] text-[var(--phosphor-cream)]'>
+      <header className='mx-auto max-w-[1200px] px-12 pt-16'>
+        <p className='m-0 mb-3 font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-[var(--phosphor-cream-dim)]'>
+          Story 2.9 · PhosphorLED + PhosphorBar atoms
+        </p>
+        <h1 className='m-0 mb-3 font-serif text-[44px] font-semibold italic leading-[1.05]'>
+          Cuatro Tracker · Status atoms
+        </h1>
+        <p className='m-0 mb-2 font-mono text-[13px] leading-[1.55] text-[var(--phosphor-cream-dim)]'>
+          Dev-only fixture. Hover any LED or bar to verify the tooltip; tab through the sample row to verify keyboard a11y.
+        </p>
+      </header>
+
+      <section className='mx-auto mt-10 max-w-[1200px] px-12'>
+        <h2 className='m-0 mb-4 font-mono text-[14px] uppercase tracking-[0.18em] text-[var(--phosphor-cream-dim)]'>
+          PhosphorLED · 5 statuses × 3 sizes
+        </h2>
+        <div className='grid grid-cols-[120px_repeat(3,_120px)] items-center gap-x-8 gap-y-4'>
+          <span aria-hidden='true' />
+          {SIZES.map((s) => (
+            <span
+              key={s}
+              className='font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--phosphor-cream-dim)]'
+            >
+              size={s}px
+            </span>
+          ))}
+          {STATUSES.map(({ status, label }) => (
+            <div key={status} className='contents'>
+              <span className='font-mono text-[12px] uppercase tracking-[0.14em]'>{status}</span>
+              {SIZES.map((size) => (
+                <span key={size} className='flex items-center'>
+                  <PhosphorLED status={status} size={size} label={label} />
+                </span>
+              ))}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className='mx-auto mt-12 max-w-[1200px] px-12'>
+        <h2 className='m-0 mb-4 font-mono text-[14px] uppercase tracking-[0.18em] text-[var(--phosphor-cream-dim)]'>
+          PhosphorBar · 9 samples
+        </h2>
+        <div className='flex flex-col gap-4'>
+          {BAR_SAMPLES.map((sample, index) => (
+            <div key={index} className='flex items-center gap-6'>
+              <span className='w-[260px] font-mono text-[12px] text-[var(--phosphor-cream-dim)]'>
+                {sample.label}
+              </span>
+              <div className='flex-1'>
+                <PhosphorBar value={sample.value} max={sample.max} label={sample.label} />
+              </div>
+              <span className='w-[100px] text-right font-mono text-[11px] text-[var(--phosphor-cream-ghost)]'>
+                {sample.value} / {sample.max}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className='mx-auto mt-12 max-w-[1200px] px-12 pb-16'>
+        <h2 className='m-0 mb-4 font-mono text-[14px] uppercase tracking-[0.18em] text-[var(--phosphor-cream-dim)]'>
+          Sample row composition (AC-3)
+        </h2>
+        <ul className='m-0 list-none p-0'>
+          {[
+            { status: 'completed' as const, title: 'Episode 1 · Cold Open', meta: '23 min · 2024' },
+            { status: 'in-progress' as const, title: 'Episode 2 · Reverberations', meta: '24 min · 2024' },
+            { status: 'backlog' as const, title: 'Episode 3 · Spectra', meta: '24 min · 2024' },
+            { status: 'on-hold' as const, title: 'Episode 4 · Glass Lake', meta: '22 min · 2024' },
+            { status: 'dropped' as const, title: 'Episode 5 · Echo Park', meta: '25 min · 2024' },
+          ].map((row, index) => (
+            <li
+              key={row.title}
+              tabIndex={0}
+              className={`flex items-center gap-4 border-b border-[var(--phosphor-cream-ghost)] px-3 py-3 focus:outline focus:outline-2 focus:outline-[var(--phosphor-cream)] focus:outline-offset-[-2px] ${
+                index % 2 === 0 ? 'bg-[var(--ground-row-even)]' : 'bg-[var(--ground-row-odd)]'
+              }`}
+            >
+              <PhosphorLED status={row.status} size={10} label={`${row.status} status`} />
+              <span className='flex-1 font-serif text-[16px]'>{row.title}</span>
+              <span className='font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--phosphor-cream-dim)]'>
+                {row.meta}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  )
+}

--- a/app/global.css
+++ b/app/global.css
@@ -190,3 +190,38 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .bs-welcome { animation: none; }
 }
+
+/* ChannelFlipTransition (Story 2.8). Portal-rendered viewport overlay used
+   around top-level nav. Symmetric 200 / 200 / 200 ms phases (band sweep,
+   hold black, fade back). The hook short-circuits before mounting under
+   prefers-reduced-motion; the media query below is defense in depth. */
+.cft {
+  position: fixed;
+  inset: 0;
+  pointer-events: auto;
+  z-index: 9999;
+}
+.cft-black-above {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  background: #000;
+  z-index: 8;
+}
+.cft-band {
+  position: absolute;
+  left: 0;
+  right: 0;
+  transform: translateY(-3px);
+  height: 6px;
+  background: var(--phosphor-cream);
+  box-shadow:
+    0 0 24px rgba(239, 230, 212, 0.95),
+    0 0 8px rgba(239, 230, 212, 1);
+  z-index: 9;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cft { display: none; }
+}

--- a/app/global.css
+++ b/app/global.css
@@ -225,3 +225,57 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .cft { display: none; }
 }
+
+/* PhosphorLED (Story 2.9). Categorical watch-state dot. Color and glow halo
+   come from tokens.css (--led-*, --led-*-glow). The base rule reads the
+   custom properties; per-status data attributes set them. */
+.led {
+  display: inline-block;
+  border-radius: 50%;
+  background: var(--led-color, var(--phosphor-cream));
+  box-shadow: var(--led-glow, 0 0 6px rgba(239, 230, 212, 0.4));
+  vertical-align: middle;
+}
+.led[data-status='completed'] {
+  --led-color: var(--led-completed);
+  --led-glow: var(--led-completed-glow);
+}
+.led[data-status='in-progress'] {
+  --led-color: var(--led-in-progress);
+  --led-glow: var(--led-in-progress-glow);
+}
+.led[data-status='backlog'] {
+  --led-color: var(--led-backlog);
+  --led-glow: var(--led-backlog-glow);
+}
+.led[data-status='dropped'] {
+  --led-color: var(--led-dropped);
+  --led-glow: var(--led-dropped-glow);
+}
+.led[data-status='on-hold'] {
+  --led-color: var(--led-on-hold);
+  --led-glow: var(--led-on-hold-glow);
+}
+
+/* PhosphorBar (Story 2.9). Thin proportional progress bar. Filled portion
+   glows phosphor-cream; unfilled is ground-lift row tint. Width transition
+   smooths value changes; reduced-motion users snap instead. */
+.pb {
+  position: relative;
+  width: 100%;
+  height: 6px;
+  background: var(--ground-row-odd);
+  overflow: hidden;
+}
+.pb-fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  background: var(--phosphor-cream);
+  box-shadow: 0 0 8px rgba(239, 230, 212, 0.6);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .pb-fill { transition: width 200ms linear; }
+}

--- a/components/atoms/PhosphorBar/PhosphorBar.tsx
+++ b/components/atoms/PhosphorBar/PhosphorBar.tsx
@@ -1,0 +1,31 @@
+export type PhosphorBarProps = {
+  value: number
+  max: number
+  label: string
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min
+  return Math.min(Math.max(value, min), max)
+}
+
+export function PhosphorBar({ value, max, label }: PhosphorBarProps) {
+  const safeMax = Number.isFinite(max) && max > 0 ? max : 0
+  const clamped = safeMax > 0 ? clamp(value, 0, safeMax) : 0
+  const pct = safeMax > 0 ? (clamped / safeMax) * 100 : 0
+  const tooltip = `${label} (${clamped} / ${safeMax})`
+
+  return (
+    <div
+      role='progressbar'
+      aria-label={label}
+      aria-valuenow={clamped}
+      aria-valuemin={0}
+      aria-valuemax={safeMax}
+      title={tooltip}
+      className='pb'
+    >
+      <div className='pb-fill' style={{ width: `${pct}%` }} />
+    </div>
+  )
+}

--- a/components/atoms/PhosphorBar/__tests__/PhosphorBar.test.tsx
+++ b/components/atoms/PhosphorBar/__tests__/PhosphorBar.test.tsx
@@ -1,0 +1,72 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { PhosphorBar } from '../PhosphorBar'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('PhosphorBar rendering (AC-2)', () => {
+  it('renders with role=progressbar and the correct aria values', () => {
+    render(<PhosphorBar value={50} max={100} label='episodes watched' />)
+    const bar = screen.getByRole('progressbar', { name: 'episodes watched' })
+    expect(bar).toHaveAttribute('aria-valuenow', '50')
+    expect(bar).toHaveAttribute('aria-valuemin', '0')
+    expect(bar).toHaveAttribute('aria-valuemax', '100')
+  })
+
+  it('renders the filled portion at value/max percent', () => {
+    render(<PhosphorBar value={25} max={100} label='progress' />)
+    const fill = document.querySelector('.pb-fill') as HTMLElement
+    expect(fill.style.width).toBe('25%')
+  })
+
+  it('label propagates to aria-label; title surfaces value / max', () => {
+    render(<PhosphorBar value={3} max={12} label='chapters read' />)
+    const bar = screen.getByRole('progressbar', { name: 'chapters read' })
+    expect(bar).toHaveAttribute('aria-label', 'chapters read')
+    expect(bar).toHaveAttribute('title', 'chapters read (3 / 12)')
+  })
+
+  it('clamps value < 0 to 0', () => {
+    render(<PhosphorBar value={-10} max={100} label='progress' />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '0')
+    expect(bar).toHaveAttribute('title', 'progress (0 / 100)')
+    const fill = document.querySelector('.pb-fill') as HTMLElement
+    expect(fill.style.width).toBe('0%')
+  })
+
+  it('clamps value > max to max', () => {
+    render(<PhosphorBar value={200} max={100} label='progress' />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '100')
+    expect(bar).toHaveAttribute('title', 'progress (100 / 100)')
+    const fill = document.querySelector('.pb-fill') as HTMLElement
+    expect(fill.style.width).toBe('100%')
+  })
+
+  it('renders empty bar with (0 / 0) tooltip when max=0', () => {
+    render(<PhosphorBar value={10} max={0} label='no data yet' />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '0')
+    expect(bar).toHaveAttribute('aria-valuemax', '0')
+    expect(bar).toHaveAttribute('title', 'no data yet (0 / 0)')
+    const fill = document.querySelector('.pb-fill') as HTMLElement
+    expect(fill.style.width).toBe('0%')
+  })
+
+  it('handles NaN value as 0 fill', () => {
+    render(<PhosphorBar value={Number.NaN} max={100} label='progress' />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '0')
+    const fill = document.querySelector('.pb-fill') as HTMLElement
+    expect(fill.style.width).toBe('0%')
+  })
+
+  it('classed as .pb for the design-system CSS branch', () => {
+    render(<PhosphorBar value={1} max={2} label='half' />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveClass('pb')
+  })
+})

--- a/components/atoms/PhosphorBar/index.ts
+++ b/components/atoms/PhosphorBar/index.ts
@@ -1,0 +1,2 @@
+export { PhosphorBar } from './PhosphorBar'
+export type { PhosphorBarProps } from './PhosphorBar'

--- a/components/atoms/PhosphorLED/PhosphorLED.tsx
+++ b/components/atoms/PhosphorLED/PhosphorLED.tsx
@@ -1,0 +1,35 @@
+export type PhosphorLEDStatus =
+  | 'completed'
+  | 'in-progress'
+  | 'backlog'
+  | 'dropped'
+  | 'on-hold'
+
+export type PhosphorLEDProps = {
+  status: PhosphorLEDStatus
+  size?: number
+  label: string
+}
+
+const DEFAULT_SIZE = 8
+
+function safeSize(input?: number): number {
+  if (typeof input !== 'number') return DEFAULT_SIZE
+  if (!Number.isFinite(input)) return DEFAULT_SIZE
+  if (input <= 0) return DEFAULT_SIZE
+  return input
+}
+
+export function PhosphorLED({ status, size, label }: PhosphorLEDProps) {
+  const px = safeSize(size)
+  return (
+    <span
+      role='img'
+      aria-label={label}
+      title={label}
+      className='led'
+      data-status={status}
+      style={{ width: px, height: px }}
+    />
+  )
+}

--- a/components/atoms/PhosphorLED/__tests__/PhosphorLED.test.tsx
+++ b/components/atoms/PhosphorLED/__tests__/PhosphorLED.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { PhosphorLED, type PhosphorLEDStatus } from '../PhosphorLED'
+
+afterEach(() => {
+  cleanup()
+})
+
+const STATUSES: PhosphorLEDStatus[] = ['completed', 'in-progress', 'backlog', 'dropped', 'on-hold']
+
+describe('PhosphorLED rendering (AC-1)', () => {
+  it.each(STATUSES)('renders status=%s with matching data-status attribute', (status) => {
+    render(<PhosphorLED status={status} label={`status ${status}`} />)
+    const led = screen.getByRole('img', { name: `status ${status}` })
+    expect(led).toHaveAttribute('data-status', status)
+  })
+
+  it('default size is 8 (px) when prop omitted', () => {
+    render(<PhosphorLED status='completed' label='ok' />)
+    const led = screen.getByRole('img', { name: 'ok' })
+    expect(led).toHaveStyle({ width: '8px', height: '8px' })
+  })
+
+  it('explicit size prop overrides the default', () => {
+    render(<PhosphorLED status='completed' label='ok' size={16} />)
+    const led = screen.getByRole('img', { name: 'ok' })
+    expect(led).toHaveStyle({ width: '16px', height: '16px' })
+  })
+
+  it('label propagates to aria-label and title (a11y + tooltip)', () => {
+    render(<PhosphorLED status='in-progress' label='currently watching' />)
+    const led = screen.getByRole('img', { name: 'currently watching' })
+    expect(led).toHaveAttribute('aria-label', 'currently watching')
+    expect(led).toHaveAttribute('title', 'currently watching')
+  })
+
+  it('classed as .led for the design-system CSS branch', () => {
+    render(<PhosphorLED status='backlog' label='in queue' />)
+    const led = screen.getByRole('img', { name: 'in queue' })
+    expect(led).toHaveClass('led')
+  })
+})

--- a/components/atoms/PhosphorLED/index.ts
+++ b/components/atoms/PhosphorLED/index.ts
@@ -1,0 +1,2 @@
+export { PhosphorLED } from './PhosphorLED'
+export type { PhosphorLEDProps, PhosphorLEDStatus } from './PhosphorLED'

--- a/components/molecules/ChannelFlipTransition/ChannelFlipTransition.tsx
+++ b/components/molecules/ChannelFlipTransition/ChannelFlipTransition.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { createPortal } from 'react-dom'
+
+export type ChannelFlipTransitionProps = {
+  progress: number
+}
+
+export function ChannelFlipTransition({ progress }: ChannelFlipTransitionProps) {
+  if (!Number.isFinite(progress)) return null
+  if (progress <= 0) return null
+  if (typeof document === 'undefined') return null
+
+  const clamped = Math.min(Math.max(progress, 0), 1)
+  const bandTop = `${clamped * 100}%`
+
+  return createPortal(
+    <div className='cft' role='presentation' aria-hidden='true'>
+      <div className='cft-black-above' style={{ height: bandTop }} />
+      <div className='cft-band' style={{ top: bandTop }} />
+    </div>,
+    document.body
+  )
+}

--- a/components/molecules/ChannelFlipTransition/__tests__/ChannelFlipTransition.test.tsx
+++ b/components/molecules/ChannelFlipTransition/__tests__/ChannelFlipTransition.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ChannelFlipTransition } from '../ChannelFlipTransition'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('ChannelFlipTransition rendering', () => {
+  it('renders null at progress=0 (no DOM cost when idle)', () => {
+    const { container } = render(<ChannelFlipTransition progress={0} />)
+    expect(container.firstChild).toBeNull()
+    expect(document.querySelector('.cft')).toBeNull()
+  })
+
+  it('renders null at negative progress', () => {
+    const { container } = render(<ChannelFlipTransition progress={-0.5} />)
+    expect(container.firstChild).toBeNull()
+    expect(document.querySelector('.cft')).toBeNull()
+  })
+
+  it('renders overlay into document.body at progress > 0', () => {
+    render(<ChannelFlipTransition progress={0.5} />)
+    const overlay = document.body.querySelector('.cft')
+    expect(overlay).not.toBeNull()
+    expect(overlay?.parentElement).toBe(document.body)
+  })
+
+  it('black slab height matches progress * 100%', () => {
+    render(<ChannelFlipTransition progress={0.25} />)
+    const blackSlab = document.body.querySelector('.cft-black-above') as HTMLElement
+    expect(blackSlab.style.height).toBe('25%')
+  })
+
+  it('band positioned at top: progress * 100%', () => {
+    render(<ChannelFlipTransition progress={0.75} />)
+    const band = document.body.querySelector('.cft-band') as HTMLElement
+    expect(band.style.top).toBe('75%')
+  })
+
+  it('clamps progress > 1 to 100%', () => {
+    render(<ChannelFlipTransition progress={1.5} />)
+    const blackSlab = document.body.querySelector('.cft-black-above') as HTMLElement
+    expect(blackSlab.style.height).toBe('100%')
+  })
+
+  it('overlay carries aria-hidden=true and role=presentation', () => {
+    render(<ChannelFlipTransition progress={0.5} />)
+    const overlay = document.body.querySelector('.cft')
+    expect(overlay?.getAttribute('aria-hidden')).toBe('true')
+    expect(overlay?.getAttribute('role')).toBe('presentation')
+  })
+})

--- a/components/molecules/ChannelFlipTransition/__tests__/flip-frames.test.ts
+++ b/components/molecules/ChannelFlipTransition/__tests__/flip-frames.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  FLIP_BAND_SWEEP_MS,
+  FLIP_HOLD_BLACK_MS,
+  FLIP_REVEAL_MS,
+  FLIP_TOTAL_MS,
+  safeTotalDurationMs,
+  scalePhases,
+} from '../flip-frames'
+
+describe('flip-frames constants', () => {
+  it('phase constants sum to FLIP_TOTAL_MS', () => {
+    expect(FLIP_BAND_SWEEP_MS + FLIP_HOLD_BLACK_MS + FLIP_REVEAL_MS).toBe(FLIP_TOTAL_MS)
+  })
+
+  it('default phase is 200 / 200 / 200', () => {
+    expect(FLIP_BAND_SWEEP_MS).toBe(200)
+    expect(FLIP_HOLD_BLACK_MS).toBe(200)
+    expect(FLIP_REVEAL_MS).toBe(200)
+    expect(FLIP_TOTAL_MS).toBe(600)
+  })
+})
+
+describe('safeTotalDurationMs', () => {
+  it('returns the input when positive finite number', () => {
+    expect(safeTotalDurationMs(900)).toBe(900)
+    expect(safeTotalDurationMs(1)).toBe(1)
+  })
+
+  it('falls back to FLIP_TOTAL_MS for 0, negative, NaN, Infinity, and undefined', () => {
+    expect(safeTotalDurationMs(undefined)).toBe(FLIP_TOTAL_MS)
+    expect(safeTotalDurationMs(0)).toBe(FLIP_TOTAL_MS)
+    expect(safeTotalDurationMs(-100)).toBe(FLIP_TOTAL_MS)
+    expect(safeTotalDurationMs(Number.NaN)).toBe(FLIP_TOTAL_MS)
+    expect(safeTotalDurationMs(Number.POSITIVE_INFINITY)).toBe(FLIP_TOTAL_MS)
+    expect(safeTotalDurationMs(Number.NEGATIVE_INFINITY)).toBe(FLIP_TOTAL_MS)
+  })
+})
+
+describe('scalePhases', () => {
+  it('returns 200 / 200 / 200 / 600 at the default total', () => {
+    const phases = scalePhases()
+    expect(phases.bandSweepMs).toBe(200)
+    expect(phases.holdBlackMs).toBe(200)
+    expect(phases.revealMs).toBe(200)
+    expect(phases.totalMs).toBe(600)
+    expect(phases.routeChangeMs).toBe(200)
+  })
+
+  it('scales proportionally at 3000ms total (5x)', () => {
+    const phases = scalePhases(3000)
+    expect(phases.bandSweepMs).toBe(1000)
+    expect(phases.holdBlackMs).toBe(1000)
+    expect(phases.revealMs).toBe(1000)
+    expect(phases.totalMs).toBe(3000)
+    expect(phases.routeChangeMs).toBe(1000)
+  })
+
+  it('preserves the 1:1:1 phase ratio across totals', () => {
+    const phases = scalePhases(900)
+    expect(phases.bandSweepMs).toBe(phases.holdBlackMs)
+    expect(phases.holdBlackMs).toBe(phases.revealMs)
+    expect(phases.bandSweepMs + phases.holdBlackMs + phases.revealMs).toBe(phases.totalMs)
+  })
+
+  it('routeChangeMs equals bandSweepMs (midpoint of the 3-phase cycle)', () => {
+    expect(scalePhases(1200).routeChangeMs).toBe(scalePhases(1200).bandSweepMs)
+    expect(scalePhases().routeChangeMs).toBe(scalePhases().bandSweepMs)
+  })
+
+  it('folds invalid totals to FLIP_TOTAL_MS', () => {
+    const phases = scalePhases(Number.NaN)
+    expect(phases.totalMs).toBe(FLIP_TOTAL_MS)
+    expect(phases.bandSweepMs).toBe(FLIP_BAND_SWEEP_MS)
+  })
+})

--- a/components/molecules/ChannelFlipTransition/__tests__/useChannelFlipNavigate.test.tsx
+++ b/components/molecules/ChannelFlipTransition/__tests__/useChannelFlipNavigate.test.tsx
@@ -1,0 +1,106 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useChannelFlipNavigate, type UseChannelFlipNavigateOptions } from '../useChannelFlipNavigate'
+
+const pushMock = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, replace: vi.fn(), back: vi.fn(), forward: vi.fn(), refresh: vi.fn() }),
+}))
+
+afterEach(() => {
+  cleanup()
+  pushMock.mockReset()
+})
+
+type HookHarnessHandle = {
+  navigate: ReturnType<typeof useChannelFlipNavigate>['navigate']
+}
+
+function HookHarness({
+  options,
+  handleRef,
+}: {
+  options: UseChannelFlipNavigateOptions
+  handleRef: { current: HookHarnessHandle | null }
+}) {
+  const { navigate, overlay } = useChannelFlipNavigate(options)
+  handleRef.current = { navigate }
+  return <>{overlay}</>
+}
+
+describe('useChannelFlipNavigate reduced-motion branch (AC-2)', () => {
+  it('calls router.push synchronously and resolves the promise', async () => {
+    const handleRef: { current: HookHarnessHandle | null } = { current: null }
+    render(<HookHarness options={{ reducedMotionOverride: true }} handleRef={handleRef} />)
+    let resolved = false
+    await act(async () => {
+      const navigatePromise = handleRef.current!.navigate('/dashboard')
+      expect(pushMock).toHaveBeenCalledWith('/dashboard')
+      await navigatePromise
+      resolved = true
+    })
+    expect(resolved).toBe(true)
+    expect(pushMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not mount the overlay in reduced-motion mode', async () => {
+    const handleRef: { current: HookHarnessHandle | null } = { current: null }
+    render(<HookHarness options={{ reducedMotionOverride: true }} handleRef={handleRef} />)
+    await act(async () => {
+      await handleRef.current!.navigate('/anywhere')
+    })
+    expect(document.body.querySelector('.cft')).toBeNull()
+  })
+})
+
+describe('useChannelFlipNavigate animated branch (AC-1, AC-3)', () => {
+  it('calls router.push after the band sweep completes (at midpoint of the cycle)', async () => {
+    const handleRef: { current: HookHarnessHandle | null } = { current: null }
+    render(
+      <HookHarness
+        options={{ reducedMotionOverride: false, totalDuration: 60 }}
+        handleRef={handleRef}
+      />
+    )
+    expect(pushMock).not.toHaveBeenCalled()
+    await act(async () => {
+      await handleRef.current!.navigate('/timeline')
+    })
+    expect(pushMock).toHaveBeenCalledWith('/timeline')
+    expect(pushMock).toHaveBeenCalledTimes(1)
+  }, 5000)
+
+  it('promise resolves after the full transition cycle (not at midpoint)', async () => {
+    const handleRef: { current: HookHarnessHandle | null } = { current: null }
+    render(
+      <HookHarness
+        options={{ reducedMotionOverride: false, totalDuration: 60 }}
+        handleRef={handleRef}
+      />
+    )
+    let resolved = false
+    await act(async () => {
+      await handleRef.current!.navigate('/library')
+      resolved = true
+    })
+    expect(resolved).toBe(true)
+  }, 5000)
+})
+
+describe('useChannelFlipNavigate cleanup on unmount (AC-1, AC-2)', () => {
+  it('does not call router.push after the component unmounts mid-flight', async () => {
+    const handleRef: { current: HookHarnessHandle | null } = { current: null }
+    const { unmount } = render(
+      <HookHarness
+        options={{ reducedMotionOverride: false, totalDuration: 60 }}
+        handleRef={handleRef}
+      />
+    )
+    handleRef.current!.navigate('/dropped')
+    unmount()
+    // wait well past the band-sweep boundary (20ms) so the un-killed timeline would have pushed by now
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    expect(pushMock).not.toHaveBeenCalled()
+  }, 5000)
+})

--- a/components/molecules/ChannelFlipTransition/flip-frames.ts
+++ b/components/molecules/ChannelFlipTransition/flip-frames.ts
@@ -1,0 +1,35 @@
+export const FLIP_TOTAL_MS = 600 as const
+export const FLIP_BAND_SWEEP_MS = 200 as const
+export const FLIP_HOLD_BLACK_MS = 200 as const
+export const FLIP_REVEAL_MS = 200 as const
+export const FLIP_ROUTE_CHANGE_MS = FLIP_BAND_SWEEP_MS
+
+export type FlipPhases = {
+  bandSweepMs: number
+  holdBlackMs: number
+  revealMs: number
+  totalMs: number
+  routeChangeMs: number
+}
+
+export function safeTotalDurationMs(input?: number): number {
+  if (typeof input !== 'number') return FLIP_TOTAL_MS
+  if (!Number.isFinite(input)) return FLIP_TOTAL_MS
+  if (input <= 0) return FLIP_TOTAL_MS
+  return input
+}
+
+export function scalePhases(totalDurationMs?: number): FlipPhases {
+  const total = safeTotalDurationMs(totalDurationMs)
+  const ratio = total / FLIP_TOTAL_MS
+  const bandSweepMs = FLIP_BAND_SWEEP_MS * ratio
+  const holdBlackMs = FLIP_HOLD_BLACK_MS * ratio
+  const revealMs = FLIP_REVEAL_MS * ratio
+  return {
+    bandSweepMs,
+    holdBlackMs,
+    revealMs,
+    totalMs: total,
+    routeChangeMs: bandSweepMs,
+  }
+}

--- a/components/molecules/ChannelFlipTransition/index.ts
+++ b/components/molecules/ChannelFlipTransition/index.ts
@@ -1,0 +1,17 @@
+export { ChannelFlipTransition } from './ChannelFlipTransition'
+export type { ChannelFlipTransitionProps } from './ChannelFlipTransition'
+export { useChannelFlipNavigate } from './useChannelFlipNavigate'
+export type {
+  ChannelFlipNavigate,
+  UseChannelFlipNavigateOptions,
+} from './useChannelFlipNavigate'
+export {
+  FLIP_TOTAL_MS,
+  FLIP_BAND_SWEEP_MS,
+  FLIP_HOLD_BLACK_MS,
+  FLIP_REVEAL_MS,
+  FLIP_ROUTE_CHANGE_MS,
+  safeTotalDurationMs,
+  scalePhases,
+} from './flip-frames'
+export type { FlipPhases } from './flip-frames'

--- a/components/molecules/ChannelFlipTransition/useChannelFlipNavigate.tsx
+++ b/components/molecules/ChannelFlipTransition/useChannelFlipNavigate.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import gsap from 'gsap'
+import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ChannelFlipTransition } from './ChannelFlipTransition'
+import { safeTotalDurationMs, scalePhases } from './flip-frames'
+
+export type UseChannelFlipNavigateOptions = {
+  totalDuration?: number
+  reducedMotionOverride?: boolean
+}
+
+export type ChannelFlipNavigate = (target: string) => Promise<void>
+
+function readInitialReducedMotion(override?: boolean): boolean {
+  if (typeof override === 'boolean') return override
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+function usePrefersReducedMotion(override: boolean | undefined, initial: boolean): boolean {
+  const [reduced, setReduced] = useState<boolean>(initial)
+
+  useEffect(() => {
+    if (typeof override === 'boolean') {
+      setReduced(override)
+      return
+    }
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+    setReduced(mql.matches)
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches)
+    mql.addEventListener('change', onChange)
+    return () => mql.removeEventListener('change', onChange)
+  }, [override])
+
+  return reduced
+}
+
+export function useChannelFlipNavigate(
+  options: UseChannelFlipNavigateOptions = {}
+): {
+  navigate: ChannelFlipNavigate
+  overlay: React.ReactNode
+} {
+  const { totalDuration, reducedMotionOverride } = options
+  const router = useRouter()
+  const initialReduced = readInitialReducedMotion(reducedMotionOverride)
+  const reduced = usePrefersReducedMotion(reducedMotionOverride, initialReduced)
+  const [progress, setProgress] = useState(0)
+  const timelineRef = useRef<gsap.core.Timeline | null>(null)
+  const rafRef = useRef<number | null>(null)
+  const reducedRef = useRef(reduced)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    reducedRef.current = reduced
+  }, [reduced])
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      timelineRef.current?.kill()
+      timelineRef.current = null
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
+    }
+  }, [])
+
+  const navigate = useCallback<ChannelFlipNavigate>(
+    (target) => {
+      return new Promise<void>((resolve) => {
+        const safePush = () => {
+          try {
+            router.push(target)
+          } catch {
+            // Router throws on invalid target; surface as a no-op so the Promise
+            // still resolves cleanly. Consumer-side logging is consumer responsibility.
+          }
+        }
+
+        if (reducedRef.current) {
+          safePush()
+          if (typeof window === 'undefined' || typeof requestAnimationFrame !== 'function') {
+            resolve()
+            return
+          }
+          rafRef.current = requestAnimationFrame(() => {
+            rafRef.current = null
+            resolve()
+          })
+          return
+        }
+
+        timelineRef.current?.kill()
+        setProgress(0)
+        const phases = scalePhases(safeTotalDurationMs(totalDuration))
+        const driver = { p: 0 }
+        let routePushed = false
+        const tl = gsap.timeline({
+          onUpdate: () => {
+            if (mountedRef.current) setProgress(driver.p)
+          },
+          onComplete: () => {
+            timelineRef.current = null
+            resolve()
+          },
+        })
+        tl.to(driver, {
+          p: 1,
+          duration: phases.bandSweepMs / 1000,
+          ease: 'none',
+          onComplete: () => {
+            if (!routePushed) {
+              routePushed = true
+              safePush()
+            }
+          },
+        })
+        tl.to(driver, { p: 1, duration: phases.holdBlackMs / 1000, ease: 'none' })
+        tl.to(driver, { p: 0, duration: phases.revealMs / 1000, ease: 'none' })
+        timelineRef.current = tl
+      })
+    },
+    [router, totalDuration]
+  )
+
+  const overlay = <ChannelFlipTransition progress={progress} />
+
+  return { navigate, overlay }
+}


### PR DESCRIPTION
Closes #68
Closes #69

## Summary

Pairs Stories 2.8 + 2.9 on the `epic-2-channelflip-phosphor` branch (one commit per issue per the bundle-PR convention). Two new motion / status primitives for Epic 2:

**Story 2.8 — `ChannelFlipTransition` + `useChannelFlipNavigate`** (`components/molecules/ChannelFlipTransition/`)
- Programmatic navigate hook that plays a 200 / 200 / 200 ms (band-sweep → hold-black → reveal) CRT channel-flip around top-level nav.
- `prefers-reduced-motion: reduce` collapses to instant route change (no overlay rendered).
- Overlay rendered via `createPortal(document.body)` so it sits above any z-index regardless of consumer tree.
- Hook returns `{ navigate, overlay }`: consumer renders `{overlay}` once; `navigate(target)` returns a Promise that resolves after the full cycle.
- GSAP timeline killed on unmount; `mountedRef` guard on `setProgress` ticks.
- Dev fixture at `/dev/flip` (4 modes + "play in place" + real navigate to /dev/boot).

**Story 2.9 — `PhosphorLED` + `PhosphorBar` atoms** (`components/atoms/`)
- 5-status LED (completed / in-progress / backlog / dropped / on-hold) with token-driven color + glow halo; numeric `size` prop, default 8 px.
- Phosphor progress bar with phosphor-cream filled portion (glowing) + ground-lift unfilled; `value` clamps to `[0, max]`; `max=0` renders empty bar.
- Both are Server Components (no `'use client'`): native `title` for tooltip + `aria-label`.
- Dev fixture at `/dev/status` (LED grid × 3 sizes, 9 bar samples, focusable sample row).

## Test plan

- [ ] `pnpm typecheck && pnpm lint` clean inside dev container.
- [ ] `pnpm vitest run components/molecules/ChannelFlipTransition components/atoms/PhosphorLED components/atoms/PhosphorBar` — 38 new tests pass (9 flip-frames + 7 ChannelFlipTransition + 5 useChannelFlipNavigate + 9 PhosphorLED + 8 PhosphorBar).
- [ ] Full `pnpm vitest run` — 145 / 147 pass (2 pre-existing BullMQ worker failures from Story 2.7 baseline; not introduced here).
- [ ] Visit `/dev/flip` while authenticated; verify slowed 3 s mode shows band sweep + hold-black + reveal; verify reduced-motion + OS-setting modes; verify "real navigate to /dev/boot".
- [ ] Visit `/dev/status`; verify 5 LED statuses × 3 sizes; verify 9 bar samples (including clamps + max=0); tab through sample row to verify LED contributes to row accessible name.