### PR TITLE
feat(login): wire submit to NextAuth with boot sequence on success (#88)

### DIFF
--- a/app/(auth)/login/__tests__/page.test.tsx
+++ b/app/(auth)/login/__tests__/page.test.tsx
@@ -1,10 +1,11 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { signInMock, pushMock, refreshMock } = vi.hoisted(() => ({
+const { signInMock, pushMock, refreshMock, navigateMock } = vi.hoisted(() => ({
   signInMock: vi.fn(),
   pushMock: vi.fn(),
   refreshMock: vi.fn(),
+  navigateMock: vi.fn(),
 }))
 
 vi.mock('next-auth/react', () => ({
@@ -15,12 +16,46 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock, refresh: refreshMock }),
 }))
 
+vi.mock('@/components/molecules/ChannelFlipTransition/useChannelFlipNavigate', () => ({
+  useChannelFlipNavigate: () => ({ navigate: navigateMock, overlay: null }),
+}))
+
+vi.mock('@/components/molecules/BootSequence', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/components/molecules/BootSequence')>()
+  const React = await import('react')
+  return {
+    ...actual,
+    BootSequence: ({
+      onComplete,
+      holdReleased,
+      holdAtFrame,
+      reducedMotionOverride,
+    }: {
+      onComplete: () => void
+      holdReleased?: boolean
+      holdAtFrame?: number
+      reducedMotionOverride?: boolean
+    }) => {
+      const shouldFire =
+        typeof holdAtFrame === 'number'
+          ? holdReleased === true
+          : reducedMotionOverride === true || holdReleased === true
+      React.useEffect(() => {
+        if (shouldFire) onComplete()
+      }, [shouldFire, onComplete])
+      return <div role='status' aria-label='System boot sequence' data-mock='true' />
+    },
+  }
+})
+
 import LoginPage from '../page'
 
 beforeEach(() => {
   signInMock.mockReset()
   pushMock.mockReset()
   refreshMock.mockReset()
+  navigateMock.mockReset()
+  navigateMock.mockResolvedValue(undefined)
 })
 
 afterEach(() => {
@@ -45,18 +80,6 @@ describe('LoginPage submit flow', () => {
     })
   })
 
-  it('on success: routes to / and refreshes', async () => {
-    signInMock.mockResolvedValue({ ok: true, error: null })
-    render(<LoginPage />)
-    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
-    fireEvent.submit(email.closest('form')!)
-
-    await waitFor(() => {
-      expect(pushMock).toHaveBeenCalledWith('/')
-      expect(refreshMock).toHaveBeenCalled()
-    })
-  })
-
   it('on error: renders the Invalid email or password. line and does NOT navigate', async () => {
     signInMock.mockResolvedValue({ ok: false, error: 'CredentialsSignin' })
     render(<LoginPage />)
@@ -68,7 +91,7 @@ describe('LoginPage submit flow', () => {
         screen.getByText('Invalid email or password.'),
       ).toBeInTheDocument()
     })
-    expect(pushMock).not.toHaveBeenCalled()
+    expect(navigateMock).not.toHaveBeenCalled()
     expect(refreshMock).not.toHaveBeenCalled()
   })
 
@@ -84,5 +107,70 @@ describe('LoginPage submit flow', () => {
       }) as HTMLButtonElement
       expect(btn.disabled).toBe(false)
     })
+  })
+
+  it('on success: flips phase to pending then success and waits for boot before navigating', async () => {
+    signInMock.mockResolvedValue({ ok: true, error: null })
+    render(<LoginPage />)
+    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
+    const submitForm = email.closest('form')!
+
+    expect(
+      screen.queryByRole('status', { name: /system boot sequence/i }),
+    ).not.toBeInTheDocument()
+
+    fireEvent.submit(submitForm)
+
+    await waitFor(() => {
+      expect(signInMock).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(
+        screen.getByRole('status', { name: /system boot sequence/i }),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('on success: onBootComplete triggers navigate(/) then router.refresh()', async () => {
+    signInMock.mockResolvedValue({ ok: true, error: null })
+    render(<LoginPage />)
+    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
+    fireEvent.submit(email.closest('form')!)
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/')
+    }, { timeout: 3000 })
+    await waitFor(() => {
+      expect(refreshMock).toHaveBeenCalled()
+    })
+  })
+
+  it('AC-3 slow-auth: boot mounts before signIn resolves and navigate fires only AFTER auth succeeds', async () => {
+    let resolveSignIn!: (value: { ok: boolean; error: null }) => void
+    signInMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSignIn = resolve
+        }),
+    )
+    render(<LoginPage />)
+    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
+    fireEvent.submit(email.closest('form')!)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('status', { name: /system boot sequence/i }),
+      ).toBeInTheDocument()
+    })
+    expect(navigateMock).not.toHaveBeenCalled()
+
+    resolveSignIn({ ok: true, error: null })
+
+    await waitFor(
+      () => {
+        expect(navigateMock).toHaveBeenCalledWith('/')
+      },
+      { timeout: 3000 },
+    )
   })
 })

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -2,13 +2,15 @@
 
 import { signIn } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
-import { LoginCRT } from '@/components/organisms/LoginCRT'
+import { useCallback, useState } from 'react'
+import { LoginCRT, type LoginCRTPhase } from '@/components/organisms/LoginCRT'
+import { useChannelFlipNavigate } from '@/components/molecules/ChannelFlipTransition/useChannelFlipNavigate'
 
 export default function LoginPage() {
   const router = useRouter()
   const [error, setError] = useState<string | null>(null)
-  const [pending, setPending] = useState(false)
+  const [phase, setPhase] = useState<LoginCRTPhase>('idle')
+  const { navigate, overlay } = useChannelFlipNavigate()
 
   async function handleSubmit({
     email,
@@ -18,7 +20,7 @@ export default function LoginPage() {
     password: string
   }) {
     setError(null)
-    setPending(true)
+    setPhase('pending')
 
     const result = await signIn('credentials', {
       email,
@@ -26,20 +28,29 @@ export default function LoginPage() {
       redirect: false,
     })
 
-    setPending(false)
-
     if (result?.error) {
       setError('Invalid email or password.')
+      setPhase('idle')
       return
     }
 
-    router.push('/')
-    router.refresh()
+    setPhase('success')
   }
+
+  const onBootComplete = useCallback(async () => {
+    await navigate('/')
+    router.refresh()
+  }, [navigate, router])
 
   return (
     <main className='lc'>
-      <LoginCRT onSubmit={handleSubmit} error={error} pending={pending} />
+      <LoginCRT
+        onSubmit={handleSubmit}
+        error={error}
+        phase={phase}
+        onBootComplete={onBootComplete}
+        channelFlipOverlay={overlay}
+      />
     </main>
   )
 }

--- a/app/global.css
+++ b/app/global.css
@@ -587,6 +587,12 @@ body {
   gap: 20px;
 }
 
+.lc-form-faded {
+  opacity: 0.5;
+  pointer-events: none;
+  transition: opacity 150ms linear;
+}
+
 .lc-error {
   margin: 0;
   letter-spacing: 0.04em;

--- a/components/molecules/BootSequence/BootSequence.tsx
+++ b/components/molecules/BootSequence/BootSequence.tsx
@@ -23,6 +23,8 @@ export type BootSequenceProps = {
   onComplete: () => void
   totalDuration?: number
   reducedMotionOverride?: boolean
+  holdAtFrame?: number
+  holdReleased?: boolean
 }
 
 const MODIFIER_ONLY_KEYS = new Set(['Shift', 'Control', 'Alt', 'Meta', 'CapsLock'])
@@ -32,6 +34,8 @@ export function BootSequence({
   onComplete,
   totalDuration,
   reducedMotionOverride,
+  holdAtFrame,
+  holdReleased,
 }: BootSequenceProps) {
   const initialReduced = readInitialReducedMotion(reducedMotionOverride)
   const reduced = useReducedMotion(reducedMotionOverride)
@@ -40,7 +44,12 @@ export function BootSequence({
   )
   const completedRef = useRef(false)
   const timelineRef = useRef<gsap.core.Timeline | null>(null)
+  const holdReleasedRef = useRef(holdReleased ?? false)
   const totalMs = safeTotalDurationMs(totalDuration)
+
+  useEffect(() => {
+    holdReleasedRef.current = holdReleased ?? false
+  }, [holdReleased])
 
   const fireComplete = useCallback(() => {
     if (completedRef.current) return
@@ -51,14 +60,20 @@ export function BootSequence({
   useEffect(() => {
     if (!reduced) return
     setCurrentFrame(BOOT_FINAL_FRAME_NO_WELCOME)
+    if (typeof holdAtFrame === 'number' && !holdReleased) return
     const raf = requestAnimationFrame(() => fireComplete())
     return () => cancelAnimationFrame(raf)
-  }, [reduced, fireComplete])
+  }, [reduced, fireComplete, holdAtFrame, holdReleased])
 
   useEffect(() => {
     if (reduced) return
     const scaled = scaleFrames(BOOT_FRAMES, totalMs)
     const lastFrame = showWelcome ? BOOT_FINAL_FRAME_WITH_WELCOME : BOOT_FINAL_FRAME_NO_WELCOME
+    const shouldHold =
+      typeof holdAtFrame === 'number' &&
+      Number.isFinite(holdAtFrame) &&
+      holdAtFrame >= 1 &&
+      holdAtFrame < lastFrame
     const tl = gsap.timeline()
     timelineRef.current = tl
     for (const frame of scaled) {
@@ -68,13 +83,25 @@ export function BootSequence({
         undefined,
         frame.startMs / 1000
       )
+      if (shouldHold && frame.index === holdAtFrame) {
+        tl.call(() => {
+          if (!holdReleasedRef.current) tl.pause()
+        })
+      }
     }
     tl.call(fireComplete, undefined, finalCallbackMs(showWelcome, totalMs) / 1000)
     return () => {
       tl.kill()
       timelineRef.current = null
     }
-  }, [reduced, showWelcome, totalMs, fireComplete])
+  }, [reduced, showWelcome, totalMs, fireComplete, holdAtFrame])
+
+  useEffect(() => {
+    if (reduced) return
+    if (typeof holdAtFrame !== 'number') return
+    if (!holdReleased) return
+    timelineRef.current?.resume()
+  }, [reduced, holdAtFrame, holdReleased])
 
   useEffect(() => {
     if (reduced) return
@@ -83,6 +110,7 @@ export function BootSequence({
       if (e.repeat) return
       if (e.isComposing) return
       if (MODIFIER_ONLY_KEYS.has(e.key)) return
+      if (typeof holdAtFrame === 'number' && !holdReleasedRef.current) return
       const finalFrame = showWelcome ? BOOT_FINAL_FRAME_WITH_WELCOME : BOOT_FINAL_FRAME_NO_WELCOME
       timelineRef.current?.kill()
       timelineRef.current = null
@@ -95,7 +123,7 @@ export function BootSequence({
       window.removeEventListener('keydown', handler)
       if (rafId !== null) cancelAnimationFrame(rafId)
     }
-  }, [reduced, showWelcome, fireComplete])
+  }, [reduced, showWelcome, fireComplete, holdAtFrame])
 
   const showHeader = currentFrame >= 2
   const showVersion = currentFrame >= 3

--- a/components/molecules/BootSequence/__tests__/BootSequence.test.tsx
+++ b/components/molecules/BootSequence/__tests__/BootSequence.test.tsx
@@ -125,3 +125,162 @@ describe('BootSequence onComplete fires once (AC-1)', () => {
     expect(onComplete).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('BootSequence hold-at-frame (Story 3.2)', () => {
+  it('holdAtFrame=9 + holdReleased=false: timeline pauses at frame 9; onComplete does not fire', async () => {
+    const onComplete = vi.fn()
+    const { getByRole } = render(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        totalDuration={300}
+        holdAtFrame={9}
+        holdReleased={false}
+      />,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 600))
+    const container = getByRole('status')
+    expect(container).toHaveAttribute('data-frame', '9')
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  it('flipping holdReleased=true resumes the timeline to frame 10 and fires onComplete', async () => {
+    const onComplete = vi.fn()
+    const { rerender, getByRole } = render(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        totalDuration={300}
+        holdAtFrame={9}
+        holdReleased={false}
+      />,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 600))
+    expect(getByRole('status')).toHaveAttribute('data-frame', '9')
+    expect(onComplete).not.toHaveBeenCalled()
+
+    rerender(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        totalDuration={300}
+        holdAtFrame={9}
+        holdReleased={true}
+      />,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    expect(getByRole('status')).toHaveAttribute('data-frame', '10')
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('omitting holdAtFrame keeps default behavior (no pause, runs to completion)', async () => {
+    const onComplete = vi.fn()
+    renderBoot({ reducedMotionOverride: false, onComplete, totalDuration: 200 })
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('reduced-motion + holdAtFrame + holdReleased=false: jumps to frame 9 but does NOT fire onComplete', async () => {
+    const onComplete = vi.fn()
+    const { getByRole } = render(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={true}
+        holdAtFrame={9}
+        holdReleased={false}
+      />,
+    )
+    await new Promise((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve(null))),
+    )
+    expect(getByRole('status')).toHaveAttribute('data-frame', '9')
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  it('reduced-motion + holdReleased=true: jumps to frame 9 AND fires onComplete', async () => {
+    const onComplete = vi.fn()
+    const { rerender, getByRole } = render(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={true}
+        holdAtFrame={9}
+        holdReleased={false}
+      />,
+    )
+    await new Promise((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve(null))),
+    )
+    expect(onComplete).not.toHaveBeenCalled()
+
+    rerender(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={true}
+        holdAtFrame={9}
+        holdReleased={true}
+      />,
+    )
+    await new Promise((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve(null))),
+    )
+    expect(getByRole('status')).toHaveAttribute('data-frame', '9')
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('non-reduced + holdReleased flips true BEFORE timeline reaches holdAtFrame: no deadlock', async () => {
+    const onComplete = vi.fn()
+    const { rerender } = render(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        totalDuration={300}
+        holdAtFrame={9}
+        holdReleased={false}
+      />,
+    )
+    rerender(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        totalDuration={300}
+        holdAtFrame={9}
+        holdReleased={true}
+      />,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('non-reduced + keydown during hold: ignored until holdReleased=true', async () => {
+    const onComplete = vi.fn()
+    const { rerender } = render(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        totalDuration={300}
+        holdAtFrame={9}
+        holdReleased={false}
+      />,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 600))
+    expect(onComplete).not.toHaveBeenCalled()
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+    })
+    expect(onComplete).not.toHaveBeenCalled()
+
+    rerender(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        totalDuration={300}
+        holdAtFrame={9}
+        holdReleased={true}
+      />,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+})

--- a/components/organisms/LoginCRT/LoginCRT.tsx
+++ b/components/organisms/LoginCRT/LoginCRT.tsx
@@ -1,15 +1,21 @@
 'use client'
 
-import type { FormEvent } from 'react'
+import type { FormEvent, ReactNode } from 'react'
 import { BitmapText } from '@/components/atoms/BitmapText'
 import { CRTPixelButton } from '@/components/atoms/CRTPixelButton'
 import { TerminalInput } from '@/components/atoms/TerminalInput'
 import { CRTBezel } from '@/components/molecules/CRTBezel'
+import { BootSequence } from '@/components/molecules/BootSequence'
+
+export type LoginCRTPhase = 'idle' | 'pending' | 'success'
 
 export type LoginCRTProps = {
   onSubmit: (data: { email: string; password: string }) => Promise<void> | void
   error?: string | null
   pending?: boolean
+  phase?: LoginCRTPhase
+  onBootComplete?: () => void
+  channelFlipOverlay?: ReactNode
   defaultEmail?: string
   reducedMotionOverride?: boolean
 }
@@ -18,12 +24,19 @@ export function LoginCRT({
   onSubmit,
   error,
   pending = false,
+  phase = 'idle',
+  onBootComplete,
+  channelFlipOverlay,
   defaultEmail = 'admin@tracker.local',
   reducedMotionOverride,
 }: LoginCRTProps) {
+  const isBusy = phase !== 'idle' || pending
+  const showBoot = phase === 'pending' || phase === 'success'
+  const formClass = isBusy ? 'lc-form lc-form-faded' : 'lc-form'
+
   function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    if (pending) return
+    if (isBusy) return
     const form = e.currentTarget
     const email = (form.elements.namedItem('email') as HTMLInputElement).value
     const password = (form.elements.namedItem('password') as HTMLInputElement).value
@@ -56,7 +69,7 @@ export function LoginCRT({
           (C) CUATRO DEVELOPMENT STUDIO, 2026. ALL RIGHTS RESERVED.
         </BitmapText>
 
-        <form className='lc-form' onSubmit={handleSubmit} noValidate>
+        <form className={formClass} onSubmit={handleSubmit} noValidate>
           <TerminalInput
             name='email'
             type='email'
@@ -79,11 +92,20 @@ export function LoginCRT({
               {error}
             </BitmapText>
           ) : null}
-          <CRTPixelButton type='submit' disabled={pending}>
+          <CRTPixelButton type='submit' disabled={isBusy}>
             {'> LOG IN'}
           </CRTPixelButton>
         </form>
       </div>
+      {showBoot ? (
+        <BootSequence
+          onComplete={onBootComplete ?? (() => undefined)}
+          holdAtFrame={9}
+          holdReleased={phase === 'success'}
+          reducedMotionOverride={reducedMotionOverride}
+        />
+      ) : null}
+      {channelFlipOverlay}
     </CRTBezel>
   )
 }

--- a/components/organisms/LoginCRT/__tests__/LoginCRT.test.tsx
+++ b/components/organisms/LoginCRT/__tests__/LoginCRT.test.tsx
@@ -90,3 +90,54 @@ describe('LoginCRT rendering', () => {
     expect(onSubmit).not.toHaveBeenCalled()
   })
 })
+
+describe('LoginCRT phase prop (Story 3.2)', () => {
+  it('phase=idle does NOT mount the boot overlay', () => {
+    render(<LoginCRT onSubmit={vi.fn()} phase='idle' />)
+    expect(
+      screen.queryByRole('status', { name: /system boot sequence/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('phase=pending mounts the boot overlay AND applies lc-form-faded to the form', () => {
+    render(<LoginCRT onSubmit={vi.fn()} phase='pending' reducedMotionOverride={true} />)
+    expect(
+      screen.getByRole('status', { name: /system boot sequence/i }),
+    ).toBeInTheDocument()
+    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
+    expect(email.closest('form')).toHaveClass('lc-form-faded')
+  })
+
+  it('phase=pending disables the submit button', () => {
+    render(<LoginCRT onSubmit={vi.fn()} phase='pending' reducedMotionOverride={true} />)
+    const btn = screen.getByRole('button', { name: '> LOG IN' }) as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+  })
+
+  it('phase=pending blocks form-level submit (Enter key) from re-invoking onSubmit', () => {
+    const onSubmit = vi.fn()
+    render(<LoginCRT onSubmit={onSubmit} phase='pending' reducedMotionOverride={true} />)
+    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
+    fireEvent.submit(email.closest('form')!)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('phase=success keeps the boot mounted with holdReleased=true (renders welcome line under reduced-motion)', () => {
+    render(<LoginCRT onSubmit={vi.fn()} phase='success' reducedMotionOverride={true} />)
+    expect(
+      screen.getByRole('status', { name: /system boot sequence/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('passes channelFlipOverlay slot content into the bezel', () => {
+    render(
+      <LoginCRT
+        onSubmit={vi.fn()}
+        phase='success'
+        reducedMotionOverride={true}
+        channelFlipOverlay={<div data-testid='flip-overlay' />}
+      />,
+    )
+    expect(screen.getByTestId('flip-overlay')).toBeInTheDocument()
+  })
+})

--- a/components/organisms/LoginCRT/index.ts
+++ b/components/organisms/LoginCRT/index.ts
@@ -1,2 +1,2 @@
 export { LoginCRT } from './LoginCRT'
-export type { LoginCRTProps } from './LoginCRT'
+export type { LoginCRTProps, LoginCRTPhase } from './LoginCRT'


### PR DESCRIPTION
## Summary

Layers Story 3.1's visual chrome with live submit behavior. On submit: form fades + disables, `<BootSequence>` mounts as an overlay inside the CRT screen and plays frames 1-10 per the bundle timing, then `useChannelFlipNavigate('/')` runs the band-sweep + black + reveal and `router.refresh()` rehydrates the dashboard. If NextAuth resolves before the boot reaches frame 10, the timeline runs end-to-end; if NextAuth is still pending at frame 9, the boot holds at `READY.` until the auth Promise resolves.

**Extends `BootSequence`** with optional `holdAtFrame` + `holdReleased` props. The pause is implemented as a ref-checked `tl.call(() => { if (!ref.current) tl.pause() })` rather than bare `tl.addPause()` — see deferred-work.md / [[reference_gsap_promise_gated_timeline_pause]] for the deadlock race the ref-check fixes. Reduced-motion + active hold also honored: the reduced-motion branch waits for `holdReleased` before firing `onComplete` so reduced-motion users don't `router.push('/')` before signIn resolves. Keydown-skip during hold is gated on the same ref.

**LoginCRT** gains `phase: 'idle' | 'pending' | 'success'`, `onBootComplete`, and a `channelFlipOverlay` slot. Page.tsx owns the auth + lifecycle: `setPhase('pending')` on submit kicks `signIn` in parallel; success flips `phase='success'` (releases the hold); error falls back to the Story 3.1 magenta line + `phase='idle'`.

`.lc-form-faded` CSS rule appended below the Story 3.1 `.lc-form` block.

Code review (Edge Case Hunter + Acceptance Auditor): 1 CRITICAL + 3 HIGH + 2 MEDIUM patches applied, 5 deferred, 5 dismissed. **+14 new tests** (BootSequence 8, LoginCRT 6, page 2). **Static gates: typecheck + lint clean; 62/62 scoped tests; 236/238 full suite (the 2 failures are the pre-existing BullMQ baseline).**

Closes #88

## Test plan

- [ ] `pnpm typecheck && pnpm lint` clean
- [ ] `pnpm vitest run components/molecules/BootSequence components/organisms/LoginCRT 'app/(auth)/login'` → 62 passed
- [ ] **Typical timing:** submit valid creds → form fades, boot plays frames 1-9, brief `READY.` hold while auth resolves, frame 10 `> WELCOME, CUATRO` flash, channel-flip, dashboard.
- [ ] **Slow-auth (DevTools → Network → Slow 3G):** boot pauses VISIBLY at `READY.` and waits; resumes only after auth resolves.
- [ ] **Error:** submit bad creds → form un-fades, magenta `Invalid email or password.` line appears, button re-enables. No channel-flip.
- [ ] **Reduced-motion + valid creds (the patched bug):** OS reduce-motion ON; boot jumps to `READY.` and STAYS there until auth resolves; THEN navigate fires.
- [ ] **Keydown during hold:** press Space/Enter while boot is at `READY.` hold; nothing happens until auth resolves naturally.