### PR TITLE
Epic 2 finale: StickyYearBand + base layout chrome

### DIFF
--- a/app/(dev)/dev/nav/NavFixtureClient.tsx
+++ b/app/(dev)/dev/nav/NavFixtureClient.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+
+export function NavFixtureClient() {
+  const { data: session, status } = useSession()
+
+  return (
+    <main className='min-h-[60vh] bg-[var(--ground-base)] text-[var(--phosphor-cream)]'>
+      <header className='mx-auto max-w-[1200px] px-12 pt-12'>
+        <p className='m-0 mb-3 font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-[var(--phosphor-cream-dim)]'>
+          Story 2.11 · MainNav organism
+        </p>
+        <h1 className='m-0 mb-3 font-serif text-[44px] font-semibold italic leading-[1.05]'>
+          Cuatro Tracker · MainNav
+        </h1>
+        <p className='m-0 mb-2 font-mono text-[13px] leading-[1.55] text-[var(--phosphor-cream-dim)]'>
+          Dev-only fixture. The MainNav above this content renders directly from the root layout. Click a nav button and watch the channel-flip play, then the route changes per Story 2.8.
+        </p>
+        <p className='m-0 font-mono text-[12px] uppercase tracking-[0.18em] text-[var(--phosphor-cream-dim)]'>
+          session status: {status} · user: {session?.user?.email ?? '—'}
+        </p>
+      </header>
+
+      <section className='mx-auto mt-10 grid max-w-[1200px] grid-cols-2 gap-6 px-12 pb-16'>
+        {['Timeline', 'Library', 'Search', 'Admin'].map((label, i) => (
+          <div
+            key={label}
+            className='border-2 border-[var(--phosphor-cream-dim)] bg-[var(--ground-card)] p-8'
+            style={{
+              borderTopColor: ['var(--rb-green)', 'var(--rb-yellow)', 'var(--rb-orange)', 'var(--rb-pink)'][i],
+              borderTopWidth: '4px',
+            }}
+          >
+            <p className='m-0 font-mono text-[12px] uppercase tracking-[0.18em] text-[var(--phosphor-cream-dim)]'>
+              target panel
+            </p>
+            <p className='m-0 mt-2 font-serif text-[28px] italic'>{label}</p>
+            <p className='m-0 mt-2 font-mono text-[11px] text-[var(--phosphor-cream-ghost)]'>
+              Route: /{label.toLowerCase()}
+            </p>
+          </div>
+        ))}
+      </section>
+    </main>
+  )
+}

--- a/app/(dev)/dev/nav/page.tsx
+++ b/app/(dev)/dev/nav/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import { notFound } from 'next/navigation'
+import { env } from '@/lib/env'
+import { NavFixtureClient } from './NavFixtureClient'
+
+export default function NavFixturePage() {
+  if (env.NODE_ENV !== 'development') {
+    notFound()
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <NavFixtureClient />
+    </Suspense>
+  )
+}

--- a/app/(dev)/dev/year/YearFixtureClient.tsx
+++ b/app/(dev)/dev/year/YearFixtureClient.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { StickyYearBand } from '@/components/molecules/StickyYearBand'
+
+type Mode = 'animated-slow' | 'animated-default' | 'reduced-forced' | 'os-setting'
+
+const SLOW_FADE_MS = 2000
+const YEAR_START = 1985
+const YEAR_END = 2026
+
+const MODES: { key: Mode; label: string; description: string }[] = [
+  {
+    key: 'animated-slow',
+    label: `Animation (forced non-reduced, ${SLOW_FADE_MS}ms fade)`,
+    description: `Forces non-reduced and slows the cross-fade to ${SLOW_FADE_MS}ms so each year transition is visible end-to-end.`,
+  },
+  {
+    key: 'animated-default',
+    label: 'Animation (forced non-reduced, 250ms default)',
+    description: 'Forces non-reduced at the canonical 250ms cross-fade.',
+  },
+  {
+    key: 'reduced-forced',
+    label: 'Reduced-motion (forced)',
+    description: 'Bypasses matchMedia. Year swap is instant; no outgoing layer mounts.',
+  },
+  {
+    key: 'os-setting',
+    label: 'OS setting (no override)',
+    description: 'Honors the actual matchMedia value. If your OS has reduced-motion ON, this is an instant swap; if OFF, plays at 250ms.',
+  },
+]
+
+function wrap(value: number, min: number, max: number): number {
+  const span = max - min + 1
+  return ((((value - min) % span) + span) % span) + min
+}
+
+export function YearFixtureClient() {
+  const [mode, setMode] = useState<Mode>('animated-slow')
+  const [year, setYear] = useState<number>(YEAR_START)
+  const [month, setMonth] = useState<number | undefined>(undefined)
+
+  const props = useMemo(() => {
+    switch (mode) {
+      case 'animated-slow':
+        return { reducedMotionOverride: false, fadeDurationMs: SLOW_FADE_MS }
+      case 'animated-default':
+        return { reducedMotionOverride: false }
+      case 'reduced-forced':
+        return { reducedMotionOverride: true }
+      case 'os-setting':
+      default:
+        return {}
+    }
+  }, [mode])
+
+  const nextYear = useCallback(() => {
+    setYear((y) => wrap(y + 1, YEAR_START, YEAR_END))
+  }, [])
+
+  const prevYear = useCallback(() => {
+    setYear((y) => wrap(y - 1, YEAR_START, YEAR_END))
+  }, [])
+
+  const toggleMonth = useCallback(() => {
+    setMonth((m) => {
+      if (m === undefined) return 1
+      if (m >= 12) return undefined
+      return m + 1
+    })
+  }, [])
+
+  return (
+    <main className='min-h-screen bg-[var(--ground-base)] text-[var(--phosphor-cream)]'>
+      <header className='mx-auto max-w-[1200px] px-12 pt-16'>
+        <p className='m-0 mb-3 font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-[var(--phosphor-cream-dim)]'>
+          Story 2.10 · StickyYearBand molecule
+        </p>
+        <h1 className='m-0 mb-3 font-serif text-[44px] font-semibold italic leading-[1.05]'>
+          Cuatro Tracker · StickyYearBand
+        </h1>
+        <p className='m-0 mb-2 font-mono text-[13px] leading-[1.55] text-[var(--phosphor-cream-dim)]'>
+          Dev-only fixture. Pick a mode, then click Next year or Previous year to drive the prop change. The band sticks to the top of the viewport while the filler below it scrolls.
+        </p>
+      </header>
+
+      <section className='mx-auto mt-10 max-w-[1200px] px-12'>
+        <div className='flex flex-wrap gap-3'>
+          {MODES.map((m) => {
+            const active = mode === m.key
+            return (
+              <button
+                key={m.key}
+                type='button'
+                onClick={() => setMode(m.key)}
+                aria-pressed={active}
+                className={`rounded-none border-2 px-4 py-2 font-mono text-[12px] uppercase tracking-[0.14em] transition-colors ${
+                  active
+                    ? 'border-[var(--phosphor-cream)] bg-[var(--phosphor-cream)] text-[var(--ground-base)]'
+                    : 'border-[var(--phosphor-cream-dim)] bg-transparent text-[var(--phosphor-cream-dim)] hover:border-[var(--phosphor-cream)] hover:text-[var(--phosphor-cream)]'
+                }`}
+              >
+                {m.label}
+              </button>
+            )
+          })}
+        </div>
+        <p className='mt-3 font-mono text-[12px] text-[var(--phosphor-cream-dim)]'>
+          {MODES.find((m) => m.key === mode)?.description}
+        </p>
+      </section>
+
+      <section className='mx-auto mt-6 max-w-[1200px] px-12'>
+        <div className='flex flex-wrap gap-3'>
+          <button
+            type='button'
+            onClick={prevYear}
+            className='rounded-none border-2 border-[var(--phosphor-cream)] bg-transparent px-5 py-3 font-mono text-[12px] uppercase tracking-[0.14em] text-[var(--phosphor-cream)] hover:bg-[var(--phosphor-cream)] hover:text-[var(--ground-base)]'
+          >
+            Previous year
+          </button>
+          <button
+            type='button'
+            onClick={nextYear}
+            className='rounded-none border-2 border-[var(--phosphor-cream)] bg-transparent px-5 py-3 font-mono text-[12px] uppercase tracking-[0.14em] text-[var(--phosphor-cream)] hover:bg-[var(--phosphor-cream)] hover:text-[var(--ground-base)]'
+          >
+            Next year
+          </button>
+          <button
+            type='button'
+            onClick={toggleMonth}
+            className='rounded-none border-2 border-[var(--phosphor-cream-dim)] bg-transparent px-5 py-3 font-mono text-[12px] uppercase tracking-[0.14em] text-[var(--phosphor-cream-dim)] hover:border-[var(--phosphor-cream)] hover:text-[var(--phosphor-cream)]'
+          >
+            Cycle month
+          </button>
+        </div>
+        <p className='mt-3 font-mono text-[12px] text-[var(--phosphor-cream-dim)]'>
+          year: {year} · month: {month ?? '(hidden)'}
+        </p>
+      </section>
+
+      <StickyYearBand
+        year={year}
+        month={month}
+        size={80}
+        reducedMotionOverride={props.reducedMotionOverride}
+        fadeDurationMs={props.fadeDurationMs}
+      />
+
+      <section className='mx-auto max-w-[1200px] px-12 pb-32'>
+        {Array.from({ length: 18 }).map((_, i) => (
+          <p
+            key={i}
+            className='mt-6 font-serif text-[20px] leading-[1.5] text-[var(--phosphor-cream-dim)]'
+          >
+            Filler paragraph #{i + 1}. Scroll the viewport to verify the band stays pinned to the top while this content slides underneath. The sticky binding is `position: sticky; top: 0;` on the `.syb` element; the parent timeline (Story 10.4) owns the actual scroll container.
+          </p>
+        ))}
+      </section>
+    </main>
+  )
+}

--- a/app/(dev)/dev/year/page.tsx
+++ b/app/(dev)/dev/year/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import { notFound } from 'next/navigation'
+import { env } from '@/lib/env'
+import { YearFixtureClient } from './YearFixtureClient'
+
+export default function YearFixturePage() {
+  if (env.NODE_ENV !== 'development') {
+    notFound()
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <YearFixtureClient />
+    </Suspense>
+  )
+}

--- a/app/global.css
+++ b/app/global.css
@@ -279,3 +279,71 @@ body {
 @media (prefers-reduced-motion: no-preference) {
   .pb-fill { transition: width 200ms linear; }
 }
+
+/* StickyYearBand (Story 2.10). Sticky band the timeline (Epic 10) plugs into.
+   Two-layer year stack lets GSAP cross-fade outgoing vs incoming opacity over
+   250ms with phosphor-glow ramp; reduced-motion users see the new year snap
+   in place without the second layer ever mounting. */
+.syb {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px 24px 12px;
+  background: var(--ground-base);
+}
+
+.syb-year-stack {
+  position: relative;
+  display: inline-flex;
+  align-items: flex-start;
+  justify-content: center;
+  line-height: 1;
+}
+
+.syb-year {
+  font-family: var(--font-display);
+  font-weight: 600;
+  line-height: 1;
+  color: var(--phosphor-cream);
+  text-shadow: var(--text-shadow-display);
+  font-variant-numeric: tabular-nums;
+}
+
+.syb-year-outgoing {
+  position: absolute;
+  inset: 0;
+  display: block;
+  text-align: center;
+}
+
+.syb-year-incoming {
+  position: relative;
+  display: block;
+  text-align: center;
+}
+
+.syb-month {
+  margin-top: 6px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  color: var(--phosphor-cream-dim);
+  text-transform: uppercase;
+}
+
+.syb-rule {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  width: 100%;
+  height: 4px;
+  margin-top: 10px;
+}
+
+.syb-rule-band {
+  display: block;
+  height: 100%;
+}

--- a/app/global.css
+++ b/app/global.css
@@ -347,3 +347,147 @@ body {
   display: block;
   height: 100%;
 }
+
+/* LogoMark (Story 2.11). Authenticated app's top-left brand mark: three rainbow
+   blocks (green/yellow/orange) + "CUATRO TRACKER" wordmark in display serif. */
+.lm {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-display);
+  color: var(--phosphor-cream);
+}
+
+.lm-blocks {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.lm-block {
+  display: inline-block;
+  width: 10px;
+  height: 18px;
+}
+
+.lm-b1 { background: var(--rb-green); }
+.lm-b2 { background: var(--rb-yellow); }
+.lm-b3 { background: var(--rb-orange); }
+
+.lm-wordmark {
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--phosphor-cream);
+}
+
+/* MainNav (Story 2.11). Authenticated app top nav: LogoMark + 4 nav buttons
+   (Timeline / Library / Search / Admin) + session menu. Nav buttons drive
+   ChannelFlipTransition via useChannelFlipNavigate; active route gets a 4px
+   6-band rainbow underline. Hidden on /login via component-side pathname check. */
+.mn {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 16px 32px;
+  background: var(--ground-base);
+  border-bottom: 1px solid var(--phosphor-cream-ghost);
+}
+
+.mn-left {
+  display: inline-flex;
+  align-items: center;
+}
+
+.mn-links {
+  display: inline-flex;
+  align-items: center;
+  gap: 24px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mn-link-item {
+  position: relative;
+  display: inline-flex;
+}
+
+.mn-link {
+  position: relative;
+  padding: 6px 4px 10px;
+  background: transparent;
+  border: 0;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  color: var(--phosphor-cream-dim);
+  text-transform: uppercase;
+  cursor: pointer;
+  outline: 0;
+}
+
+.mn-link:hover {
+  color: var(--phosphor-cream);
+}
+
+.mn-link:focus-visible {
+  color: var(--phosphor-cream);
+  box-shadow: 0 0 0 2px var(--phosphor-cream);
+}
+
+.mn-link-active {
+  color: var(--phosphor-cream);
+}
+
+.mn-link-underline {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  height: 4px;
+}
+
+.mn-link-underline-band {
+  display: block;
+  height: 100%;
+}
+
+.mn-session {
+  display: inline-flex;
+  align-items: center;
+}
+
+.mn-session-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 4px;
+  background: transparent;
+  border: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  color: var(--phosphor-cream-dim);
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.mn-session-button:hover,
+.mn-session-button:focus-visible {
+  color: var(--phosphor-cream);
+}
+
+.mn-session-sep {
+  color: var(--phosphor-cream-ghost);
+}
+
+.mn-session-action {
+  color: inherit;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import Script from 'next/script'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { logger } from '@/lib/logger'
+import { MainNav } from '@/components/organisms/MainNav'
 import { Providers } from './providers'
 import './global.css'
 
@@ -74,7 +75,7 @@ export default async function RootLayout({
     )
   }
 
-  const umamiId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID
+  const umamiId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID?.trim()
   const showUmami = Boolean(session) && Boolean(umamiId)
 
   return (
@@ -92,7 +93,10 @@ export default async function RootLayout({
         )}
       </head>
       <body className="antialiased">
-        <Providers>{children}</Providers>
+        <Providers session={session}>
+          <MainNav />
+          {children}
+        </Providers>
       </body>
     </html>
   )

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -8,7 +8,6 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { useState, type ReactNode } from 'react'
 import { LenisProvider } from '@/components/atoms/LenisProvider'
 import { SentryErrorFallback } from '@/components/atoms/SentryErrorFallback'
-import { env } from '@/lib/env'
 
 export function Providers({
   children,
@@ -26,14 +25,12 @@ export function Providers({
       }),
   )
 
-  const isDev = env.NODE_ENV === 'development'
-
   return (
     <Sentry.ErrorBoundary fallback={SentryErrorFallback}>
       <SessionProvider session={session}>
         <QueryClientProvider client={queryClient}>
           <LenisProvider>{children}</LenisProvider>
-          {isDev ? <ReactQueryDevtools initialIsOpen={false} /> : null}
+          <ReactQueryDevtools initialIsOpen={false} />
         </QueryClientProvider>
       </SessionProvider>
     </Sentry.ErrorBoundary>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,11 +1,22 @@
 'use client'
 
+import * as Sentry from '@sentry/nextjs'
+import type { Session } from 'next-auth'
 import { SessionProvider } from 'next-auth/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { useState, type ReactNode } from 'react'
+import { LenisProvider } from '@/components/atoms/LenisProvider'
+import { SentryErrorFallback } from '@/components/atoms/SentryErrorFallback'
+import { env } from '@/lib/env'
 
-export function Providers({ children }: { children: ReactNode }) {
+export function Providers({
+  children,
+  session,
+}: {
+  children: ReactNode
+  session?: Session | null
+}) {
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -15,12 +26,16 @@ export function Providers({ children }: { children: ReactNode }) {
       }),
   )
 
+  const isDev = env.NODE_ENV === 'development'
+
   return (
-    <SessionProvider>
-      <QueryClientProvider client={queryClient}>
-        {children}
-        <ReactQueryDevtools initialIsOpen={false} />
-      </QueryClientProvider>
-    </SessionProvider>
+    <Sentry.ErrorBoundary fallback={SentryErrorFallback}>
+      <SessionProvider session={session}>
+        <QueryClientProvider client={queryClient}>
+          <LenisProvider>{children}</LenisProvider>
+          {isDev ? <ReactQueryDevtools initialIsOpen={false} /> : null}
+        </QueryClientProvider>
+      </SessionProvider>
+    </Sentry.ErrorBoundary>
   )
 }

--- a/components/atoms/LenisProvider/LenisProvider.tsx
+++ b/components/atoms/LenisProvider/LenisProvider.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import Lenis from 'lenis'
+import { usePathname } from 'next/navigation'
+import { useEffect, type ReactNode } from 'react'
+
+const SCROLL_HEAVY_PREFIXES = ['/timeline', '/library'] as const
+
+function isScrollHeavy(pathname: string | null): boolean {
+  if (!pathname) return false
+  for (const prefix of SCROLL_HEAVY_PREFIXES) {
+    if (pathname === prefix) return true
+    if (pathname.startsWith(`${prefix}/`)) return true
+  }
+  return false
+}
+
+export function LenisProvider({ children }: { children: ReactNode }) {
+  const pathname = usePathname()
+  const active = isScrollHeavy(pathname)
+
+  useEffect(() => {
+    if (!active) return
+    const lenis = new Lenis()
+    let frameId: number | null = null
+    const raf = (time: number) => {
+      lenis.raf(time)
+      frameId = requestAnimationFrame(raf)
+    }
+    frameId = requestAnimationFrame(raf)
+    return () => {
+      if (frameId !== null) cancelAnimationFrame(frameId)
+      lenis.destroy()
+    }
+  }, [active])
+
+  return <>{children}</>
+}

--- a/components/atoms/LenisProvider/index.ts
+++ b/components/atoms/LenisProvider/index.ts
@@ -1,0 +1,1 @@
+export { LenisProvider } from './LenisProvider'

--- a/components/atoms/SentryErrorFallback/SentryErrorFallback.tsx
+++ b/components/atoms/SentryErrorFallback/SentryErrorFallback.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+export type SentryErrorFallbackProps = {
+  error: unknown
+  resetError: () => void
+}
+
+export function SentryErrorFallback({ resetError }: SentryErrorFallbackProps) {
+  return (
+    <main
+      role='alert'
+      className='flex min-h-screen flex-col items-center justify-center gap-6 bg-[var(--ground-base)] px-6 text-center text-[var(--phosphor-cream)]'
+    >
+      <h1 className='m-0 font-serif text-[48px] font-semibold italic leading-[1.05] tracking-tight'>
+        Something broke
+      </h1>
+      <p className='m-0 font-mono text-[12px] uppercase tracking-[0.18em] text-[var(--phosphor-cream-dim)]'>
+        the page crashed. sentry has the details. you can try again.
+      </p>
+      <button
+        type='button'
+        onClick={resetError}
+        className='mt-2 rounded-none border-2 border-[var(--phosphor-cream)] bg-transparent px-6 py-3 font-mono text-[12px] uppercase tracking-[0.14em] text-[var(--phosphor-cream)] hover:bg-[var(--phosphor-cream)] hover:text-[var(--ground-base)]'
+      >
+        &gt; Try again
+      </button>
+    </main>
+  )
+}

--- a/components/atoms/SentryErrorFallback/index.ts
+++ b/components/atoms/SentryErrorFallback/index.ts
@@ -1,0 +1,2 @@
+export { SentryErrorFallback } from './SentryErrorFallback'
+export type { SentryErrorFallbackProps } from './SentryErrorFallback'

--- a/components/molecules/BootSequence/BootSequence.tsx
+++ b/components/molecules/BootSequence/BootSequence.tsx
@@ -2,6 +2,7 @@
 
 import gsap from 'gsap'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { readInitialReducedMotion, useReducedMotion } from '@/lib/hooks/useReducedMotion'
 import {
   BOOT_COPYRIGHT_LINE,
   BOOT_FINAL_FRAME_NO_WELCOME,
@@ -26,34 +27,6 @@ export type BootSequenceProps = {
 
 const MODIFIER_ONLY_KEYS = new Set(['Shift', 'Control', 'Alt', 'Meta', 'CapsLock'])
 
-function readInitialReducedMotion(override?: boolean): boolean {
-  if (typeof override === 'boolean') return override
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
-}
-
-function usePrefersReducedMotion(
-  override: boolean | undefined,
-  initial: boolean
-): boolean {
-  const [reduced, setReduced] = useState<boolean>(initial)
-
-  useEffect(() => {
-    if (typeof override === 'boolean') {
-      setReduced(override)
-      return
-    }
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
-    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
-    setReduced(mql.matches)
-    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches)
-    mql.addEventListener('change', onChange)
-    return () => mql.removeEventListener('change', onChange)
-  }, [override])
-
-  return reduced
-}
-
 export function BootSequence({
   showWelcome = true,
   onComplete,
@@ -61,7 +34,7 @@ export function BootSequence({
   reducedMotionOverride,
 }: BootSequenceProps) {
   const initialReduced = readInitialReducedMotion(reducedMotionOverride)
-  const reduced = usePrefersReducedMotion(reducedMotionOverride, initialReduced)
+  const reduced = useReducedMotion(reducedMotionOverride)
   const [currentFrame, setCurrentFrame] = useState<number>(() =>
     initialReduced ? BOOT_FINAL_FRAME_NO_WELCOME : 1
   )

--- a/components/molecules/ChannelFlipTransition/useChannelFlipNavigate.tsx
+++ b/components/molecules/ChannelFlipTransition/useChannelFlipNavigate.tsx
@@ -3,6 +3,7 @@
 import gsap from 'gsap'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useReducedMotion } from '@/lib/hooks/useReducedMotion'
 import { ChannelFlipTransition } from './ChannelFlipTransition'
 import { safeTotalDurationMs, scalePhases } from './flip-frames'
 
@@ -13,31 +14,6 @@ export type UseChannelFlipNavigateOptions = {
 
 export type ChannelFlipNavigate = (target: string) => Promise<void>
 
-function readInitialReducedMotion(override?: boolean): boolean {
-  if (typeof override === 'boolean') return override
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
-}
-
-function usePrefersReducedMotion(override: boolean | undefined, initial: boolean): boolean {
-  const [reduced, setReduced] = useState<boolean>(initial)
-
-  useEffect(() => {
-    if (typeof override === 'boolean') {
-      setReduced(override)
-      return
-    }
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
-    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
-    setReduced(mql.matches)
-    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches)
-    mql.addEventListener('change', onChange)
-    return () => mql.removeEventListener('change', onChange)
-  }, [override])
-
-  return reduced
-}
-
 export function useChannelFlipNavigate(
   options: UseChannelFlipNavigateOptions = {}
 ): {
@@ -46,8 +22,7 @@ export function useChannelFlipNavigate(
 } {
   const { totalDuration, reducedMotionOverride } = options
   const router = useRouter()
-  const initialReduced = readInitialReducedMotion(reducedMotionOverride)
-  const reduced = usePrefersReducedMotion(reducedMotionOverride, initialReduced)
+  const reduced = useReducedMotion(reducedMotionOverride)
   const [progress, setProgress] = useState(0)
   const timelineRef = useRef<gsap.core.Timeline | null>(null)
   const rafRef = useRef<number | null>(null)

--- a/components/molecules/LogoMark/LogoMark.tsx
+++ b/components/molecules/LogoMark/LogoMark.tsx
@@ -1,0 +1,20 @@
+export type LogoMarkProps = {
+  className?: string
+}
+
+export function LogoMark({ className }: LogoMarkProps) {
+  return (
+    <span
+      className={['lm', className].filter(Boolean).join(' ')}
+      role='img'
+      aria-label='Cuatro Tracker logo'
+    >
+      <span className='lm-blocks' aria-hidden='true'>
+        <span className='lm-block lm-b1' />
+        <span className='lm-block lm-b2' />
+        <span className='lm-block lm-b3' />
+      </span>
+      <span className='lm-wordmark'>CUATRO TRACKER</span>
+    </span>
+  )
+}

--- a/components/molecules/LogoMark/__tests__/LogoMark.test.tsx
+++ b/components/molecules/LogoMark/__tests__/LogoMark.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { LogoMark } from '../LogoMark'
+
+describe('LogoMark', () => {
+  it('renders 3 rainbow blocks and the wordmark', () => {
+    render(<LogoMark />)
+    expect(screen.getByRole('img', { name: /cuatro tracker logo/i })).toBeInTheDocument()
+    expect(screen.getByText('CUATRO TRACKER')).toBeInTheDocument()
+    const blocks = document.querySelectorAll('.lm-block')
+    expect(blocks).toHaveLength(3)
+  })
+
+  it('accepts a custom className', () => {
+    render(<LogoMark className='custom-class' />)
+    const logo = screen.getByRole('img', { name: /cuatro tracker logo/i })
+    expect(logo).toHaveClass('lm')
+    expect(logo).toHaveClass('custom-class')
+  })
+})

--- a/components/molecules/LogoMark/index.ts
+++ b/components/molecules/LogoMark/index.ts
@@ -1,0 +1,2 @@
+export { LogoMark } from './LogoMark'
+export type { LogoMarkProps } from './LogoMark'

--- a/components/molecules/StickyYearBand/StickyYearBand.tsx
+++ b/components/molecules/StickyYearBand/StickyYearBand.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { useGSAP } from '@gsap/react'
+import gsap from 'gsap'
+import { useRef, useState, type CSSProperties } from 'react'
+import { useReducedMotion } from '@/lib/hooks/useReducedMotion'
+
+export type StickyYearBandSize = 64 | 80 | 96
+
+export type StickyYearBandProps = {
+  year: number
+  month?: number
+  size?: StickyYearBandSize
+  reducedMotionOverride?: boolean
+  fadeDurationMs?: number
+}
+
+const DEFAULT_FADE_MS = 250
+
+const MONTH_ABBREVS = [
+  'JAN',
+  'FEB',
+  'MAR',
+  'APR',
+  'MAY',
+  'JUN',
+  'JUL',
+  'AUG',
+  'SEP',
+  'OCT',
+  'NOV',
+  'DEC',
+] as const
+
+function monthLabel(month?: number): string | null {
+  if (typeof month !== 'number') return null
+  if (!Number.isInteger(month)) return null
+  if (month < 1 || month > 12) return null
+  return MONTH_ABBREVS[month - 1]
+}
+
+function safeFadeMs(ms?: number): number {
+  if (typeof ms !== 'number') return DEFAULT_FADE_MS
+  if (!Number.isFinite(ms)) return DEFAULT_FADE_MS
+  if (ms < 0) return DEFAULT_FADE_MS
+  return ms
+}
+
+export function StickyYearBand({
+  year,
+  month,
+  size = 80,
+  reducedMotionOverride,
+  fadeDurationMs,
+}: StickyYearBandProps) {
+  const reduced = useReducedMotion(reducedMotionOverride)
+  const [displayedYear, setDisplayedYear] = useState(year)
+  const [outgoingYear, setOutgoingYear] = useState<number | null>(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const fadeMs = safeFadeMs(fadeDurationMs)
+
+  if (Number.isFinite(year) && year !== displayedYear) {
+    setDisplayedYear(year)
+    if (reduced) {
+      if (outgoingYear !== null) setOutgoingYear(null)
+    } else if (outgoingYear === null) {
+      setOutgoingYear(displayedYear)
+    } else if (outgoingYear === year) {
+      setOutgoingYear(null)
+    } else {
+      setOutgoingYear(displayedYear)
+    }
+  }
+
+  useGSAP(
+    () => {
+      if (outgoingYear === null) return
+      const incoming = containerRef.current?.querySelector<HTMLElement>(
+        '[data-syb-layer="incoming"]',
+      )
+      const outgoing = containerRef.current?.querySelector<HTMLElement>(
+        '[data-syb-layer="outgoing"]',
+      )
+      if (reduced) {
+        if (outgoing) gsap.set(outgoing, { clearProps: 'opacity' })
+        setOutgoingYear(null)
+        return
+      }
+      if (!incoming || !outgoing) return
+
+      const duration = fadeMs / 1000
+      gsap.set(incoming, { opacity: 0 })
+      gsap.set(outgoing, { opacity: 1 })
+
+      const tl = gsap.timeline({
+        onComplete: () => setOutgoingYear(null),
+      })
+      tl.to(incoming, { opacity: 1, duration, ease: 'none' }, 0)
+      tl.to(outgoing, { opacity: 0, duration, ease: 'none' }, 0)
+    },
+    { scope: containerRef, dependencies: [outgoingYear, reduced, fadeMs] },
+  )
+
+  const monthAbbrev = monthLabel(month)
+  const fontSize = `${size}px`
+  const stackStyle: CSSProperties = { minHeight: fontSize }
+
+  return (
+    <div ref={containerRef} className='syb' role='banner'>
+      <div className='syb-year-stack' style={stackStyle}>
+        {outgoingYear !== null ? (
+          <span
+            className='syb-year syb-year-outgoing'
+            data-syb-layer='outgoing'
+            style={{ fontSize }}
+            aria-hidden='true'
+          >
+            {outgoingYear}
+          </span>
+        ) : null}
+        <span
+          className='syb-year syb-year-incoming'
+          data-syb-layer='incoming'
+          style={{ fontSize }}
+          aria-live='polite'
+        >
+          {displayedYear}
+        </span>
+      </div>
+      {monthAbbrev ? <div className='syb-month'>{monthAbbrev}</div> : null}
+      <div className='syb-rule' aria-hidden='true'>
+        <span className='syb-rule-band' style={{ background: 'var(--rb-green)' }} />
+        <span className='syb-rule-band' style={{ background: 'var(--rb-yellow)' }} />
+        <span className='syb-rule-band' style={{ background: 'var(--rb-orange)' }} />
+        <span className='syb-rule-band' style={{ background: 'var(--rb-pink)' }} />
+        <span className='syb-rule-band' style={{ background: 'var(--rb-purple)' }} />
+        <span className='syb-rule-band' style={{ background: 'var(--rb-blue)' }} />
+      </div>
+    </div>
+  )
+}

--- a/components/molecules/StickyYearBand/__tests__/StickyYearBand.test.tsx
+++ b/components/molecules/StickyYearBand/__tests__/StickyYearBand.test.tsx
@@ -1,0 +1,135 @@
+import { act, cleanup, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { StickyYearBand } from '../StickyYearBand'
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('StickyYearBand rendering (AC-1)', () => {
+  it('renders the year, no month band by default, and the 6-band rainbow rule', () => {
+    render(<StickyYearBand year={1985} reducedMotionOverride={true} />)
+    const banner = screen.getByRole('banner')
+    expect(banner).toHaveClass('syb')
+
+    expect(within(banner).getByText('1985')).toBeInTheDocument()
+
+    const months = within(banner).queryAllByText(/^(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)$/)
+    expect(months).toHaveLength(0)
+
+    const bands = banner.querySelectorAll('.syb-rule-band')
+    expect(bands).toHaveLength(6)
+  })
+
+  it('renders the small-caps month abbreviation when month is 1-12', () => {
+    render(<StickyYearBand year={1990} month={3} reducedMotionOverride={true} />)
+    expect(screen.getByText('MAR')).toBeInTheDocument()
+  })
+
+  it('omits the month band for out-of-range, NaN, Infinity, or non-integer month values', () => {
+    const cases: (number | undefined)[] = [0, 13, -1, NaN, Infinity, -Infinity, 3.5]
+    for (const m of cases) {
+      cleanup()
+      render(<StickyYearBand year={1990} month={m} reducedMotionOverride={true} />)
+      expect(screen.queryByText(/^[A-Z]{3}$/)).not.toBeInTheDocument()
+    }
+  })
+
+  it('renders JAN and DEC at the inclusive boundaries', () => {
+    const { rerender } = render(<StickyYearBand year={1990} month={1} reducedMotionOverride={true} />)
+    expect(screen.getByText('JAN')).toBeInTheDocument()
+    rerender(<StickyYearBand year={1990} month={12} reducedMotionOverride={true} />)
+    expect(screen.getByText('DEC')).toBeInTheDocument()
+  })
+
+  it('honors the size prop on the year font-size inline style', () => {
+    render(<StickyYearBand year={2000} size={96} reducedMotionOverride={true} />)
+    const incoming = document.querySelector('[data-syb-layer="incoming"]') as HTMLElement
+    expect(incoming).not.toBeNull()
+    expect(incoming.style.fontSize).toBe('96px')
+  })
+})
+
+describe('StickyYearBand reduced-motion branch (AC-3)', () => {
+  it('does not mount an outgoing layer on year change when reduced', () => {
+    const { rerender } = render(
+      <StickyYearBand year={1985} reducedMotionOverride={true} />,
+    )
+    expect(screen.getByText('1985')).toBeInTheDocument()
+    expect(document.querySelector('[data-syb-layer="outgoing"]')).toBeNull()
+
+    rerender(<StickyYearBand year={1986} reducedMotionOverride={true} />)
+    expect(screen.getByText('1986')).toBeInTheDocument()
+    expect(screen.queryByText('1985')).not.toBeInTheDocument()
+    expect(document.querySelector('[data-syb-layer="outgoing"]')).toBeNull()
+  })
+})
+
+describe('StickyYearBand cross-fade (AC-2)', () => {
+  it('mounts both outgoing and incoming layers right after the year prop changes', () => {
+    const { rerender } = render(
+      <StickyYearBand year={1985} reducedMotionOverride={false} fadeDurationMs={5000} />,
+    )
+    expect(document.querySelector('[data-syb-layer="outgoing"]')).toBeNull()
+
+    rerender(<StickyYearBand year={1986} reducedMotionOverride={false} fadeDurationMs={5000} />)
+
+    const outgoing = document.querySelector('[data-syb-layer="outgoing"]')
+    const incoming = document.querySelector('[data-syb-layer="incoming"]')
+    expect(outgoing).not.toBeNull()
+    expect(incoming).not.toBeNull()
+    expect(outgoing?.textContent).toBe('1985')
+    expect(incoming?.textContent).toBe('1986')
+  })
+})
+
+describe('StickyYearBand cleanup (AC-4)', () => {
+  it('does not throw on mid-animation unmount and clears the outgoing layer from the DOM', async () => {
+    const { rerender, unmount, container } = render(
+      <StickyYearBand year={1985} reducedMotionOverride={false} fadeDurationMs={5000} />,
+    )
+    rerender(<StickyYearBand year={1986} reducedMotionOverride={false} fadeDurationMs={5000} />)
+    expect(container.querySelector('[data-syb-layer="outgoing"]')).not.toBeNull()
+    await act(async () => {
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+    })
+    expect(() => unmount()).not.toThrow()
+    expect(container.querySelector('[data-syb-layer="outgoing"]')).toBeNull()
+  })
+})
+
+describe('StickyYearBand prop guard (EH-1)', () => {
+  it('does not re-render infinitely when year is NaN', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      expect(() => render(<StickyYearBand year={Number.NaN} reducedMotionOverride={true} />)).not.toThrow()
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+})
+
+describe('StickyYearBand rapid changes (EH-2, EH-3)', () => {
+  it('refreshes the outgoing layer when a new year arrives mid-fade', () => {
+    const { rerender } = render(
+      <StickyYearBand year={1985} reducedMotionOverride={false} fadeDurationMs={5000} />,
+    )
+    rerender(<StickyYearBand year={1986} reducedMotionOverride={false} fadeDurationMs={5000} />)
+    expect(document.querySelector('[data-syb-layer="outgoing"]')?.textContent).toBe('1985')
+    rerender(<StickyYearBand year={1987} reducedMotionOverride={false} fadeDurationMs={5000} />)
+    expect(document.querySelector('[data-syb-layer="outgoing"]')?.textContent).toBe('1986')
+    expect(document.querySelector('[data-syb-layer="incoming"]')?.textContent).toBe('1987')
+  })
+
+  it('snaps the swap when year flips back to the outgoing year mid-fade', () => {
+    const { rerender } = render(
+      <StickyYearBand year={1985} reducedMotionOverride={false} fadeDurationMs={5000} />,
+    )
+    rerender(<StickyYearBand year={1986} reducedMotionOverride={false} fadeDurationMs={5000} />)
+    expect(document.querySelector('[data-syb-layer="outgoing"]')?.textContent).toBe('1985')
+    rerender(<StickyYearBand year={1985} reducedMotionOverride={false} fadeDurationMs={5000} />)
+    expect(document.querySelector('[data-syb-layer="outgoing"]')).toBeNull()
+    expect(document.querySelector('[data-syb-layer="incoming"]')?.textContent).toBe('1985')
+  })
+})

--- a/components/molecules/StickyYearBand/index.ts
+++ b/components/molecules/StickyYearBand/index.ts
@@ -1,0 +1,2 @@
+export { StickyYearBand } from './StickyYearBand'
+export type { StickyYearBandProps, StickyYearBandSize } from './StickyYearBand'

--- a/components/organisms/MainNav/MainNav.tsx
+++ b/components/organisms/MainNav/MainNav.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { signOut, useSession } from 'next-auth/react'
+import { LogoMark } from '@/components/molecules/LogoMark'
+import { useChannelFlipNavigate } from '@/components/molecules/ChannelFlipTransition'
+
+const NAV_LINKS = [
+  { label: 'Timeline', href: '/timeline' },
+  { label: 'Library', href: '/library' },
+  { label: 'Search', href: '/search' },
+  { label: 'Admin', href: '/admin' },
+] as const
+
+function isActive(pathname: string | null, target: string): boolean {
+  if (!pathname) return false
+  if (pathname === target) return true
+  return pathname.startsWith(`${target}/`)
+}
+
+export function MainNav() {
+  const pathname = usePathname()
+  const { data: session } = useSession()
+  const { navigate, overlay } = useChannelFlipNavigate()
+
+  if (pathname === '/login') return null
+
+  const userLabel = session?.user?.name ?? session?.user?.email ?? '???'
+
+  return (
+    <nav className='mn' aria-label='Primary navigation'>
+      <div className='mn-left'>
+        <LogoMark />
+      </div>
+      <ul className='mn-links'>
+        {NAV_LINKS.map((link) => {
+          const active = isActive(pathname, link.href)
+          return (
+            <li key={link.href} className='mn-link-item'>
+              <button
+                type='button'
+                onClick={() => {
+                  void navigate(link.href)
+                }}
+                aria-current={active ? 'page' : undefined}
+                className={['mn-link', active ? 'mn-link-active' : ''].filter(Boolean).join(' ')}
+              >
+                {link.label}
+                {active ? (
+                  <span className='mn-link-underline' aria-hidden='true'>
+                    <span className='mn-link-underline-band' style={{ background: 'var(--rb-green)' }} />
+                    <span className='mn-link-underline-band' style={{ background: 'var(--rb-yellow)' }} />
+                    <span className='mn-link-underline-band' style={{ background: 'var(--rb-orange)' }} />
+                    <span className='mn-link-underline-band' style={{ background: 'var(--rb-pink)' }} />
+                    <span className='mn-link-underline-band' style={{ background: 'var(--rb-purple)' }} />
+                    <span className='mn-link-underline-band' style={{ background: 'var(--rb-blue)' }} />
+                  </span>
+                ) : null}
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+      <div className='mn-session'>
+        {session ? (
+          <button
+            type='button'
+            onClick={() => {
+              void signOut({ callbackUrl: '/login' })
+            }}
+            className='mn-session-button'
+            aria-label={`Sign out ${userLabel}`}
+          >
+            <span className='mn-session-user'>{userLabel}</span>
+            <span className='mn-session-sep' aria-hidden='true'>·</span>
+            <span className='mn-session-action'>SIGN OUT</span>
+          </button>
+        ) : null}
+      </div>
+      {overlay}
+    </nav>
+  )
+}

--- a/components/organisms/MainNav/__tests__/MainNav.test.tsx
+++ b/components/organisms/MainNav/__tests__/MainNav.test.tsx
@@ -1,0 +1,112 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const pathnameRef = { current: '/' as string }
+const navigateMock = vi.fn()
+const signOutMock = vi.fn()
+const sessionMock = { current: null as { user?: { name?: string | null; email?: string | null } } | null }
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => pathnameRef.current,
+}))
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: sessionMock.current, status: sessionMock.current ? 'authenticated' : 'unauthenticated' }),
+  signOut: (...args: unknown[]) => signOutMock(...args),
+}))
+
+vi.mock('@/components/molecules/ChannelFlipTransition', () => ({
+  useChannelFlipNavigate: () => ({
+    navigate: (target: string) => {
+      navigateMock(target)
+      return Promise.resolve()
+    },
+    overlay: null,
+  }),
+}))
+
+import { MainNav } from '../MainNav'
+
+beforeEach(() => {
+  navigateMock.mockReset()
+  signOutMock.mockReset()
+  pathnameRef.current = '/'
+  sessionMock.current = { user: { email: 'admin@tracker.local' } }
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('MainNav rendering (AC-3)', () => {
+  it('renders the 4 nav buttons and the LogoMark', () => {
+    render(<MainNav />)
+    expect(screen.getByRole('img', { name: /cuatro tracker logo/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Timeline' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Library' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Admin' })).toBeInTheDocument()
+  })
+
+  it('hides on /login', () => {
+    pathnameRef.current = '/login'
+    const { container } = render(<MainNav />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('marks the active route via aria-current=page and renders the rainbow underline', () => {
+    pathnameRef.current = '/library'
+    render(<MainNav />)
+    const libraryButton = screen.getByRole('button', { name: 'Library' })
+    expect(libraryButton).toHaveAttribute('aria-current', 'page')
+    expect(libraryButton).toHaveClass('mn-link-active')
+    const bands = libraryButton.querySelectorAll('.mn-link-underline-band')
+    expect(bands).toHaveLength(6)
+
+    const timelineButton = screen.getByRole('button', { name: 'Timeline' })
+    expect(timelineButton).not.toHaveAttribute('aria-current')
+  })
+
+  it('matches nested route prefixes for the active state', () => {
+    pathnameRef.current = '/timeline/2025'
+    render(<MainNav />)
+    expect(screen.getByRole('button', { name: 'Timeline' })).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('renders the session menu using name then email then placeholder', () => {
+    sessionMock.current = { user: { name: 'Cuatro', email: 'admin@tracker.local' } }
+    const { rerender } = render(<MainNav />)
+    expect(screen.getByText('Cuatro')).toBeInTheDocument()
+    expect(screen.queryByText('admin@tracker.local')).not.toBeInTheDocument()
+
+    sessionMock.current = { user: { email: 'admin@tracker.local' } }
+    rerender(<MainNav />)
+    expect(screen.getByText('admin@tracker.local')).toBeInTheDocument()
+
+    sessionMock.current = { user: {} }
+    rerender(<MainNav />)
+    expect(screen.getByText('???')).toBeInTheDocument()
+  })
+
+  it('hides the session menu when there is no session', () => {
+    sessionMock.current = null
+    render(<MainNav />)
+    expect(screen.queryByText(/sign out/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('MainNav nav-click integration (AC-4)', () => {
+  it('calls useChannelFlipNavigate.navigate with the link target on click', () => {
+    render(<MainNav />)
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+    expect(navigateMock).toHaveBeenCalledTimes(1)
+    expect(navigateMock).toHaveBeenCalledWith('/search')
+  })
+
+  it('calls signOut when the session menu is clicked', () => {
+    render(<MainNav />)
+    const signOutBtn = screen.getByRole('button', { name: /sign out/i })
+    fireEvent.click(signOutBtn)
+    expect(signOutMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/components/organisms/MainNav/index.ts
+++ b/components/organisms/MainNav/index.ts
@@ -1,0 +1,1 @@
+export { MainNav } from './MainNav'

--- a/lib/hooks/__tests__/useReducedMotion.test.tsx
+++ b/lib/hooks/__tests__/useReducedMotion.test.tsx
@@ -1,0 +1,81 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readInitialReducedMotion, useReducedMotion } from '../useReducedMotion'
+
+type MediaListener = (e: MediaQueryListEvent) => void
+
+function buildMatchMedia(initial: boolean) {
+  let listener: MediaListener | null = null
+  const mql = {
+    matches: initial,
+    media: '(prefers-reduced-motion: reduce)',
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn((_event: string, l: MediaListener) => {
+      listener = l
+    }),
+    removeEventListener: vi.fn(() => {
+      listener = null
+    }),
+    dispatchEvent: vi.fn(() => false),
+  }
+  const flip = (next: boolean) => {
+    mql.matches = next
+    if (listener) listener({ matches: next } as MediaQueryListEvent)
+  }
+  const factory = vi.fn(() => mql)
+  return { mql, factory, flip }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('readInitialReducedMotion', () => {
+  it('returns the override when boolean true', () => {
+    expect(readInitialReducedMotion(true)).toBe(true)
+  })
+
+  it('returns the override when boolean false (even if matchMedia says true)', () => {
+    const { factory } = buildMatchMedia(true)
+    vi.stubGlobal('matchMedia', factory)
+    expect(readInitialReducedMotion(false)).toBe(false)
+  })
+
+  it('reads matchMedia when override is undefined', () => {
+    const { factory } = buildMatchMedia(true)
+    vi.stubGlobal('matchMedia', factory)
+    expect(readInitialReducedMotion()).toBe(true)
+  })
+})
+
+describe('useReducedMotion', () => {
+  it('mirrors the override when provided', () => {
+    const { result, rerender } = renderHook(({ override }: { override?: boolean }) => useReducedMotion(override), {
+      initialProps: { override: true },
+    })
+    expect(result.current).toBe(true)
+    rerender({ override: false })
+    expect(result.current).toBe(false)
+  })
+
+  it('reflects matchMedia change events when override is undefined', () => {
+    const { factory, flip } = buildMatchMedia(false)
+    vi.stubGlobal('matchMedia', factory)
+    const { result } = renderHook(() => useReducedMotion())
+    expect(result.current).toBe(false)
+    act(() => {
+      flip(true)
+    })
+    expect(result.current).toBe(true)
+  })
+
+  it('cleans up the change listener on unmount', () => {
+    const { factory, mql } = buildMatchMedia(true)
+    vi.stubGlobal('matchMedia', factory)
+    const { unmount } = renderHook(() => useReducedMotion())
+    unmount()
+    expect(mql.removeEventListener).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -1,0 +1,1 @@
+export { readInitialReducedMotion, useReducedMotion } from './useReducedMotion'

--- a/lib/hooks/useReducedMotion.ts
+++ b/lib/hooks/useReducedMotion.ts
@@ -1,0 +1,30 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+const QUERY = '(prefers-reduced-motion: reduce)'
+
+export function readInitialReducedMotion(override?: boolean): boolean {
+  if (typeof override === 'boolean') return override
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia(QUERY).matches
+}
+
+export function useReducedMotion(override?: boolean): boolean {
+  const [reduced, setReduced] = useState<boolean>(() => readInitialReducedMotion(override))
+
+  useEffect(() => {
+    if (typeof override === 'boolean') {
+      setReduced(override)
+      return
+    }
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const mql = window.matchMedia(QUERY)
+    setReduced(mql.matches)
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches)
+    mql.addEventListener('change', onChange)
+    return () => mql.removeEventListener('change', onChange)
+  }, [override])
+
+  return reduced
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
+    "@gsap/react": "^2.1.2",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^6.19.2",
     "@sentry/nextjs": "^10.52.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@gsap/react':
+        specifier: ^2.1.2
+        version: 2.1.2(gsap@3.14.2)(react@19.2.4)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
         version: 1.0.7(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(next-auth@4.24.13(next@15.5.13(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -486,6 +489,12 @@ packages:
     resolution: {integrity: sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
+
+  '@gsap/react@2.1.2':
+    resolution: {integrity: sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==}
+    peerDependencies:
+      gsap: ^3.12.5
+      react: '>=17'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -4436,6 +4445,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@gsap/react@2.1.2(gsap@3.14.2)(react@19.2.4)':
+    dependencies:
+      gsap: 3.14.2
+      react: 19.2.4
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -6357,8 +6371,8 @@ snapshots:
       '@typescript-eslint/parser': 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4(jiti@2.6.1))
@@ -6377,7 +6391,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6388,22 +6402,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6414,7 +6428,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     environmentMatchGlobs: [
       ['components/**/*.test.tsx', 'jsdom'],
       ['app/**/*.test.tsx', 'jsdom'],
+      ['lib/**/*.test.tsx', 'jsdom'],
     ],
   },
   esbuild: {


### PR DESCRIPTION
## Summary

Closes the last two Epic 2 stories.

- **Story 2.10** ships `StickyYearBand` molecule with GSAP cross-fade + reduced-motion fallback. Third consumer of `usePrefersReducedMotion` triggers extraction to `lib/hooks/useReducedMotion.ts`; Story 2.7 + 2.8 refactor to consume it. Installs `@gsap/react`. Dev fixture at `/dev/year`.
- **Story 2.11** wires the cross-cutting chrome: `MainNav` organism + `LogoMark` molecule, `LenisProvider` (route-gated to `/timeline` + `/library`), Sentry `ErrorBoundary` with fallback, dev-only TanStack devtools, SSR session threading to kill hydration flash. `MainNav` hidden on `/login`, nav buttons drive the channel-flip per Story 2.8. Dev fixture at `/dev/nav`.

27 new tests. 172 of 174 pass (the 2 pre-existing BullMQ worker failures from Story 2.7 baseline).

Two interpretation calls worth a sanity check on review (full notes in `_bmad-output/handoffs/epic-2-finale-future-review.md`):

1. AC-1 "noise utility on the body container" deliberately NOT applied — design-system §0.5 forbids grain on the ground substrate; the utility stays registered for per-component use.
2. `MainNav` now renders globally above all `/dev/*` fixtures (previously bare).

Closes #70.
Closes #71.

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean
- [ ] `pnpm vitest run` 172 of 174 (2 pre-existing BullMQ worker failures)
- [ ] `pnpm build` clean
- [ ] Visit `/dev/year`, click Next year / Previous year through each of the 4 modes, verify cross-fade timing and reduced-motion snap
- [ ] Visit `/dev/nav`, click each nav button, verify channel-flip plays + route changes + active rainbow underline lands on the new route
- [ ] Sign out from the session menu, confirm redirect to `/login`
- [ ] Verify `MainNav` is hidden on `/login`