### PR TITLE
feat(login): rebuild login screen visual chrome (#86)

### DIFF
--- a/app/(auth)/login/__tests__/page.test.tsx
+++ b/app/(auth)/login/__tests__/page.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { signInMock, pushMock, refreshMock } = vi.hoisted(() => ({
+  signInMock: vi.fn(),
+  pushMock: vi.fn(),
+  refreshMock: vi.fn(),
+}))
+
+vi.mock('next-auth/react', () => ({
+  signIn: signInMock,
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+}))
+
+import LoginPage from '../page'
+
+beforeEach(() => {
+  signInMock.mockReset()
+  pushMock.mockReset()
+  refreshMock.mockReset()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('LoginPage submit flow', () => {
+  it('submits the form with email + password and the credentials provider shape', async () => {
+    signInMock.mockResolvedValue({ ok: true, error: null })
+    render(<LoginPage />)
+    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
+    const password = screen.getByLabelText('PASSWORD') as HTMLInputElement
+    fireEvent.change(password, { target: { value: 'adminpass' } })
+    fireEvent.submit(email.closest('form')!)
+
+    await waitFor(() => {
+      expect(signInMock).toHaveBeenCalledWith('credentials', {
+        email: 'admin@tracker.local',
+        password: 'adminpass',
+        redirect: false,
+      })
+    })
+  })
+
+  it('on success: routes to / and refreshes', async () => {
+    signInMock.mockResolvedValue({ ok: true, error: null })
+    render(<LoginPage />)
+    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
+    fireEvent.submit(email.closest('form')!)
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith('/')
+      expect(refreshMock).toHaveBeenCalled()
+    })
+  })
+
+  it('on error: renders the Invalid email or password. line and does NOT navigate', async () => {
+    signInMock.mockResolvedValue({ ok: false, error: 'CredentialsSignin' })
+    render(<LoginPage />)
+    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
+    fireEvent.submit(email.closest('form')!)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Invalid email or password.'),
+      ).toBeInTheDocument()
+    })
+    expect(pushMock).not.toHaveBeenCalled()
+    expect(refreshMock).not.toHaveBeenCalled()
+  })
+
+  it('on error: the submit button is re-enabled after the round-trip', async () => {
+    signInMock.mockResolvedValue({ ok: false, error: 'CredentialsSignin' })
+    render(<LoginPage />)
+    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
+    fireEvent.submit(email.closest('form')!)
+
+    await waitFor(() => {
+      const btn = screen.getByRole('button', {
+        name: '> LOG IN',
+      }) as HTMLButtonElement
+      expect(btn.disabled).toBe(false)
+    })
+  })
+})

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -2,22 +2,23 @@
 
 import { signIn } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
-import { type FormEvent, useState } from 'react'
+import { useState } from 'react'
+import { LoginCRT } from '@/components/organisms/LoginCRT'
 
 export default function LoginPage() {
   const router = useRouter()
-  const [error, setError] = useState('')
+  const [error, setError] = useState<string | null>(null)
   const [pending, setPending] = useState(false)
 
-  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
-    e.preventDefault()
-    setError('')
+  async function handleSubmit({
+    email,
+    password,
+  }: {
+    email: string
+    password: string
+  }) {
+    setError(null)
     setPending(true)
-
-    const form = e.currentTarget
-    const email = (form.elements.namedItem('email') as HTMLInputElement).value
-    const password = (form.elements.namedItem('password') as HTMLInputElement)
-      .value
 
     const result = await signIn('credentials', {
       email,
@@ -37,62 +38,8 @@ export default function LoginPage() {
   }
 
   return (
-    <main className="min-h-screen flex items-center justify-center bg-zinc-950 px-4">
-      <div className="w-full max-w-sm">
-        <h1 className="text-xl font-semibold text-zinc-100 mb-1 text-center tracking-tight">
-          Cuatro Tracker
-        </h1>
-        <p className="text-sm text-zinc-500 mb-8 text-center">
-          Sign in to continue
-        </p>
-
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label
-              htmlFor="email"
-              className="block text-xs text-zinc-400 mb-1.5 font-medium"
-            >
-              Email
-            </label>
-            <input
-              id="email"
-              name="email"
-              type="email"
-              required
-              autoComplete="email"
-              defaultValue="admin@tracker.local"
-              className="w-full px-3 py-2 bg-zinc-900 border border-zinc-800 rounded-lg text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-zinc-700 transition-colors"
-            />
-          </div>
-
-          <div>
-            <label
-              htmlFor="password"
-              className="block text-xs text-zinc-400 mb-1.5 font-medium"
-            >
-              Password
-            </label>
-            <input
-              id="password"
-              name="password"
-              type="password"
-              required
-              autoComplete="current-password"
-              className="w-full px-3 py-2 bg-zinc-900 border border-zinc-800 rounded-lg text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-zinc-700 transition-colors"
-            />
-          </div>
-
-          {error && <p className="text-xs text-red-400">{error}</p>}
-
-          <button
-            type="submit"
-            disabled={pending}
-            className="w-full py-2 px-4 bg-zinc-100 hover:bg-white text-zinc-900 rounded-lg text-sm font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed mt-2"
-          >
-            {pending ? 'Signing in...' : 'Sign in'}
-          </button>
-        </form>
-      </div>
+    <main className='lc'>
+      <LoginCRT onSubmit={handleSubmit} error={error} pending={pending} />
     </main>
   )
 }

--- a/app/global.css
+++ b/app/global.css
@@ -491,3 +491,288 @@ body {
 .mn-session-action {
   color: inherit;
 }
+
+/* LoginCRT (Story 3.1). Login screen visual chrome: CRT bezel + bitmap header
+   + terminal inputs + CRT-pixel submit. Mirrors the bundle's
+   login-styles.css (lines 78-279) re-namespaced to the .lc / .crt / .bt / .ti /
+   .cpb prefixes. The bezel exterior is the only .bg-noise consumer here
+   (design-system §0.5 allows hero CRT bezel exteriors); the inner .crt-screen-wrap
+   stays grain-free as a running-content surface. */
+.lc {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(
+    ellipse at center,
+    var(--ground-base) 0%,
+    var(--ground-base) 45%,
+    #15101f 100%
+  );
+  padding: 24px;
+}
+
+.crt {
+  position: relative;
+  width: 720px;
+  max-width: 100%;
+  aspect-ratio: 4 / 3;
+  filter:
+    drop-shadow(0 32px 48px rgba(0, 0, 0, 0.55))
+    drop-shadow(0 8px 16px rgba(0, 0, 0, 0.4));
+}
+
+.crt > svg.crt-shell {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.crt-screen-wrap {
+  position: absolute;
+  left: 7.8%;
+  top: 7.4%;
+  width: 84.4%;
+  height: 73.5%;
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--ground-base);
+  box-shadow:
+    inset 0 0 60px rgba(0, 0, 0, 0.85),
+    inset 0 0 12px rgba(123, 92, 255, 0.18),
+    inset 0 2px 0 rgba(0, 0, 0, 0.6);
+}
+
+.crt-screen-wrap::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at center, transparent 55%, rgba(0, 0, 0, 0.55) 100%),
+    repeating-linear-gradient(to bottom, transparent 0 2px, rgba(0, 0, 0, 0.18) 2px 3px);
+  pointer-events: none;
+  z-index: 4;
+}
+
+.crt-screen-wrap::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 140% 90% at 50% -20%,
+    rgba(239, 230, 212, 0.08),
+    transparent 55%
+  );
+  pointer-events: none;
+  z-index: 5;
+}
+
+.lc-screen {
+  position: absolute;
+  inset: 0;
+  padding: 38px 46px 42px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: var(--phosphor-cream);
+  z-index: 2;
+}
+
+.lc-form {
+  margin-top: 28px;
+  width: 100%;
+  max-width: 460px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.lc-error {
+  margin: 0;
+  letter-spacing: 0.04em;
+  overflow-wrap: anywhere;
+}
+
+.bt {
+  font-family: var(--font-bitmap);
+  letter-spacing: 0.04em;
+  line-height: 1;
+  color: var(--bt-color, var(--phosphor-cream));
+}
+
+.bt-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  margin-top: 0;
+}
+
+.bt-blocks {
+  display: inline-flex;
+  gap: 1px;
+  font-family: var(--font-bitmap);
+  font-size: 30px;
+  line-height: 1;
+}
+
+.bt-blocks span {
+  display: inline-block;
+}
+
+.bt-b1 {
+  color: var(--rb-green);
+}
+
+.bt-b2 {
+  color: var(--rb-yellow);
+}
+
+.bt-b3 {
+  color: var(--rb-orange);
+}
+
+.ti {
+  display: block;
+}
+
+.ti-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  color: var(--phosphor-cream-dim);
+  text-transform: uppercase;
+  margin-bottom: 6px;
+  display: block;
+}
+
+.ti-wrap {
+  position: relative;
+  border-bottom: 1px solid var(--phosphor-cream-ghost);
+  display: flex;
+  align-items: center;
+  padding: 6px 2px;
+  transition: border-color 120ms linear, box-shadow 120ms linear;
+}
+
+.ti-wrap[data-focused='true'] {
+  border-bottom: 2px solid var(--neon-blue);
+  box-shadow:
+    0 1px 0 0 var(--neon-blue),
+    0 6px 12px -6px rgba(63, 169, 255, 0.4),
+    0 0 6px rgba(63, 169, 255, 0.4);
+}
+
+.ti-field {
+  background: transparent;
+  border: 0;
+  outline: none;
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 16px;
+  color: var(--phosphor-cream);
+  padding: 0 2px;
+  letter-spacing: 0.02em;
+  /* Native caret hidden because .ti-cursor draws the indicator. */
+  caret-color: transparent;
+}
+
+.ti-field::placeholder {
+  color: var(--phosphor-cream-ghost);
+}
+
+.ti-field::selection {
+  background: rgba(63, 169, 255, 0.35);
+}
+
+.ti-cursor {
+  display: none;
+  width: 9px;
+  height: 18px;
+  background: var(--phosphor-cream);
+  margin-left: 2px;
+  vertical-align: middle;
+}
+
+.ti-wrap[data-focused='true'] .ti-cursor {
+  display: inline-block;
+  animation: ti-blink 1s steps(1) infinite;
+}
+
+@keyframes ti-blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ti-wrap[data-focused='true'] .ti-cursor {
+    animation: none;
+    opacity: 1;
+  }
+}
+
+.ti-wrap[data-rm='false'][data-focused='true'] .ti-cursor {
+  animation: ti-blink 1s steps(1) infinite;
+  opacity: 1;
+}
+
+.ti-wrap[data-rm='true'][data-focused='true'] .ti-cursor {
+  animation: none;
+  opacity: 1;
+}
+
+.cpb {
+  margin-top: 6px;
+  width: 100%;
+  font-family: var(--font-bitmap);
+  font-size: 22px;
+  letter-spacing: 0.06em;
+  color: var(--phosphor-cream);
+  background: transparent;
+  border: 1px solid var(--phosphor-cream);
+  padding: 12px 18px;
+  cursor: pointer;
+  transition:
+    background 100ms linear,
+    color 100ms linear,
+    border-width 100ms linear,
+    text-shadow 120ms linear;
+  text-align: center;
+}
+
+.cpb:hover,
+.cpb:focus-visible {
+  outline: none;
+  background: var(--phosphor-cream);
+  color: var(--ground-base);
+  border-width: 2px;
+  padding: 11px 17px;
+  text-shadow: 0 0 6px rgba(239, 230, 212, 0.55);
+}
+
+.cpb[disabled] {
+  border-color: var(--phosphor-cream-ghost);
+  color: var(--phosphor-cream-ghost);
+  cursor: not-allowed;
+  background: transparent;
+  text-shadow: none;
+}
+
+.cpb[data-inline='true'] {
+  width: auto;
+}
+
+@media (max-width: 480px) {
+  .crt {
+    width: 340px;
+  }
+  .lc-screen {
+    padding: 22px 22px 26px;
+  }
+  .lc-form {
+    max-width: 100%;
+    margin-top: 22px;
+    gap: 16px;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -41,7 +41,7 @@ const bodySerif = EB_Garamond({
 const monoSans = IBM_Plex_Mono({
   variable: '--font-mono',
   subsets: ['latin'],
-  weight: ['400', '600'],
+  weight: ['400', '500', '600'],
   style: ['normal'],
   display: 'swap',
   fallback: ['ui-monospace', 'Menlo', 'monospace'],

--- a/components/atoms/BitmapText/BitmapText.tsx
+++ b/components/atoms/BitmapText/BitmapText.tsx
@@ -1,0 +1,44 @@
+import type { CSSProperties, JSX, ReactNode } from 'react'
+
+export type BitmapTextTone = 'cream' | 'cream-dim' | 'cream-ghost' | 'magenta'
+
+export type BitmapTextProps = {
+  children: ReactNode
+  size?: number
+  tone?: BitmapTextTone
+  glow?: boolean
+  className?: string
+  as?: keyof JSX.IntrinsicElements
+}
+
+const TONE_VAR: Record<BitmapTextTone, string> = {
+  cream: 'var(--phosphor-cream)',
+  'cream-dim': 'var(--phosphor-cream-dim)',
+  'cream-ghost': 'var(--phosphor-cream-ghost)',
+  magenta: 'var(--magenta)',
+}
+
+const GLOW_SHADOW: Record<BitmapTextTone, string> = {
+  cream: '0 0 8px rgba(239, 230, 212, 0.4)',
+  'cream-dim': '0 0 8px rgba(239, 230, 212, 0.4)',
+  'cream-ghost': '0 0 8px rgba(239, 230, 212, 0.4)',
+  magenta: '0 0 8px rgba(214, 53, 124, 0.55)',
+}
+
+export function BitmapText({
+  children,
+  size = 18,
+  tone = 'cream',
+  glow = false,
+  className,
+  as,
+}: BitmapTextProps) {
+  const Tag = (as ?? 'span') as keyof JSX.IntrinsicElements
+  const style: CSSProperties & Record<string, string | number> = {
+    fontSize: `${size}px`,
+    ['--bt-color']: TONE_VAR[tone],
+  }
+  if (glow) style.textShadow = GLOW_SHADOW[tone]
+  const cls = className ? `bt ${className}` : 'bt'
+  return <Tag className={cls} style={style}>{children}</Tag>
+}

--- a/components/atoms/BitmapText/__tests__/BitmapText.test.tsx
+++ b/components/atoms/BitmapText/__tests__/BitmapText.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { BitmapText } from '../BitmapText'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('BitmapText rendering', () => {
+  it('renders children with the bt class by default', () => {
+    render(<BitmapText>HELLO</BitmapText>)
+    const el = screen.getByText('HELLO')
+    expect(el).toHaveClass('bt')
+    expect(el.tagName).toBe('SPAN')
+  })
+
+  it('applies the size prop as inline font-size', () => {
+    render(<BitmapText size={30}>BIG</BitmapText>)
+    const el = screen.getByText('BIG')
+    expect(el).toHaveStyle({ fontSize: '30px' })
+  })
+
+  it('tone=cream-dim sets --bt-color to the phosphor-cream-dim token', () => {
+    render(<BitmapText tone='cream-dim'>DIM</BitmapText>)
+    const el = screen.getByText('DIM')
+    expect(el.style.getPropertyValue('--bt-color')).toBe('var(--phosphor-cream-dim)')
+  })
+
+  it('tone=magenta sets --bt-color to the magenta token', () => {
+    render(<BitmapText tone='magenta'>ERR</BitmapText>)
+    const el = screen.getByText('ERR')
+    expect(el.style.getPropertyValue('--bt-color')).toBe('var(--magenta)')
+  })
+
+  it('glow=true on cream applies the cream text-shadow', () => {
+    render(<BitmapText glow>GLOW</BitmapText>)
+    const el = screen.getByText('GLOW')
+    expect(el).toHaveStyle({ textShadow: '0 0 8px rgba(239, 230, 212, 0.4)' })
+  })
+
+  it('glow=true on magenta applies the magenta text-shadow', () => {
+    render(
+      <BitmapText tone='magenta' glow>
+        ALERT
+      </BitmapText>,
+    )
+    const el = screen.getByText('ALERT')
+    expect(el).toHaveStyle({ textShadow: '0 0 8px rgba(214, 53, 124, 0.55)' })
+  })
+
+  it('as=div renders a div instead of a span', () => {
+    render(<BitmapText as='div'>BLOCK</BitmapText>)
+    const el = screen.getByText('BLOCK')
+    expect(el.tagName).toBe('DIV')
+  })
+
+  it('passes the className prop through alongside the bt base', () => {
+    render(<BitmapText className='extra'>X</BitmapText>)
+    const el = screen.getByText('X')
+    expect(el).toHaveClass('bt')
+    expect(el).toHaveClass('extra')
+  })
+})

--- a/components/atoms/BitmapText/index.ts
+++ b/components/atoms/BitmapText/index.ts
@@ -1,0 +1,2 @@
+export { BitmapText } from './BitmapText'
+export type { BitmapTextProps, BitmapTextTone } from './BitmapText'

--- a/components/atoms/CRTPixelButton/CRTPixelButton.tsx
+++ b/components/atoms/CRTPixelButton/CRTPixelButton.tsx
@@ -1,0 +1,31 @@
+import { forwardRef, type ReactNode } from 'react'
+
+export type CRTPixelButtonProps = {
+  children: ReactNode
+  type?: 'button' | 'submit'
+  disabled?: boolean
+  onClick?: () => void
+  fullWidth?: boolean
+  className?: string
+}
+
+export const CRTPixelButton = forwardRef<HTMLButtonElement, CRTPixelButtonProps>(
+  function CRTPixelButton(
+    { children, type = 'button', disabled = false, onClick, fullWidth = true, className },
+    ref,
+  ) {
+    const cls = className ? `cpb ${className}` : 'cpb'
+    return (
+      <button
+        ref={ref}
+        type={type}
+        disabled={disabled}
+        onClick={onClick}
+        className={cls}
+        data-inline={fullWidth ? undefined : 'true'}
+      >
+        {children}
+      </button>
+    )
+  },
+)

--- a/components/atoms/CRTPixelButton/__tests__/CRTPixelButton.test.tsx
+++ b/components/atoms/CRTPixelButton/__tests__/CRTPixelButton.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CRTPixelButton } from '../CRTPixelButton'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('CRTPixelButton rendering', () => {
+  it('renders children with the cpb class', () => {
+    render(<CRTPixelButton>{'> LOG IN'}</CRTPixelButton>)
+    const btn = screen.getByRole('button', { name: '> LOG IN' })
+    expect(btn).toHaveClass('cpb')
+  })
+
+  it('default type is button', () => {
+    render(<CRTPixelButton>X</CRTPixelButton>)
+    const btn = screen.getByRole('button', { name: 'X' }) as HTMLButtonElement
+    expect(btn.type).toBe('button')
+  })
+
+  it('type=submit propagates to the underlying button', () => {
+    render(<CRTPixelButton type='submit'>SUBMIT</CRTPixelButton>)
+    const btn = screen.getByRole('button', { name: 'SUBMIT' }) as HTMLButtonElement
+    expect(btn.type).toBe('submit')
+  })
+
+  it('disabled=true sets the disabled attribute', () => {
+    render(<CRTPixelButton disabled>X</CRTPixelButton>)
+    const btn = screen.getByRole('button', { name: 'X' }) as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+  })
+
+  it('click handler fires when not disabled', () => {
+    const onClick = vi.fn()
+    render(<CRTPixelButton onClick={onClick}>GO</CRTPixelButton>)
+    fireEvent.click(screen.getByRole('button', { name: 'GO' }))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('click handler does not fire when disabled', () => {
+    const onClick = vi.fn()
+    render(
+      <CRTPixelButton disabled onClick={onClick}>
+        NOPE
+      </CRTPixelButton>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'NOPE' }))
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('fullWidth=false sets data-inline="true"', () => {
+    render(<CRTPixelButton fullWidth={false}>X</CRTPixelButton>)
+    const btn = screen.getByRole('button', { name: 'X' })
+    expect(btn).toHaveAttribute('data-inline', 'true')
+  })
+
+  it('fullWidth=true (default) omits data-inline', () => {
+    render(<CRTPixelButton>X</CRTPixelButton>)
+    const btn = screen.getByRole('button', { name: 'X' })
+    expect(btn).not.toHaveAttribute('data-inline')
+  })
+})

--- a/components/atoms/CRTPixelButton/index.ts
+++ b/components/atoms/CRTPixelButton/index.ts
@@ -1,0 +1,2 @@
+export { CRTPixelButton } from './CRTPixelButton'
+export type { CRTPixelButtonProps } from './CRTPixelButton'

--- a/components/atoms/TerminalInput/TerminalInput.tsx
+++ b/components/atoms/TerminalInput/TerminalInput.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { forwardRef, useId, useState } from 'react'
+
+export type TerminalInputProps = {
+  id?: string
+  name: string
+  type?: 'text' | 'email' | 'password'
+  label: string
+  defaultValue?: string
+  autoComplete?: string
+  required?: boolean
+  reducedMotionOverride?: boolean
+}
+
+export const TerminalInput = forwardRef<HTMLInputElement, TerminalInputProps>(
+  function TerminalInput(
+    {
+      id,
+      name,
+      type = 'text',
+      label,
+      defaultValue,
+      autoComplete,
+      required,
+      reducedMotionOverride,
+    },
+    ref,
+  ) {
+    const reactId = useId()
+    const inputId = id ?? `ti-${reactId}`
+    const [focused, setFocused] = useState(false)
+    const rmValue =
+      reducedMotionOverride === undefined ? undefined : String(reducedMotionOverride)
+
+    return (
+      <div className='ti'>
+        <label htmlFor={inputId} className='ti-label'>
+          {label}
+        </label>
+        <div
+          className='ti-wrap'
+          data-focused={focused ? 'true' : 'false'}
+          data-rm={rmValue}
+          data-testid='ti-wrap'
+        >
+          <input
+            ref={ref}
+            id={inputId}
+            name={name}
+            type={type}
+            defaultValue={defaultValue}
+            autoComplete={autoComplete}
+            required={required}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
+            className='ti-field'
+          />
+          <span className='ti-cursor' aria-hidden='true' data-testid='ti-cursor' />
+        </div>
+      </div>
+    )
+  },
+)

--- a/components/atoms/TerminalInput/__tests__/TerminalInput.test.tsx
+++ b/components/atoms/TerminalInput/__tests__/TerminalInput.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { TerminalInput } from '../TerminalInput'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('TerminalInput rendering', () => {
+  it('renders label + input + cursor span', () => {
+    render(<TerminalInput name='email' label='EMAIL' />)
+    expect(screen.getByText('EMAIL')).toBeInTheDocument()
+    expect(screen.getByLabelText('EMAIL')).toBeInTheDocument()
+    expect(screen.getByTestId('ti-cursor')).toBeInTheDocument()
+  })
+
+  it('label htmlFor links the input via useId when no id prop is provided', () => {
+    render(<TerminalInput name='email' label='EMAIL' />)
+    const input = screen.getByLabelText('EMAIL') as HTMLInputElement
+    const label = screen.getByText('EMAIL') as HTMLLabelElement
+    expect(label.htmlFor).toBeTruthy()
+    expect(label.htmlFor).toBe(input.id)
+  })
+
+  it('explicit id prop overrides the generated id', () => {
+    render(<TerminalInput id='custom-id' name='email' label='EMAIL' />)
+    const input = screen.getByLabelText('EMAIL') as HTMLInputElement
+    expect(input.id).toBe('custom-id')
+  })
+
+  it('defaultValue pre-fills the input', () => {
+    render(
+      <TerminalInput
+        name='email'
+        label='EMAIL'
+        defaultValue='admin@tracker.local'
+      />,
+    )
+    const input = screen.getByLabelText('EMAIL') as HTMLInputElement
+    expect(input.value).toBe('admin@tracker.local')
+  })
+
+  it('focus flips data-focused on the wrap, blur resets it', () => {
+    render(<TerminalInput name='email' label='EMAIL' />)
+    const wrap = screen.getByTestId('ti-wrap')
+    const input = screen.getByLabelText('EMAIL')
+
+    expect(wrap).toHaveAttribute('data-focused', 'false')
+    fireEvent.focus(input)
+    expect(wrap).toHaveAttribute('data-focused', 'true')
+    fireEvent.blur(input)
+    expect(wrap).toHaveAttribute('data-focused', 'false')
+  })
+
+  it('reducedMotionOverride=true sets data-rm="true" on the wrap', () => {
+    render(
+      <TerminalInput name='email' label='EMAIL' reducedMotionOverride={true} />,
+    )
+    const wrap = screen.getByTestId('ti-wrap')
+    expect(wrap).toHaveAttribute('data-rm', 'true')
+  })
+
+  it('reducedMotionOverride=false sets data-rm="false" on the wrap', () => {
+    render(
+      <TerminalInput name='email' label='EMAIL' reducedMotionOverride={false} />,
+    )
+    const wrap = screen.getByTestId('ti-wrap')
+    expect(wrap).toHaveAttribute('data-rm', 'false')
+  })
+
+  it('omits data-rm when reducedMotionOverride is not provided', () => {
+    render(<TerminalInput name='email' label='EMAIL' />)
+    const wrap = screen.getByTestId('ti-wrap')
+    expect(wrap).not.toHaveAttribute('data-rm')
+  })
+
+  it('type=password renders a password input', () => {
+    render(<TerminalInput name='password' label='PASSWORD' type='password' />)
+    const input = screen.getByLabelText('PASSWORD') as HTMLInputElement
+    expect(input.type).toBe('password')
+  })
+
+  it('passes autoComplete and required through to the input', () => {
+    render(
+      <TerminalInput
+        name='email'
+        label='EMAIL'
+        autoComplete='email'
+        required
+      />,
+    )
+    const input = screen.getByLabelText('EMAIL') as HTMLInputElement
+    expect(input.autocomplete).toBe('email')
+    expect(input.required).toBe(true)
+  })
+})

--- a/components/atoms/TerminalInput/index.ts
+++ b/components/atoms/TerminalInput/index.ts
@@ -1,0 +1,2 @@
+export { TerminalInput } from './TerminalInput'
+export type { TerminalInputProps } from './TerminalInput'

--- a/components/molecules/CRTBezel/CRTBezel.tsx
+++ b/components/molecules/CRTBezel/CRTBezel.tsx
@@ -1,0 +1,137 @@
+import type { ReactNode } from 'react'
+
+export type CRTBezelSize = 'login' | 'hero'
+
+export type CRTBezelProps = {
+  children: ReactNode
+  size?: CRTBezelSize
+  className?: string
+}
+
+export function CRTBezel({ children, size = 'login', className }: CRTBezelProps) {
+  const cls = className ? `crt bg-noise ${className}` : 'crt bg-noise'
+  return (
+    <div className={cls} data-size={size}>
+      <svg
+        className='crt-shell'
+        viewBox='0 0 800 600'
+        preserveAspectRatio='none'
+        aria-hidden='true'
+      >
+        <defs>
+          <linearGradient id='shellH' x1='0' y1='0' x2='0' y2='1'>
+            <stop offset='0' stopColor='#D9CFB8' />
+            <stop offset='0.5' stopColor='#C9BFA8' />
+            <stop offset='1' stopColor='#A89E87' />
+          </linearGradient>
+          <linearGradient id='shellHi' x1='0' y1='0' x2='0' y2='1'>
+            <stop offset='0' stopColor='#E8DEC4' />
+            <stop offset='1' stopColor='#C9BFA8' stopOpacity='0' />
+          </linearGradient>
+          <linearGradient id='chinG' x1='0' y1='0' x2='0' y2='1'>
+            <stop offset='0' stopColor='#BFB59E' />
+            <stop offset='1' stopColor='#9C927B' />
+          </linearGradient>
+          <radialGradient id='ledG' cx='0.5' cy='0.5' r='0.5'>
+            <stop offset='0' stopColor='#A8FF7B' />
+            <stop offset='0.5' stopColor='#5DD46B' />
+            <stop offset='1' stopColor='#2C5C2F' />
+          </radialGradient>
+        </defs>
+
+        <rect x='0' y='0' width='800' height='600' fill='url(#shellH)' />
+        <rect x='0' y='0' width='800' height='120' fill='url(#shellHi)' opacity='0.55' />
+
+        <rect x='48' y='36' width='704' height='478' fill='#1A1426' />
+        <rect
+          x='48'
+          y='36'
+          width='704'
+          height='478'
+          fill='none'
+          stroke='#5C5443'
+          strokeWidth='2'
+        />
+        <rect x='50' y='38' width='700' height='2' fill='#2A1F3A' />
+        <rect x='46' y='34' width='708' height='2' fill='#8E8470' />
+
+        <rect x='0' y='514' width='800' height='86' fill='url(#chinG)' />
+        <rect x='0' y='514' width='800' height='2' fill='#5C5443' />
+        <rect x='0' y='516' width='800' height='2' fill='#E8DEC4' opacity='0.5' />
+
+        <g opacity='0.55'>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <rect
+              key={`vent-l-${i}`}
+              x={66 + i * 9}
+              y='540'
+              width='3'
+              height='40'
+              fill='#5C5443'
+            />
+          ))}
+        </g>
+        <g opacity='0.55'>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <rect
+              key={`vent-r-${i}`}
+              x={680 + i * 9}
+              y='540'
+              width='3'
+              height='40'
+              fill='#5C5443'
+            />
+          ))}
+        </g>
+
+        <g transform='translate(400, 562)' textAnchor='middle'>
+          <text
+            x='0'
+            y='0'
+            fontFamily='IBM Plex Mono, monospace'
+            fontSize='14'
+            fontWeight='700'
+            letterSpacing='6'
+            fill='#5C5443'
+            opacity='0.85'
+          >
+            CUATRO
+          </text>
+          <text
+            x='0'
+            y='-1'
+            fontFamily='IBM Plex Mono, monospace'
+            fontSize='14'
+            fontWeight='700'
+            letterSpacing='6'
+            fill='#E8DEC4'
+            opacity='0.4'
+          >
+            CUATRO
+          </text>
+        </g>
+
+        <circle cx='730' cy='558' r='5' fill='url(#ledG)' />
+        <circle cx='730' cy='558' r='9' fill='#5DD46B' opacity='0.18' />
+        <text
+          x='710'
+          y='562'
+          fontFamily='IBM Plex Mono, monospace'
+          fontSize='9'
+          letterSpacing='2'
+          fill='#5C5443'
+          textAnchor='end'
+        >
+          PWR
+        </text>
+
+        <rect x='0' y='0' width='6' height='600' fill='#000' opacity='0.18' />
+        <rect x='794' y='0' width='6' height='600' fill='#000' opacity='0.18' />
+        <rect x='0' y='0' width='800' height='3' fill='#fff' opacity='0.25' />
+      </svg>
+      <div className='crt-screen-wrap' data-testid='crt-screen-wrap'>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/components/molecules/CRTBezel/__tests__/CRTBezel.test.tsx
+++ b/components/molecules/CRTBezel/__tests__/CRTBezel.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { CRTBezel } from '../CRTBezel'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('CRTBezel rendering', () => {
+  it('renders an svg with viewBox 0 0 800 600', () => {
+    const { container } = render(
+      <CRTBezel>
+        <span>inside</span>
+      </CRTBezel>,
+    )
+    const svg = container.querySelector('svg.crt-shell')
+    expect(svg).not.toBeNull()
+    expect(svg).toHaveAttribute('viewBox', '0 0 800 600')
+  })
+
+  it('the outer .crt div carries the bg-noise utility', () => {
+    const { container } = render(
+      <CRTBezel>
+        <span>x</span>
+      </CRTBezel>,
+    )
+    const outer = container.querySelector('.crt')
+    expect(outer).not.toBeNull()
+    expect(outer).toHaveClass('bg-noise')
+  })
+
+  it('renders the embossed CUATRO chin wordmark (twice for the embossed shadow)', () => {
+    const { container } = render(
+      <CRTBezel>
+        <span>x</span>
+      </CRTBezel>,
+    )
+    const wordmarks = container.querySelectorAll('text')
+    const cuatroTexts = Array.from(wordmarks).filter((t) =>
+      t.textContent === 'CUATRO',
+    )
+    expect(cuatroTexts.length).toBe(2)
+  })
+
+  it('renders the power LED as two circles + a PWR label', () => {
+    const { container } = render(
+      <CRTBezel>
+        <span>x</span>
+      </CRTBezel>,
+    )
+    const circles = container.querySelectorAll('circle')
+    expect(circles.length).toBe(2)
+    const pwrLabel = Array.from(container.querySelectorAll('text')).find(
+      (t) => t.textContent === 'PWR',
+    )
+    expect(pwrLabel).toBeDefined()
+  })
+
+  it('children render inside the .crt-screen-wrap slot', () => {
+    render(
+      <CRTBezel>
+        <p>SCREEN CONTENT</p>
+      </CRTBezel>,
+    )
+    const wrap = screen.getByTestId('crt-screen-wrap')
+    expect(wrap).toHaveClass('crt-screen-wrap')
+    expect(wrap.textContent).toBe('SCREEN CONTENT')
+  })
+
+  it('does NOT render the bundle internal grain filter (stripped per OI #10)', () => {
+    const { container } = render(
+      <CRTBezel>
+        <span>x</span>
+      </CRTBezel>,
+    )
+    const grainFilter = container.querySelector('filter#grain')
+    expect(grainFilter).toBeNull()
+  })
+
+  it('default size renders data-size="login" on the outer div', () => {
+    const { container } = render(
+      <CRTBezel>
+        <span>x</span>
+      </CRTBezel>,
+    )
+    const outer = container.querySelector('.crt')
+    expect(outer).toHaveAttribute('data-size', 'login')
+  })
+
+  it('size="hero" renders data-size="hero" on the outer div', () => {
+    const { container } = render(
+      <CRTBezel size='hero'>
+        <span>x</span>
+      </CRTBezel>,
+    )
+    const outer = container.querySelector('.crt')
+    expect(outer).toHaveAttribute('data-size', 'hero')
+  })
+})

--- a/components/molecules/CRTBezel/index.ts
+++ b/components/molecules/CRTBezel/index.ts
@@ -1,0 +1,2 @@
+export { CRTBezel } from './CRTBezel'
+export type { CRTBezelProps, CRTBezelSize } from './CRTBezel'

--- a/components/organisms/LoginCRT/LoginCRT.tsx
+++ b/components/organisms/LoginCRT/LoginCRT.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import type { FormEvent } from 'react'
+import { BitmapText } from '@/components/atoms/BitmapText'
+import { CRTPixelButton } from '@/components/atoms/CRTPixelButton'
+import { TerminalInput } from '@/components/atoms/TerminalInput'
+import { CRTBezel } from '@/components/molecules/CRTBezel'
+
+export type LoginCRTProps = {
+  onSubmit: (data: { email: string; password: string }) => Promise<void> | void
+  error?: string | null
+  pending?: boolean
+  defaultEmail?: string
+  reducedMotionOverride?: boolean
+}
+
+export function LoginCRT({
+  onSubmit,
+  error,
+  pending = false,
+  defaultEmail = 'admin@tracker.local',
+  reducedMotionOverride,
+}: LoginCRTProps) {
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (pending) return
+    const form = e.currentTarget
+    const email = (form.elements.namedItem('email') as HTMLInputElement).value
+    const password = (form.elements.namedItem('password') as HTMLInputElement).value
+    void onSubmit({ email, password })
+  }
+
+  return (
+    <CRTBezel>
+      <div className='lc-screen'>
+        <header className='bt-header'>
+          <span className='bt-blocks' aria-hidden='true'>
+            <span className='bt-b1'>▓</span>
+            <span className='bt-b2'>▓</span>
+            <span className='bt-b3'>▓</span>
+          </span>
+          <BitmapText size={30} glow>
+            CUATRO TRACKER
+          </BitmapText>
+          <span className='bt-blocks' aria-hidden='true'>
+            <span className='bt-b3'>▓</span>
+            <span className='bt-b2'>▓</span>
+            <span className='bt-b1'>▓</span>
+          </span>
+        </header>
+
+        <BitmapText size={20} tone='cream-dim' as='div'>
+          VERSION 0.2.0
+        </BitmapText>
+        <BitmapText size={16} tone='cream-ghost' as='div'>
+          (C) CUATRO DEVELOPMENT STUDIO, 2026. ALL RIGHTS RESERVED.
+        </BitmapText>
+
+        <form className='lc-form' onSubmit={handleSubmit} noValidate>
+          <TerminalInput
+            name='email'
+            type='email'
+            label='EMAIL'
+            required
+            autoComplete='email'
+            defaultValue={defaultEmail}
+            reducedMotionOverride={reducedMotionOverride}
+          />
+          <TerminalInput
+            name='password'
+            type='password'
+            label='PASSWORD'
+            required
+            autoComplete='current-password'
+            reducedMotionOverride={reducedMotionOverride}
+          />
+          {error ? (
+            <BitmapText size={18} tone='magenta' as='p' className='lc-error'>
+              {error}
+            </BitmapText>
+          ) : null}
+          <CRTPixelButton type='submit' disabled={pending}>
+            {'> LOG IN'}
+          </CRTPixelButton>
+        </form>
+      </div>
+    </CRTBezel>
+  )
+}

--- a/components/organisms/LoginCRT/__tests__/LoginCRT.test.tsx
+++ b/components/organisms/LoginCRT/__tests__/LoginCRT.test.tsx
@@ -1,0 +1,92 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { LoginCRT } from '../LoginCRT'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('LoginCRT rendering', () => {
+  it('renders the bitmap header, version line, copyright, and submit button', () => {
+    render(<LoginCRT onSubmit={vi.fn()} />)
+    expect(screen.getByText('CUATRO TRACKER')).toBeInTheDocument()
+    expect(screen.getByText('VERSION 0.2.0')).toBeInTheDocument()
+    expect(
+      screen.getByText('(C) CUATRO DEVELOPMENT STUDIO, 2026. ALL RIGHTS RESERVED.'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '> LOG IN' })).toBeInTheDocument()
+  })
+
+  it('renders email + password inputs with their labels', () => {
+    render(<LoginCRT onSubmit={vi.fn()} />)
+    expect(screen.getByLabelText('EMAIL')).toBeInTheDocument()
+    expect(screen.getByLabelText('PASSWORD')).toBeInTheDocument()
+  })
+
+  it('email defaults to admin@tracker.local (AC-5)', () => {
+    render(<LoginCRT onSubmit={vi.fn()} />)
+    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
+    expect(email.value).toBe('admin@tracker.local')
+  })
+
+  it('defaultEmail prop overrides the default value', () => {
+    render(<LoginCRT onSubmit={vi.fn()} defaultEmail='someone@example.com' />)
+    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
+    expect(email.value).toBe('someone@example.com')
+  })
+
+  it('submit invokes onSubmit with the current form values', () => {
+    const onSubmit = vi.fn()
+    render(<LoginCRT onSubmit={onSubmit} />)
+    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
+    const password = screen.getByLabelText('PASSWORD') as HTMLInputElement
+    fireEvent.change(email, { target: { value: 'a@b.c' } })
+    fireEvent.change(password, { target: { value: 'pw' } })
+    fireEvent.submit(email.closest('form')!)
+    expect(onSubmit).toHaveBeenCalledWith({ email: 'a@b.c', password: 'pw' })
+  })
+
+  it('pending=true disables the submit button', () => {
+    render(<LoginCRT onSubmit={vi.fn()} pending={true} />)
+    const btn = screen.getByRole('button', { name: '> LOG IN' }) as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+  })
+
+  it('pending=false leaves the submit button enabled', () => {
+    render(<LoginCRT onSubmit={vi.fn()} pending={false} />)
+    const btn = screen.getByRole('button', { name: '> LOG IN' }) as HTMLButtonElement
+    expect(btn.disabled).toBe(false)
+  })
+
+  it('error string renders the magenta error line', () => {
+    render(
+      <LoginCRT onSubmit={vi.fn()} error='Invalid email or password.' />,
+    )
+    const errorLine = screen.getByText('Invalid email or password.')
+    expect(errorLine).toBeInTheDocument()
+    expect(errorLine).toHaveClass('lc-error')
+    expect(errorLine.style.getPropertyValue('--bt-color')).toBe('var(--magenta)')
+  })
+
+  it('null/undefined error does NOT render the error line', () => {
+    render(<LoginCRT onSubmit={vi.fn()} error={null} />)
+    expect(
+      screen.queryByText('Invalid email or password.'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('threads reducedMotionOverride to both TerminalInputs', () => {
+    render(<LoginCRT onSubmit={vi.fn()} reducedMotionOverride={true} />)
+    const wraps = screen.getAllByTestId('ti-wrap')
+    expect(wraps).toHaveLength(2)
+    wraps.forEach((w) => expect(w).toHaveAttribute('data-rm', 'true'))
+  })
+
+  it('pending=true blocks form-level submit (Enter key) from invoking onSubmit again', () => {
+    const onSubmit = vi.fn()
+    render(<LoginCRT onSubmit={onSubmit} pending={true} />)
+    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
+    fireEvent.submit(email.closest('form')!)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/components/organisms/LoginCRT/index.ts
+++ b/components/organisms/LoginCRT/index.ts
@@ -1,0 +1,2 @@
+export { LoginCRT } from './LoginCRT'
+export type { LoginCRTProps } from './LoginCRT'


### PR DESCRIPTION
## Summary

Rebuilds `/login` against the 2026-04-26 design bundle. Replaces the scaffold form with a beige CRT bezel SVG, bitmap header, terminal inputs with neon-blue focus underlines + blinking phosphor-cream cursor blocks, and a `> LOG IN` CRT-pixel button. Preserves the NextAuth round-trip (`signIn('credentials', { email, password, redirect: false })`), `defaultValue="admin@tracker.local"`, and the `Invalid email or password.` error path verbatim.

Ships 5 new components per ` docs/component-inventory.md`:

- **Atoms:** `BitmapText`, `TerminalInput` (real `<span>` cursor with CSS-driven blink + `data-rm` reduced-motion escape), `CRTPixelButton`.
- **Molecule:** `CRTBezel` — lifts the bundle's SVG verbatim (gradients, vents, embossed `CUATRO` chin wordmark, green power LED, side bevels) with the internal `<filter id='grain'>` stripped per OI #10 so `bg-noise` is the single canonical source.
- **Organism:** `LoginCRT` — composes bezel + header + version + copyright + form + error + submit.

CSS rules land in `app/global.css` under `.lc / .crt / .bt / .ti / .cpb` namespaces. `@media (max-width: 480px)` scales the bezel to 340px wide; `@media (prefers-reduced-motion: reduce)` zeros the cursor blink. Bumps IBM Plex Mono to weights `['400', '500', '600']` so `.ti-label` (font-weight: 500) doesn't fall back to synthetic bold.

49 new tests across 6 files (BitmapText 8, TerminalInput 10, CRTPixelButton 8, CRTBezel 8, LoginCRT 11, login page 4). bmad-code-review (Edge Case Hunter + Acceptance Auditor): 0 violations across 5 ACs + 11 OIs; 2 patches applied (form-level double-submit guard, `.lc-error` overflow-wrap); 3 defers logged in `deferred-work.md`.

Closes #86

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean
- [ ] `pnpm vitest run components/atoms/BitmapText components/atoms/TerminalInput components/atoms/CRTPixelButton components/molecules/CRTBezel components/organisms/LoginCRT 'app/(auth)/login'` → 49 passed
- [ ] Visit `http://127.0.0.1:3000/login` (logged out). Frame A renders: centered beige CRT bezel, rainbow `▓▓▓ CUATRO TRACKER ▓▓▓`, version + copyright, `admin@tracker.local` pre-filled, `> LOG IN` button.
- [ ] Frame B: focus EMAIL field → 2px neon-blue bottom border + box-shadow stack + 9×18px cream cursor block blinking at 1s.
- [ ] Frame C: focus PASSWORD field → same focus treatment, EMAIL returns to default.
- [ ] Frame J: OS reduced-motion ON → cursor renders solid.
- [ ] Resize to 480px width → bezel scales to ~340px, form gap drops to 16px.
- [ ] Submit with bad password → magenta `Invalid email or password.` appears, button re-enables.
- [ ] Submit with `${ADMIN_PASS}` → navigates to `/`.

Visual verification target: `docs/delivery/3-1-login-chrome.md` § How to verify.