### PR TITLE
feat(login): wire error path with StatusBanner + reduced-motion fallback (#90)

### DIFF
--- a/app/(auth)/login/__tests__/page.test.tsx
+++ b/app/(auth)/login/__tests__/page.test.tsx
@@ -27,22 +27,33 @@ vi.mock('@/components/molecules/BootSequence', async (importOriginal) => {
     ...actual,
     BootSequence: ({
       onComplete,
+      onTruncate,
       holdReleased,
       holdAtFrame,
+      truncate,
       reducedMotionOverride,
     }: {
       onComplete: () => void
+      onTruncate?: () => void
       holdReleased?: boolean
       holdAtFrame?: number
+      truncate?: boolean
       reducedMotionOverride?: boolean
     }) => {
-      const shouldFire =
-        typeof holdAtFrame === 'number'
+      const shouldFireComplete =
+        !truncate &&
+        (typeof holdAtFrame === 'number'
           ? holdReleased === true
-          : reducedMotionOverride === true || holdReleased === true
+          : reducedMotionOverride === true || holdReleased === true)
       React.useEffect(() => {
-        if (shouldFire) onComplete()
-      }, [shouldFire, onComplete])
+        if (shouldFireComplete) onComplete()
+      }, [shouldFireComplete, onComplete])
+      React.useEffect(() => {
+        if (!truncate) return
+        if (!onTruncate) return
+        const id = setTimeout(() => onTruncate(), 0)
+        return () => clearTimeout(id)
+      }, [truncate, onTruncate])
       return <div role='status' aria-label='System boot sequence' data-mock='true' />
     },
   }
@@ -80,17 +91,16 @@ describe('LoginPage submit flow', () => {
     })
   })
 
-  it('on error: renders the Invalid email or password. line and does NOT navigate', async () => {
+  it('on error: enters error-truncating phase then settles to idle with the > ACCESS DENIED banner; does NOT navigate', async () => {
     signInMock.mockResolvedValue({ ok: false, error: 'CredentialsSignin' })
     render(<LoginPage />)
     const email = screen.getByLabelText('EMAIL') as HTMLInputElement
     fireEvent.submit(email.closest('form')!)
 
     await waitFor(() => {
-      expect(
-        screen.getByText('Invalid email or password.'),
-      ).toBeInTheDocument()
+      expect(screen.getByText('> ACCESS DENIED')).toBeInTheDocument()
     })
+    expect(screen.getByText('INVALID EMAIL OR PASSWORD')).toBeInTheDocument()
     expect(navigateMock).not.toHaveBeenCalled()
     expect(refreshMock).not.toHaveBeenCalled()
   })
@@ -107,6 +117,33 @@ describe('LoginPage submit flow', () => {
       }) as HTMLButtonElement
       expect(btn.disabled).toBe(false)
     })
+  })
+
+  it('on error: focus moves to the password field for retry', async () => {
+    signInMock.mockResolvedValue({ ok: false, error: 'CredentialsSignin' })
+    render(<LoginPage />)
+    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
+    fireEvent.submit(email.closest('form')!)
+
+    await waitFor(() => {
+      expect(screen.getByText('> ACCESS DENIED')).toBeInTheDocument()
+    })
+    expect(document.activeElement).toBe(screen.getByLabelText('PASSWORD'))
+  })
+
+  it('on error: form values are retained (email defaultValue + typed password)', async () => {
+    signInMock.mockResolvedValue({ ok: false, error: 'CredentialsSignin' })
+    render(<LoginPage />)
+    const email = screen.getByLabelText('EMAIL') as HTMLInputElement
+    const password = screen.getByLabelText('PASSWORD') as HTMLInputElement
+    fireEvent.change(password, { target: { value: 'wrong-pass' } })
+    fireEvent.submit(email.closest('form')!)
+
+    await waitFor(() => {
+      expect(screen.getByText('> ACCESS DENIED')).toBeInTheDocument()
+    })
+    expect(email.value).toBe('admin@tracker.local')
+    expect(password.value).toBe('wrong-pass')
   })
 
   it('on success: flips phase to pending then success and waits for boot before navigating', async () => {

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -29,8 +29,7 @@ export default function LoginPage() {
     })
 
     if (result?.error) {
-      setError('Invalid email or password.')
-      setPhase('idle')
+      setPhase('error-truncating')
       return
     }
 
@@ -42,6 +41,11 @@ export default function LoginPage() {
     router.refresh()
   }, [navigate, router])
 
+  const onBootTruncate = useCallback(() => {
+    setError('Invalid email or password.')
+    setPhase('idle')
+  }, [])
+
   return (
     <main className='lc'>
       <LoginCRT
@@ -49,6 +53,7 @@ export default function LoginPage() {
         error={error}
         phase={phase}
         onBootComplete={onBootComplete}
+        onBootTruncate={onBootTruncate}
         channelFlipOverlay={overlay}
       />
     </main>

--- a/app/global.css
+++ b/app/global.css
@@ -593,10 +593,56 @@ body {
   transition: opacity 150ms linear;
 }
 
-.lc-error {
+.lc-screen-shake {
+  animation: lc-glitch-shake 150ms steps(5);
+}
+
+@keyframes lc-glitch-shake {
+  0% { transform: translate(0, 0); }
+  20% { transform: translate(-2px, 0); }
+  40% { transform: translate(2px, 0); }
+  60% { transform: translate(-2px, 0); }
+  80% { transform: translate(1px, 0); }
+  100% { transform: translate(0, 0); }
+}
+
+/* StatusBanner (Story 3.3). Two-line system message: bitmap primary +
+   small-caps secondary. Magenta error variant used on login; cream / cream-dim
+   variants reserved for Story 9 Steam-private banner + Story 13 404 / empty states. */
+.sb {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.sb-primary {
   margin: 0;
-  letter-spacing: 0.04em;
-  overflow-wrap: anywhere;
+}
+
+.sb-secondary {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  color: var(--phosphor-cream-dim);
+  text-transform: uppercase;
+}
+
+.bs-truncating {
+  animation: bs-dissolve 200ms 150ms forwards ease-out;
+  pointer-events: none;
+}
+
+@keyframes bs-dissolve {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lc-screen-shake { animation: none; }
+  .bs-truncating { animation: none; opacity: 0; }
 }
 
 .bt {

--- a/components/atoms/BitmapText/BitmapText.tsx
+++ b/components/atoms/BitmapText/BitmapText.tsx
@@ -1,6 +1,11 @@
 import type { CSSProperties, JSX, ReactNode } from 'react'
 
-export type BitmapTextTone = 'cream' | 'cream-dim' | 'cream-ghost' | 'magenta'
+export type BitmapTextTone =
+  | 'cream'
+  | 'cream-dim'
+  | 'cream-ghost'
+  | 'magenta'
+  | 'orange'
 
 export type BitmapTextProps = {
   children: ReactNode
@@ -16,6 +21,7 @@ const TONE_VAR: Record<BitmapTextTone, string> = {
   'cream-dim': 'var(--phosphor-cream-dim)',
   'cream-ghost': 'var(--phosphor-cream-ghost)',
   magenta: 'var(--magenta)',
+  orange: 'var(--rb-orange)',
 }
 
 const GLOW_SHADOW: Record<BitmapTextTone, string> = {
@@ -23,6 +29,7 @@ const GLOW_SHADOW: Record<BitmapTextTone, string> = {
   'cream-dim': '0 0 8px rgba(239, 230, 212, 0.4)',
   'cream-ghost': '0 0 8px rgba(239, 230, 212, 0.4)',
   magenta: '0 0 8px rgba(214, 53, 124, 0.55)',
+  orange: '0 0 8px rgba(255, 179, 71, 0.55)',
 }
 
 export function BitmapText({

--- a/components/molecules/BootSequence/BootSequence.tsx
+++ b/components/molecules/BootSequence/BootSequence.tsx
@@ -25,7 +25,11 @@ export type BootSequenceProps = {
   reducedMotionOverride?: boolean
   holdAtFrame?: number
   holdReleased?: boolean
+  truncate?: boolean
+  onTruncate?: () => void
 }
+
+const TRUNCATE_TOTAL_MS = 350
 
 const MODIFIER_ONLY_KEYS = new Set(['Shift', 'Control', 'Alt', 'Meta', 'CapsLock'])
 
@@ -36,6 +40,8 @@ export function BootSequence({
   reducedMotionOverride,
   holdAtFrame,
   holdReleased,
+  truncate,
+  onTruncate,
 }: BootSequenceProps) {
   const initialReduced = readInitialReducedMotion(reducedMotionOverride)
   const reduced = useReducedMotion(reducedMotionOverride)
@@ -110,6 +116,7 @@ export function BootSequence({
       if (e.repeat) return
       if (e.isComposing) return
       if (MODIFIER_ONLY_KEYS.has(e.key)) return
+      if (truncate) return
       if (typeof holdAtFrame === 'number' && !holdReleasedRef.current) return
       const finalFrame = showWelcome ? BOOT_FINAL_FRAME_WITH_WELCOME : BOOT_FINAL_FRAME_NO_WELCOME
       timelineRef.current?.kill()
@@ -123,7 +130,26 @@ export function BootSequence({
       window.removeEventListener('keydown', handler)
       if (rafId !== null) cancelAnimationFrame(rafId)
     }
-  }, [reduced, showWelcome, fireComplete, holdAtFrame])
+  }, [reduced, showWelcome, fireComplete, holdAtFrame, truncate])
+
+  const truncatedRef = useRef(false)
+  useEffect(() => {
+    if (!truncate) {
+      truncatedRef.current = false
+      return
+    }
+    if (truncatedRef.current) return
+    truncatedRef.current = true
+    timelineRef.current?.kill()
+    timelineRef.current = null
+    if (!onTruncate) return
+    if (reduced) {
+      const raf = requestAnimationFrame(() => onTruncate())
+      return () => cancelAnimationFrame(raf)
+    }
+    const timer = window.setTimeout(() => onTruncate(), TRUNCATE_TOTAL_MS)
+    return () => window.clearTimeout(timer)
+  }, [truncate, onTruncate, reduced])
 
   const showHeader = currentFrame >= 2
   const showVersion = currentFrame >= 3
@@ -132,13 +158,16 @@ export function BootSequence({
   const showReady = currentFrame >= 9
   const showWelcomeLine = currentFrame >= 10 && showWelcome
 
+  const cls = truncate ? 'bs bs-truncating' : 'bs'
+
   return (
     <div
-      className='bs'
+      className={cls}
       role='status'
       aria-live='polite'
       aria-label='System boot sequence'
       data-frame={currentFrame}
+      data-truncating={truncate ? 'true' : undefined}
     >
       {showHeader && (
         <div className='bs-header' aria-hidden='true'>

--- a/components/molecules/BootSequence/__tests__/BootSequence.test.tsx
+++ b/components/molecules/BootSequence/__tests__/BootSequence.test.tsx
@@ -284,3 +284,149 @@ describe('BootSequence hold-at-frame (Story 3.2)', () => {
     expect(onComplete).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('BootSequence truncate (Story 3.3)', () => {
+  it('truncate=true applies the bs-truncating class to the boot container', () => {
+    const onComplete = vi.fn()
+    const { getByRole } = render(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        truncate={true}
+      />,
+    )
+    const container = getByRole('status')
+    expect(container).toHaveClass('bs-truncating')
+    expect(container).toHaveAttribute('data-truncating', 'true')
+  })
+
+  it('truncate=true fires onTruncate after the 350ms dissolve under non-reduced motion', async () => {
+    const onComplete = vi.fn()
+    const onTruncate = vi.fn()
+    const { rerender } = render(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        totalDuration={1200}
+        truncate={false}
+        onTruncate={onTruncate}
+      />,
+    )
+    rerender(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        totalDuration={1200}
+        truncate={true}
+        onTruncate={onTruncate}
+      />,
+    )
+    expect(onTruncate).not.toHaveBeenCalled()
+    await new Promise((resolve) => setTimeout(resolve, 450))
+    expect(onTruncate).toHaveBeenCalledTimes(1)
+  })
+
+  it('truncate=true under reduced motion fires onTruncate within 1 RAF (no dissolve wait)', async () => {
+    const onComplete = vi.fn()
+    const onTruncate = vi.fn()
+    render(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={true}
+        truncate={true}
+        onTruncate={onTruncate}
+      />,
+    )
+    await new Promise((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve(null))),
+    )
+    expect(onTruncate).toHaveBeenCalledTimes(1)
+  })
+
+  it('truncate kills the main timeline; onComplete does not fire post-truncate', async () => {
+    const onComplete = vi.fn()
+    const onTruncate = vi.fn()
+    const { rerender } = render(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        totalDuration={300}
+        truncate={false}
+        onTruncate={onTruncate}
+      />,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    rerender(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        totalDuration={300}
+        truncate={true}
+        onTruncate={onTruncate}
+      />,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 800))
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(onTruncate).toHaveBeenCalledTimes(1)
+  })
+
+  it('onTruncate fires once per truncate true transition (EH-2: recoverable across retries)', async () => {
+    const onComplete = vi.fn()
+    const onTruncate = vi.fn()
+    const { rerender } = render(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        truncate={false}
+        onTruncate={onTruncate}
+      />,
+    )
+    rerender(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        truncate={true}
+        onTruncate={onTruncate}
+      />,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 450))
+    expect(onTruncate).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        truncate={false}
+        onTruncate={onTruncate}
+      />,
+    )
+    rerender(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        truncate={true}
+        onTruncate={onTruncate}
+      />,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 450))
+    expect(onTruncate).toHaveBeenCalledTimes(2)
+  })
+
+  it('keydown during truncate=true does NOT fire fireComplete (EH-3 fix)', async () => {
+    const onComplete = vi.fn()
+    const onTruncate = vi.fn()
+    render(
+      <BootSequence
+        onComplete={onComplete}
+        reducedMotionOverride={false}
+        truncate={true}
+        onTruncate={onTruncate}
+      />,
+    )
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+    })
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+})

--- a/components/molecules/StatusBanner/StatusBanner.tsx
+++ b/components/molecules/StatusBanner/StatusBanner.tsx
@@ -1,0 +1,34 @@
+import { BitmapText, type BitmapTextTone } from '@/components/atoms/BitmapText'
+
+export type StatusBannerVariant = 'error' | 'info' | 'warning'
+
+export type StatusBannerProps = {
+  variant: StatusBannerVariant
+  primary: string
+  secondary?: string
+  className?: string
+}
+
+const TONE_BY_VARIANT: Record<StatusBannerVariant, BitmapTextTone> = {
+  error: 'magenta',
+  info: 'cream',
+  warning: 'orange',
+}
+
+export function StatusBanner({
+  variant,
+  primary,
+  secondary,
+  className,
+}: StatusBannerProps) {
+  const cls = className ? `sb ${className}` : 'sb'
+  const tone = TONE_BY_VARIANT[variant]
+  return (
+    <div className={cls} data-variant={variant} role='alert'>
+      <BitmapText size={20} tone={tone} glow as='p' className='sb-primary'>
+        {primary}
+      </BitmapText>
+      {secondary ? <p className='sb-secondary'>{secondary}</p> : null}
+    </div>
+  )
+}

--- a/components/molecules/StatusBanner/__tests__/StatusBanner.test.tsx
+++ b/components/molecules/StatusBanner/__tests__/StatusBanner.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { StatusBanner } from '../StatusBanner'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('StatusBanner rendering', () => {
+  it('renders the primary line with the sb class on the wrapper', () => {
+    const { container } = render(
+      <StatusBanner variant='error' primary='> ACCESS DENIED' />,
+    )
+    expect(container.querySelector('.sb')).not.toBeNull()
+    expect(screen.getByText('> ACCESS DENIED')).toBeInTheDocument()
+  })
+
+  it('applies data-variant matching the variant prop', () => {
+    const { container } = render(
+      <StatusBanner variant='error' primary='X' />,
+    )
+    expect(container.querySelector('.sb')).toHaveAttribute('data-variant', 'error')
+  })
+
+  it('has role=alert on the wrapper (assertive aria-live is implied by role)', () => {
+    render(<StatusBanner variant='error' primary='X' />)
+    const banner = screen.getByRole('alert')
+    expect(banner).not.toHaveAttribute('aria-live')
+  })
+
+  it('warning variant routes primary tone to orange (sets --bt-color to --rb-orange)', () => {
+    render(<StatusBanner variant='warning' primary='WARN' />)
+    const primary = screen.getByText('WARN')
+    expect(primary.style.getPropertyValue('--bt-color')).toBe('var(--rb-orange)')
+  })
+
+  it('renders secondary line when provided', () => {
+    render(
+      <StatusBanner
+        variant='error'
+        primary='> ACCESS DENIED'
+        secondary='INVALID EMAIL OR PASSWORD'
+      />,
+    )
+    expect(screen.getByText('INVALID EMAIL OR PASSWORD')).toBeInTheDocument()
+  })
+
+  it('omits secondary line when not provided', () => {
+    const { container } = render(
+      <StatusBanner variant='error' primary='> ACCESS DENIED' />,
+    )
+    expect(container.querySelector('.sb-secondary')).toBeNull()
+  })
+
+  it('error variant routes primary tone to magenta (sets --bt-color)', () => {
+    render(<StatusBanner variant='error' primary='ERR' />)
+    const primary = screen.getByText('ERR')
+    expect(primary.style.getPropertyValue('--bt-color')).toBe('var(--magenta)')
+  })
+
+  it('info variant routes primary tone to cream', () => {
+    render(<StatusBanner variant='info' primary='INFO' />)
+    const primary = screen.getByText('INFO')
+    expect(primary.style.getPropertyValue('--bt-color')).toBe('var(--phosphor-cream)')
+  })
+
+  it('passes the className prop through alongside the sb base', () => {
+    const { container } = render(
+      <StatusBanner variant='error' primary='X' className='extra' />,
+    )
+    const sb = container.querySelector('.sb')
+    expect(sb).toHaveClass('sb')
+    expect(sb).toHaveClass('extra')
+  })
+})

--- a/components/molecules/StatusBanner/index.ts
+++ b/components/molecules/StatusBanner/index.ts
@@ -1,0 +1,2 @@
+export { StatusBanner } from './StatusBanner'
+export type { StatusBannerProps, StatusBannerVariant } from './StatusBanner'

--- a/components/organisms/LoginCRT/LoginCRT.tsx
+++ b/components/organisms/LoginCRT/LoginCRT.tsx
@@ -1,13 +1,14 @@
 'use client'
 
-import type { FormEvent, ReactNode } from 'react'
+import { useEffect, useRef, type FormEvent, type ReactNode } from 'react'
 import { BitmapText } from '@/components/atoms/BitmapText'
 import { CRTPixelButton } from '@/components/atoms/CRTPixelButton'
 import { TerminalInput } from '@/components/atoms/TerminalInput'
 import { CRTBezel } from '@/components/molecules/CRTBezel'
 import { BootSequence } from '@/components/molecules/BootSequence'
+import { StatusBanner } from '@/components/molecules/StatusBanner'
 
-export type LoginCRTPhase = 'idle' | 'pending' | 'success'
+export type LoginCRTPhase = 'idle' | 'pending' | 'success' | 'error-truncating'
 
 export type LoginCRTProps = {
   onSubmit: (data: { email: string; password: string }) => Promise<void> | void
@@ -15,10 +16,14 @@ export type LoginCRTProps = {
   pending?: boolean
   phase?: LoginCRTPhase
   onBootComplete?: () => void
+  onBootTruncate?: () => void
   channelFlipOverlay?: ReactNode
   defaultEmail?: string
   reducedMotionOverride?: boolean
 }
+
+const ERROR_BANNER_PRIMARY = '> ACCESS DENIED'
+const ERROR_BANNER_SECONDARY = 'INVALID EMAIL OR PASSWORD'
 
 export function LoginCRT({
   onSubmit,
@@ -26,13 +31,31 @@ export function LoginCRT({
   pending = false,
   phase = 'idle',
   onBootComplete,
+  onBootTruncate,
   channelFlipOverlay,
   defaultEmail = 'admin@tracker.local',
   reducedMotionOverride,
 }: LoginCRTProps) {
   const isBusy = phase !== 'idle' || pending
-  const showBoot = phase === 'pending' || phase === 'success'
+  const showBoot = phase === 'pending' || phase === 'success' || phase === 'error-truncating'
+  const isTruncating = phase === 'error-truncating'
   const formClass = isBusy ? 'lc-form lc-form-faded' : 'lc-form'
+  const screenClass = isTruncating ? 'lc-screen lc-screen-shake' : 'lc-screen'
+
+  const passwordRef = useRef<HTMLInputElement | null>(null)
+  const prevErrorRef = useRef<string | null | undefined>(error)
+
+  useEffect(() => {
+    if (!error) {
+      prevErrorRef.current = error
+      return
+    }
+    if (prevErrorRef.current === error) return
+    prevErrorRef.current = error
+    if (phase === 'idle') {
+      passwordRef.current?.focus()
+    }
+  }, [error, phase])
 
   function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -45,7 +68,7 @@ export function LoginCRT({
 
   return (
     <CRTBezel>
-      <div className='lc-screen'>
+      <div className={screenClass}>
         <header className='bt-header'>
           <span className='bt-blocks' aria-hidden='true'>
             <span className='bt-b1'>▓</span>
@@ -80,6 +103,7 @@ export function LoginCRT({
             reducedMotionOverride={reducedMotionOverride}
           />
           <TerminalInput
+            ref={passwordRef}
             name='password'
             type='password'
             label='PASSWORD'
@@ -87,10 +111,12 @@ export function LoginCRT({
             autoComplete='current-password'
             reducedMotionOverride={reducedMotionOverride}
           />
-          {error ? (
-            <BitmapText size={18} tone='magenta' as='p' className='lc-error'>
-              {error}
-            </BitmapText>
+          {error && phase === 'idle' ? (
+            <StatusBanner
+              variant='error'
+              primary={ERROR_BANNER_PRIMARY}
+              secondary={ERROR_BANNER_SECONDARY}
+            />
           ) : null}
           <CRTPixelButton type='submit' disabled={isBusy}>
             {'> LOG IN'}
@@ -100,8 +126,10 @@ export function LoginCRT({
       {showBoot ? (
         <BootSequence
           onComplete={onBootComplete ?? (() => undefined)}
+          onTruncate={onBootTruncate ?? (() => undefined)}
           holdAtFrame={9}
           holdReleased={phase === 'success'}
+          truncate={isTruncating}
           reducedMotionOverride={reducedMotionOverride}
         />
       ) : null}

--- a/components/organisms/LoginCRT/__tests__/LoginCRT.test.tsx
+++ b/components/organisms/LoginCRT/__tests__/LoginCRT.test.tsx
@@ -58,21 +58,20 @@ describe('LoginCRT rendering', () => {
     expect(btn.disabled).toBe(false)
   })
 
-  it('error string renders the magenta error line', () => {
+  it('error string renders the StatusBanner with > ACCESS DENIED + INVALID EMAIL OR PASSWORD', () => {
     render(
       <LoginCRT onSubmit={vi.fn()} error='Invalid email or password.' />,
     )
-    const errorLine = screen.getByText('Invalid email or password.')
-    expect(errorLine).toBeInTheDocument()
-    expect(errorLine).toHaveClass('lc-error')
-    expect(errorLine.style.getPropertyValue('--bt-color')).toBe('var(--magenta)')
+    const banner = screen.getByRole('alert')
+    expect(banner).toHaveAttribute('data-variant', 'error')
+    expect(banner).toHaveClass('sb')
+    expect(screen.getByText('> ACCESS DENIED')).toBeInTheDocument()
+    expect(screen.getByText('INVALID EMAIL OR PASSWORD')).toBeInTheDocument()
   })
 
-  it('null/undefined error does NOT render the error line', () => {
+  it('null/undefined error does NOT render the StatusBanner', () => {
     render(<LoginCRT onSubmit={vi.fn()} error={null} />)
-    expect(
-      screen.queryByText('Invalid email or password.'),
-    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 
   it('threads reducedMotionOverride to both TerminalInputs', () => {
@@ -139,5 +138,75 @@ describe('LoginCRT phase prop (Story 3.2)', () => {
       />,
     )
     expect(screen.getByTestId('flip-overlay')).toBeInTheDocument()
+  })
+})
+
+describe('LoginCRT error-truncating phase + StatusBanner (Story 3.3)', () => {
+  it('phase=error-truncating applies the shake class to .lc-screen and keeps the boot mounted with truncate=true', () => {
+    const { container } = render(
+      <LoginCRT
+        onSubmit={vi.fn()}
+        phase='error-truncating'
+        reducedMotionOverride={true}
+      />,
+    )
+    expect(container.querySelector('.lc-screen-shake')).not.toBeNull()
+    const boot = screen.getByRole('status', { name: /system boot sequence/i })
+    expect(boot).toHaveClass('bs-truncating')
+  })
+
+  it('phase=error-truncating does NOT render the StatusBanner (banner appears after onBootTruncate flips phase to idle)', () => {
+    render(
+      <LoginCRT
+        onSubmit={vi.fn()}
+        phase='error-truncating'
+        error='Invalid email or password.'
+        reducedMotionOverride={true}
+      />,
+    )
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('phase=idle + error string renders StatusBanner with > ACCESS DENIED + INVALID EMAIL OR PASSWORD', () => {
+    render(
+      <LoginCRT
+        onSubmit={vi.fn()}
+        phase='idle'
+        error='Invalid email or password.'
+      />,
+    )
+    const banner = screen.getByRole('alert')
+    expect(banner).toHaveAttribute('data-variant', 'error')
+    expect(screen.getByText('> ACCESS DENIED')).toBeInTheDocument()
+    expect(screen.getByText('INVALID EMAIL OR PASSWORD')).toBeInTheDocument()
+  })
+
+  it('focus moves to the password field on the null → error transition', () => {
+    const { rerender } = render(
+      <LoginCRT onSubmit={vi.fn()} phase='idle' error={null} />,
+    )
+    expect(document.activeElement).not.toBe(screen.getByLabelText('PASSWORD'))
+
+    rerender(
+      <LoginCRT
+        onSubmit={vi.fn()}
+        phase='idle'
+        error='Invalid email or password.'
+      />,
+    )
+    expect(document.activeElement).toBe(screen.getByLabelText('PASSWORD'))
+  })
+
+  it('the original BitmapText magenta error line is REMOVED in favor of StatusBanner', () => {
+    render(
+      <LoginCRT
+        onSubmit={vi.fn()}
+        phase='idle'
+        error='Invalid email or password.'
+      />,
+    )
+    expect(
+      screen.queryByText('Invalid email or password.'),
+    ).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

Closes the login error-path chrome layered on Stories 3.1 (visual) + 3.2 (success boot). On signIn error: boot timeline truncates (`.lc-screen-shake` 150ms glitch + `.bs-truncating` 200ms dissolve, total 350ms), then a `StatusBanner` molecule with `> ACCESS DENIED` (magenta+glow) + `INVALID EMAIL OR PASSWORD` (IBM Plex Mono small-caps) renders above the submit button; focus shifts to the password field for retry; email + typed password values are retained. Reduced-motion users skip every animation and see the static banner immediately.

**New molecule** `StatusBanner` (`components/molecules/StatusBanner/`) — `variant: 'error' | 'info' | 'warning'`, `primary: string`, `secondary?: string`. Inventory row 70. Future consumers: Story 9 Steam-private banner, Story 13 error-states templates. `BitmapText` extends with an `'orange'` tone for the warning variant per [[reference_cuatro_tracker_font_variables]] / `--rb-orange`.

**BootSequence extension:** `truncate` + `onTruncate` props. Reduced-motion path fires `onTruncate` in 1 RAF; non-reduced fires after 350ms. `truncatedRef` resets on `truncate → false` so retry-after-error cycles work (EH-2 fix). Keydown handler now gates on `!truncate` so a stray Enter during the error animation can't trip channel-flip (EH-3 fix).

**LoginCRT extension:** `LoginCRTPhase` adds `'error-truncating'`. On error: page sets phase to `'error-truncating'` (NO setError yet) → BootSequence handles the 350ms animation → `onBootTruncate` callback → page sets `error + setPhase('idle')` → StatusBanner appears with the error banner; useEffect focuses password on the null → error transition.

Code review (EH + AA): **0 CRITICAL violations on the 4 ACs**, 6 patches applied (1 a11y, 2 race fixes, 1 spec-deviation, 2 cleanup), 2 defers logged. **92/92 scoped tests pass; 258/260 full suite (the 2 BullMQ baseline failures only).**

Closes #90

## Test plan

- [ ] `pnpm typecheck && pnpm lint` clean
- [ ] `pnpm vitest run` → 258 passed (2 baseline BullMQ failures unrelated)
- [ ] **Bad credentials path:** submit with wrong password → form fades, boot runs briefly, glitch-shake (150ms 2px jitter on `.lc-screen`), boot overlay dissolves over 200ms, form un-fades, `> ACCESS DENIED` + `INVALID EMAIL OR PASSWORD` banner appears, **focus is on the password field**, email pre-fill retained.
- [ ] **Retry after error:** click submit again with wrong password → second error truncation works (EH-2 regression).
- [ ] **Reduced-motion + bad creds:** OS reduce-motion ON; banner appears immediately with no shake / no dissolve animation; focus on password.
- [ ] **Keydown during shake/dissolve:** press Enter while boot is mid-truncation → nothing happens, no channel-flip (EH-3 regression).
- [ ] **Good creds path still works:** sanity check Story 3.2 path is intact.