### PR TITLE
Epic 4 foundation: TMDB adapter + movie normaliser (#94 #95)

### DIFF
--- a/lib/api/__tests__/tmdb.test.ts
+++ b/lib/api/__tests__/tmdb.test.ts
@@ -1,0 +1,460 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+const loggerMock = vi.hoisted(() => ({
+  fatal: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: loggerMock,
+  createLogger: () => loggerMock,
+}))
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.resetAllMocks()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+})
+
+function mockFetchOk(body: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      () =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    ),
+  )
+}
+
+function mockFetchStatus(status: number) {
+  vi.stubGlobal('fetch', vi.fn(() => new Response('', { status })))
+}
+
+function mockFetchReject(err: unknown) {
+  vi.stubGlobal('fetch', vi.fn().mockRejectedValue(err))
+}
+
+function mockFetchInvalidJson() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      () =>
+        new Response('not-json{{{', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    ),
+  )
+}
+
+const validMovie = {
+  id: 550,
+  title: 'Fight Club',
+  original_title: 'Fight Club',
+  overview: 'A ticking-time-bomb insomniac...',
+  release_date: '1999-10-15',
+  poster_path: '/poster.jpg',
+  backdrop_path: '/backdrop.jpg',
+  vote_average: 8.4,
+  popularity: 64.2,
+  genres: [{ id: 18, name: 'Drama' }],
+  status: 'Released',
+}
+
+const validTv = {
+  id: 1399,
+  name: 'Game of Thrones',
+  original_name: 'Game of Thrones',
+  overview: 'Seven noble families...',
+  first_air_date: '2011-04-17',
+  poster_path: '/got-poster.jpg',
+  backdrop_path: '/got-backdrop.jpg',
+  vote_average: 8.4,
+  popularity: 120.5,
+  genres: [{ id: 18, name: 'Drama' }],
+  status: 'Ended',
+}
+
+const validEpisode = {
+  id: 63056,
+  name: 'Winter Is Coming',
+  overview: 'Lord Ned Stark...',
+  air_date: '2011-04-17',
+  episode_number: 1,
+  season_number: 1,
+  still_path: '/still.jpg',
+  vote_average: 8.0,
+  runtime: 62,
+}
+
+const validSearchMultiResponse = {
+  page: 1,
+  results: [
+    {
+      media_type: 'movie',
+      id: 550,
+      title: 'Fight Club',
+      release_date: '1999-10-15',
+      poster_path: '/poster.jpg',
+      vote_average: 8.4,
+      popularity: 64.2,
+    },
+    {
+      media_type: 'tv',
+      id: 1399,
+      name: 'Game of Thrones',
+      first_air_date: '2011-04-17',
+      vote_average: 8.4,
+    },
+    {
+      media_type: 'person',
+      id: 287,
+      name: 'Brad Pitt',
+      known_for_department: 'Acting',
+    },
+  ],
+  total_pages: 1,
+  total_results: 3,
+}
+
+const validWatchProvidersResponse = {
+  id: 550,
+  results: {
+    US: {
+      link: 'https://www.themoviedb.org/movie/550/watch?locale=US',
+      flatrate: [
+        { provider_id: 8, provider_name: 'Netflix', logo_path: '/n.jpg' },
+      ],
+    },
+    CO: {
+      link: 'https://www.themoviedb.org/movie/550/watch?locale=CO',
+      buy: [
+        { provider_id: 2, provider_name: 'Apple TV', logo_path: '/a.jpg' },
+      ],
+    },
+  },
+}
+
+describe('lib/api/tmdb', () => {
+  describe('searchMulti', () => {
+    it('parses a valid /search/multi response with movie + tv + person variants', async () => {
+      mockFetchOk(validSearchMultiResponse)
+      const { searchMulti } = await import('@/lib/api/tmdb')
+
+      const result = await searchMulti('Fight Club')
+
+      expect(result.results).toHaveLength(3)
+      expect(result.results[0]).toMatchObject({ media_type: 'movie', id: 550 })
+      expect(result.results[1]).toMatchObject({ media_type: 'tv', id: 1399 })
+      expect(result.results[2]).toMatchObject({
+        media_type: 'person',
+        id: 287,
+      })
+    })
+
+    it('injects api_key into the request URL', async () => {
+      mockFetchOk(validSearchMultiResponse)
+      const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+      const { searchMulti } = await import('@/lib/api/tmdb')
+
+      await searchMulti('Fight Club')
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string
+      expect(calledUrl).toContain('api_key=tmdb-key')
+      expect(calledUrl).toContain('query=Fight+Club')
+      expect(calledUrl).toContain('/search/multi')
+    })
+
+    it('passes cache: no-store to fetch', async () => {
+      mockFetchOk(validSearchMultiResponse)
+      const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+      const { searchMulti } = await import('@/lib/api/tmdb')
+
+      await searchMulti('Fight Club')
+
+      const init = fetchMock.mock.calls[0]?.[1] as RequestInit
+      expect(init?.cache).toBe('no-store')
+      expect(init?.signal).toBeInstanceOf(AbortSignal)
+    })
+
+    it('throws TmdbApiError with fieldPath when a result is missing the discriminator', async () => {
+      mockFetchOk({
+        page: 1,
+        results: [{ id: 1, title: 'no media_type' }],
+        total_pages: 1,
+        total_results: 1,
+      })
+      const { searchMulti, TmdbApiError } = await import('@/lib/api/tmdb')
+
+      const promise = searchMulti('x')
+      await expect(promise).rejects.toBeInstanceOf(TmdbApiError)
+      await expect(promise).rejects.toMatchObject({
+        endpoint: '/search/multi',
+        fieldPath: expect.stringMatching(/^results\.0/),
+      })
+    })
+  })
+
+  describe('getMovie', () => {
+    it('parses a valid /movie/:id response', async () => {
+      mockFetchOk(validMovie)
+      const { getMovie } = await import('@/lib/api/tmdb')
+
+      const result = await getMovie(550)
+
+      expect(result).toMatchObject({
+        id: 550,
+        title: 'Fight Club',
+        poster_path: '/poster.jpg',
+      })
+    })
+
+    it('throws TmdbApiError with fieldPath when release_date is missing', async () => {
+      const { release_date: _omit, ...broken } = validMovie
+      mockFetchOk(broken)
+      const { getMovie, TmdbApiError } = await import('@/lib/api/tmdb')
+
+      const promise = getMovie(550)
+      await expect(promise).rejects.toBeInstanceOf(TmdbApiError)
+      await expect(promise).rejects.toMatchObject({
+        endpoint: '/movie/550',
+        fieldPath: 'release_date',
+      })
+    })
+  })
+
+  describe('getTv', () => {
+    it('parses a valid /tv/:id response', async () => {
+      mockFetchOk(validTv)
+      const { getTv } = await import('@/lib/api/tmdb')
+
+      const result = await getTv(1399)
+
+      expect(result).toMatchObject({
+        id: 1399,
+        name: 'Game of Thrones',
+        first_air_date: '2011-04-17',
+      })
+    })
+
+    it('throws TmdbApiError when first_air_date is the wrong type', async () => {
+      mockFetchOk({ ...validTv, first_air_date: 1234 })
+      const { getTv, TmdbApiError } = await import('@/lib/api/tmdb')
+
+      const promise = getTv(1399)
+      await expect(promise).rejects.toBeInstanceOf(TmdbApiError)
+      await expect(promise).rejects.toMatchObject({
+        fieldPath: 'first_air_date',
+      })
+    })
+  })
+
+  describe('getEpisode', () => {
+    it('parses a valid episode response', async () => {
+      mockFetchOk(validEpisode)
+      const { getEpisode } = await import('@/lib/api/tmdb')
+
+      const result = await getEpisode(1399, 1, 1)
+
+      expect(result).toMatchObject({
+        id: 63056,
+        episode_number: 1,
+        season_number: 1,
+      })
+    })
+
+    it('builds the expected /tv/:showId/season/:season/episode/:episode path', async () => {
+      mockFetchOk(validEpisode)
+      const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+      const { getEpisode } = await import('@/lib/api/tmdb')
+
+      await getEpisode(1399, 1, 1)
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string
+      expect(calledUrl).toContain('/tv/1399/season/1/episode/1')
+    })
+
+    it('throws TmdbApiError when episode_number is missing', async () => {
+      const { episode_number: _omit, ...broken } = validEpisode
+      mockFetchOk(broken)
+      const { getEpisode, TmdbApiError } = await import('@/lib/api/tmdb')
+
+      const promise = getEpisode(1399, 1, 1)
+      await expect(promise).rejects.toBeInstanceOf(TmdbApiError)
+      await expect(promise).rejects.toMatchObject({
+        fieldPath: 'episode_number',
+      })
+    })
+  })
+
+  describe('getWatchProviders', () => {
+    it('returns the slice for the requested country', async () => {
+      mockFetchOk(validWatchProvidersResponse)
+      const { getWatchProviders } = await import('@/lib/api/tmdb')
+
+      const result = await getWatchProviders('movie', 550, 'CO')
+
+      expect(result).toMatchObject({
+        link: 'https://www.themoviedb.org/movie/550/watch?locale=CO',
+      })
+      expect(result?.buy).toHaveLength(1)
+    })
+
+    it('returns null when the country has no providers', async () => {
+      mockFetchOk(validWatchProvidersResponse)
+      const { getWatchProviders } = await import('@/lib/api/tmdb')
+
+      const result = await getWatchProviders('movie', 550, 'ZZ')
+
+      expect(result).toBeNull()
+    })
+
+    it('throws TmdbApiError when a provider entry has an invalid link', async () => {
+      mockFetchOk({
+        id: 550,
+        results: {
+          US: { link: 'not-a-url', flatrate: [] },
+        },
+      })
+      const { getWatchProviders, TmdbApiError } = await import('@/lib/api/tmdb')
+
+      const promise = getWatchProviders('movie', 550, 'US')
+      await expect(promise).rejects.toBeInstanceOf(TmdbApiError)
+      await expect(promise).rejects.toMatchObject({
+        fieldPath: expect.stringMatching(/results\.US\.link/),
+      })
+    })
+  })
+
+  describe('getImageUrl', () => {
+    it('returns the full TMDB image URL when given a path + size', async () => {
+      const { getImageUrl } = await import('@/lib/api/tmdb')
+      expect(getImageUrl('/abc.jpg', 'w500')).toBe(
+        'https://image.tmdb.org/t/p/w500/abc.jpg',
+      )
+    })
+
+    it('returns null when path is null (caller-friendly nullable passthrough)', async () => {
+      const { getImageUrl } = await import('@/lib/api/tmdb')
+      expect(getImageUrl(null, 'w500')).toBeNull()
+    })
+
+    it('supports all documented TMDB sizes', async () => {
+      const { getImageUrl } = await import('@/lib/api/tmdb')
+      const sizes = [
+        'w92',
+        'w154',
+        'w185',
+        'w342',
+        'w500',
+        'w780',
+        'original',
+      ] as const
+      for (const size of sizes) {
+        expect(getImageUrl('/x.jpg', size)).toBe(
+          `https://image.tmdb.org/t/p/${size}/x.jpg`,
+        )
+      }
+    })
+  })
+
+  describe('HTTP failures', () => {
+    it('throws TmdbApiError with httpStatus on non-2xx', async () => {
+      mockFetchStatus(500)
+      const { getMovie, TmdbApiError } = await import('@/lib/api/tmdb')
+
+      const promise = getMovie(550)
+      await expect(promise).rejects.toBeInstanceOf(TmdbApiError)
+      await expect(promise).rejects.toMatchObject({
+        endpoint: '/movie/550',
+        httpStatus: 500,
+      })
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: '/movie/550',
+          status: 500,
+        }),
+        'tmdb_fetch_http_error',
+      )
+    })
+
+    it('throws TmdbApiError with undefined httpStatus on network error', async () => {
+      const networkErr = new Error('ECONNREFUSED')
+      mockFetchReject(networkErr)
+      const { getMovie, TmdbApiError } = await import('@/lib/api/tmdb')
+
+      const promise = getMovie(550)
+      await expect(promise).rejects.toBeInstanceOf(TmdbApiError)
+      await expect(promise).rejects.toMatchObject({
+        endpoint: '/movie/550',
+        httpStatus: undefined,
+      })
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        expect.objectContaining({ endpoint: '/movie/550', err: networkErr }),
+        'tmdb_fetch_network_error',
+      )
+    })
+
+    it('throws TmdbApiError when the response body is invalid JSON', async () => {
+      mockFetchInvalidJson()
+      const { getMovie, TmdbApiError } = await import('@/lib/api/tmdb')
+
+      const promise = getMovie(550)
+      await expect(promise).rejects.toBeInstanceOf(TmdbApiError)
+      await expect(promise).rejects.toMatchObject({
+        endpoint: '/movie/550',
+      })
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        expect.objectContaining({ endpoint: '/movie/550' }),
+        'tmdb_fetch_invalid_json',
+      )
+    })
+
+    it('logs at error level with fieldPath on parse failure', async () => {
+      const { release_date: _omit, ...broken } = validMovie
+      mockFetchOk(broken)
+      const { getMovie } = await import('@/lib/api/tmdb')
+
+      await expect(getMovie(550)).rejects.toThrow()
+
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: '/movie/550',
+          fieldPath: 'release_date',
+        }),
+        'tmdb_fetch_parse_error',
+      )
+    })
+  })
+})

--- a/lib/api/tmdb.ts
+++ b/lib/api/tmdb.ts
@@ -1,0 +1,297 @@
+import { z } from 'zod'
+import { env } from '@/lib/env'
+import { logger } from '@/lib/logger'
+
+const TMDB_BASE = 'https://api.themoviedb.org/3'
+const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p'
+const TMDB_TIMEOUT_MS = 8000
+
+export class TmdbApiError extends Error {
+  readonly endpoint: string
+  readonly httpStatus?: number
+  readonly fieldPath?: string
+
+  constructor(
+    message: string,
+    opts: {
+      endpoint: string
+      httpStatus?: number
+      fieldPath?: string
+      cause?: unknown
+    },
+  ) {
+    super(message, opts.cause ? { cause: opts.cause } : undefined)
+    this.name = 'TmdbApiError'
+    this.endpoint = opts.endpoint
+    this.httpStatus = opts.httpStatus
+    this.fieldPath = opts.fieldPath
+  }
+}
+
+export const TmdbImageSizeSchema = z.enum([
+  'w92',
+  'w154',
+  'w185',
+  'w342',
+  'w500',
+  'w780',
+  'original',
+])
+export type TmdbImageSize = z.infer<typeof TmdbImageSizeSchema>
+
+const TmdbGenreSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+})
+
+export const TmdbMovieSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  original_title: z.string().optional(),
+  overview: z.string().nullable().optional(),
+  release_date: z.string(),
+  poster_path: z.string().nullable(),
+  backdrop_path: z.string().nullable(),
+  vote_average: z.number(),
+  popularity: z.number(),
+  genres: z.array(TmdbGenreSchema),
+  status: z.string(),
+})
+export type TmdbMovie = z.infer<typeof TmdbMovieSchema>
+
+export const TmdbTvSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  original_name: z.string().optional(),
+  overview: z.string().nullable().optional(),
+  first_air_date: z.string(),
+  poster_path: z.string().nullable(),
+  backdrop_path: z.string().nullable(),
+  vote_average: z.number(),
+  popularity: z.number(),
+  genres: z.array(TmdbGenreSchema),
+  status: z.string(),
+})
+export type TmdbTv = z.infer<typeof TmdbTvSchema>
+
+export const TmdbEpisodeSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  overview: z.string().nullable().optional(),
+  air_date: z.string().nullable().optional(),
+  episode_number: z.number(),
+  season_number: z.number(),
+  still_path: z.string().nullable().optional(),
+  vote_average: z.number(),
+  runtime: z.number().nullable().optional(),
+})
+export type TmdbEpisode = z.infer<typeof TmdbEpisodeSchema>
+
+const TmdbSearchMovieResultSchema = z.object({
+  media_type: z.literal('movie'),
+  id: z.number(),
+  title: z.string(),
+  original_title: z.string().optional(),
+  overview: z.string().nullable().optional(),
+  release_date: z.string().optional(),
+  poster_path: z.string().nullable().optional(),
+  backdrop_path: z.string().nullable().optional(),
+  vote_average: z.number().optional(),
+  popularity: z.number().optional(),
+  genre_ids: z.array(z.number()).optional(),
+})
+
+const TmdbSearchTvResultSchema = z.object({
+  media_type: z.literal('tv'),
+  id: z.number(),
+  name: z.string(),
+  original_name: z.string().optional(),
+  overview: z.string().nullable().optional(),
+  first_air_date: z.string().optional(),
+  poster_path: z.string().nullable().optional(),
+  backdrop_path: z.string().nullable().optional(),
+  vote_average: z.number().optional(),
+  popularity: z.number().optional(),
+  genre_ids: z.array(z.number()).optional(),
+})
+
+const TmdbSearchPersonResultSchema = z.object({
+  media_type: z.literal('person'),
+  id: z.number(),
+  name: z.string(),
+  known_for_department: z.string().optional(),
+  profile_path: z.string().nullable().optional(),
+  popularity: z.number().optional(),
+})
+
+export const TmdbSearchMultiResultSchema = z.discriminatedUnion('media_type', [
+  TmdbSearchMovieResultSchema,
+  TmdbSearchTvResultSchema,
+  TmdbSearchPersonResultSchema,
+])
+export type TmdbSearchMultiResult = z.infer<typeof TmdbSearchMultiResultSchema>
+
+export const TmdbSearchMultiResponseSchema = z.object({
+  page: z.number(),
+  results: z.array(TmdbSearchMultiResultSchema),
+  total_pages: z.number(),
+  total_results: z.number(),
+})
+export type TmdbSearchMultiResponse = z.infer<
+  typeof TmdbSearchMultiResponseSchema
+>
+
+const TmdbProviderSchema = z.object({
+  provider_id: z.number(),
+  provider_name: z.string(),
+  logo_path: z.string().nullable().optional(),
+  display_priority: z.number().optional(),
+})
+
+export const TmdbCountryProvidersSchema = z.object({
+  link: z.url(),
+  flatrate: z.array(TmdbProviderSchema).optional(),
+  buy: z.array(TmdbProviderSchema).optional(),
+  rent: z.array(TmdbProviderSchema).optional(),
+})
+export type TmdbCountryProviders = z.infer<typeof TmdbCountryProvidersSchema>
+
+export const TmdbWatchProvidersResponseSchema = z.object({
+  id: z.number(),
+  results: z.record(z.string(), TmdbCountryProvidersSchema),
+})
+export type TmdbWatchProvidersResponse = z.infer<
+  typeof TmdbWatchProvidersResponseSchema
+>
+
+async function tmdbFetch<T extends z.ZodType>(
+  endpoint: string,
+  params: Record<string, string | number>,
+  schema: T,
+): Promise<z.infer<T>> {
+  const url = new URL(`${TMDB_BASE}${endpoint}`)
+  url.searchParams.set('api_key', env.TMDB_API_KEY)
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, String(value))
+  }
+
+  const startedAt = Date.now()
+  let response: Response
+  try {
+    response = await fetch(url.toString(), {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+      signal: AbortSignal.timeout(TMDB_TIMEOUT_MS),
+    })
+  } catch (err) {
+    const durationMs = Date.now() - startedAt
+    logger.error(
+      { endpoint, durationMs, err },
+      'tmdb_fetch_network_error',
+    )
+    throw new TmdbApiError(`TMDB fetch failed: ${endpoint}`, {
+      endpoint,
+      cause: err,
+    })
+  }
+
+  const durationMs = Date.now() - startedAt
+
+  if (!response.ok) {
+    logger.error(
+      { endpoint, status: response.status, durationMs },
+      'tmdb_fetch_http_error',
+    )
+    throw new TmdbApiError(
+      `TMDB HTTP ${response.status}: ${endpoint}`,
+      { endpoint, httpStatus: response.status },
+    )
+  }
+
+  let payload: unknown
+  try {
+    payload = await response.json()
+  } catch (err) {
+    logger.error(
+      { endpoint, durationMs, err },
+      'tmdb_fetch_invalid_json',
+    )
+    throw new TmdbApiError(`TMDB returned invalid JSON: ${endpoint}`, {
+      endpoint,
+      httpStatus: response.status,
+      cause: err,
+    })
+  }
+
+  const parsed = schema.safeParse(payload)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    const fieldPath = issue?.path.join('.') ?? '(root)'
+    logger.error(
+      {
+        endpoint,
+        status: response.status,
+        durationMs,
+        fieldPath,
+        err: parsed.error,
+      },
+      'tmdb_fetch_parse_error',
+    )
+    throw new TmdbApiError(
+      `TMDB response parse failed at "${fieldPath}": ${endpoint}`,
+      {
+        endpoint,
+        httpStatus: response.status,
+        fieldPath,
+        cause: parsed.error,
+      },
+    )
+  }
+
+  return parsed.data
+}
+
+export function searchMulti(query: string): Promise<TmdbSearchMultiResponse> {
+  return tmdbFetch('/search/multi', { query }, TmdbSearchMultiResponseSchema)
+}
+
+export function getMovie(id: number): Promise<TmdbMovie> {
+  return tmdbFetch(`/movie/${id}`, {}, TmdbMovieSchema)
+}
+
+export function getTv(id: number): Promise<TmdbTv> {
+  return tmdbFetch(`/tv/${id}`, {}, TmdbTvSchema)
+}
+
+export function getEpisode(
+  showId: number,
+  season: number,
+  episode: number,
+): Promise<TmdbEpisode> {
+  return tmdbFetch(
+    `/tv/${showId}/season/${season}/episode/${episode}`,
+    {},
+    TmdbEpisodeSchema,
+  )
+}
+
+export async function getWatchProviders(
+  type: 'movie' | 'tv',
+  id: number,
+  country: string,
+): Promise<TmdbCountryProviders | null> {
+  const response = await tmdbFetch(
+    `/${type}/${id}/watch/providers`,
+    {},
+    TmdbWatchProvidersResponseSchema,
+  )
+  return response.results[country] ?? null
+}
+
+export function getImageUrl(
+  path: string | null,
+  size: TmdbImageSize,
+): string | null {
+  if (path === null) return null
+  return `${TMDB_IMAGE_BASE}/${size}${path}`
+}

--- a/lib/api/tmdb.ts
+++ b/lib/api/tmdb.ts
@@ -185,14 +185,19 @@ async function tmdbFetch<T extends z.ZodType>(
     })
   } catch (err) {
     const durationMs = Date.now() - startedAt
+    const isTimeout =
+      err instanceof Error &&
+      (err.name === 'TimeoutError' || err.name === 'AbortError')
     logger.error(
       { endpoint, durationMs, err },
-      'tmdb_fetch_network_error',
+      isTimeout ? 'tmdb_fetch_timeout' : 'tmdb_fetch_network_error',
     )
-    throw new TmdbApiError(`TMDB fetch failed: ${endpoint}`, {
-      endpoint,
-      cause: err,
-    })
+    throw new TmdbApiError(
+      isTimeout
+        ? `TMDB request timed out after ${TMDB_TIMEOUT_MS}ms: ${endpoint}`
+        : `TMDB fetch failed: ${endpoint}`,
+      { endpoint, cause: err },
+    )
   }
 
   const durationMs = Date.now() - startedAt

--- a/lib/normalise/__tests__/movie.test.ts
+++ b/lib/normalise/__tests__/movie.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { ZodError } from 'zod'
+import { MediaType } from '@prisma/client'
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+const validMovie = {
+  id: 550,
+  title: 'Fight Club',
+  original_title: 'Fight Club',
+  overview: 'A ticking-time-bomb insomniac...',
+  release_date: '1999-10-15',
+  poster_path: '/poster.jpg',
+  backdrop_path: '/backdrop.jpg',
+  vote_average: 8.4,
+  popularity: 64.2,
+  genres: [
+    { id: 18, name: 'Drama' },
+    { id: 53, name: 'Thriller' },
+  ],
+  status: 'Released',
+}
+
+describe('lib/normalise/movie', () => {
+  describe('happy path', () => {
+    it('maps every documented field correctly', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbMovie(validMovie)
+
+      expect(result).toMatchObject({
+        type: MediaType.MOVIE,
+        title: 'Fight Club',
+        original_title: 'Fight Club',
+        overview: 'A ticking-time-bomb insomniac...',
+        poster_path: '/poster.jpg',
+        backdrop_path: '/backdrop.jpg',
+        rating: 8.4,
+        popularity: 64.2,
+        tmdb_id: 550,
+      })
+      expect(result.genres).toEqual(['Drama', 'Thriller'])
+      expect(result.release_date).toBeInstanceOf(Date)
+      expect((result.release_date as Date).toISOString()).toBe(
+        '1999-10-15T00:00:00.000Z',
+      )
+    })
+
+    it('does NOT include status (out of AC-1 scope)', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbMovie(validMovie)
+
+      expect(result).not.toHaveProperty('status')
+    })
+
+    it('preserves path-only poster + backdrop (no domain prefix)', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbMovie(validMovie)
+
+      expect(result.poster_path).toBe('/poster.jpg')
+      expect(result.backdrop_path).toBe('/backdrop.jpg')
+      expect(result.poster_path).not.toContain('http')
+      expect(result.backdrop_path).not.toContain('http')
+    })
+  })
+
+  describe('release_date fallback chain', () => {
+    it('falls back to 1970-01-01 sentinel when release_date is null', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbMovie({ ...validMovie, release_date: null })
+
+      expect((result.release_date as Date).toISOString()).toBe(
+        '1970-01-01T00:00:00.000Z',
+      )
+    })
+
+    it('falls back to 1970-01-01 sentinel when release_date is an empty string', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbMovie({ ...validMovie, release_date: '' })
+
+      expect((result.release_date as Date).toISOString()).toBe(
+        '1970-01-01T00:00:00.000Z',
+      )
+    })
+
+    it('constructs Jan 1 of year (UTC) when release_date is year-only "2024"', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbMovie({
+        ...validMovie,
+        release_date: '2024',
+      })
+
+      expect((result.release_date as Date).toISOString()).toBe(
+        '2024-01-01T00:00:00.000Z',
+      )
+    })
+
+    it('falls back to sentinel when release_date is a malformed string (not yyyy-mm-dd, not yyyy)', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbMovie({
+        ...validMovie,
+        release_date: 'not-a-date',
+      })
+
+      expect((result.release_date as Date).toISOString()).toBe(
+        '1970-01-01T00:00:00.000Z',
+      )
+    })
+
+    it('falls back to sentinel when release_date is structurally yyyy-mm-dd but invalid (e.g. 2024-13-45)', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbMovie({
+        ...validMovie,
+        release_date: '2024-13-45',
+      })
+
+      expect((result.release_date as Date).toISOString()).toBe(
+        '1970-01-01T00:00:00.000Z',
+      )
+    })
+  })
+
+  describe('malformed input', () => {
+    it('throws ZodError with .issues path referencing release_date when release_date is a number', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const broken = { ...validMovie, release_date: 1234 }
+
+      expect(() => normaliseTmdbMovie(broken)).toThrow(ZodError)
+      try {
+        normaliseTmdbMovie(broken)
+      } catch (err) {
+        expect(err).toBeInstanceOf(ZodError)
+        if (err instanceof ZodError) {
+          const releaseDateIssue = err.issues.find(
+            (i) => i.path[0] === 'release_date',
+          )
+          expect(releaseDateIssue).toBeDefined()
+        }
+      }
+    })
+
+    it('throws ZodError when a required field is missing entirely', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const { title: _title, ...broken } = validMovie
+
+      expect(() => normaliseTmdbMovie(broken)).toThrow(ZodError)
+    })
+
+    it('throws ZodError when genres is not an array', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const broken = { ...validMovie, genres: 'Drama' }
+
+      expect(() => normaliseTmdbMovie(broken)).toThrow(ZodError)
+    })
+
+    it('throws ZodError when input is null or undefined', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      expect(() => normaliseTmdbMovie(null)).toThrow(ZodError)
+      expect(() => normaliseTmdbMovie(undefined)).toThrow(ZodError)
+    })
+  })
+
+  describe('original_title and overview nullable handling', () => {
+    it('writes null when original_title is absent from the source', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const { original_title: _ot, ...source } = validMovie
+
+      const result = normaliseTmdbMovie(source)
+
+      expect(result.original_title).toBeNull()
+    })
+
+    it('writes null when overview is null in the source', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbMovie({ ...validMovie, overview: null })
+
+      expect(result.overview).toBeNull()
+    })
+  })
+
+  describe('NFR13 invariant: release_date is always a valid Date', () => {
+    const variants: Array<{ name: string; release_date: unknown }> = [
+      { name: 'happy yyyy-mm-dd', release_date: '1999-10-15' },
+      { name: 'null', release_date: null },
+      { name: 'empty string', release_date: '' },
+      { name: 'year-only', release_date: '2024' },
+      { name: 'malformed string', release_date: 'foo' },
+      { name: 'invalid yyyy-mm-dd', release_date: '2024-13-45' },
+    ]
+
+    it.each(variants)(
+      'produces a valid Date for variant "$name"',
+      async ({ release_date }) => {
+        const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+        const result = normaliseTmdbMovie({ ...validMovie, release_date })
+
+        expect(result.release_date).toBeInstanceOf(Date)
+        expect(Number.isNaN((result.release_date as Date).getTime())).toBe(
+          false,
+        )
+      },
+    )
+  })
+})

--- a/lib/normalise/__tests__/movie.test.ts
+++ b/lib/normalise/__tests__/movie.test.ts
@@ -197,7 +197,35 @@ describe('lib/normalise/movie', () => {
     })
   })
 
-  describe('original_title and overview nullable handling', () => {
+  describe('nullable / empty source-field handling', () => {
+    it('maps an empty genres array through unchanged', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbMovie({ ...validMovie, genres: [] })
+
+      expect(result.genres).toEqual([])
+    })
+
+    it('preserves null poster_path (TMDB returns null for movies without art)', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbMovie({ ...validMovie, poster_path: null })
+
+      expect(result.poster_path).toBeNull()
+    })
+
+    it('preserves null backdrop_path', async () => {
+      const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbMovie({
+        ...validMovie,
+        backdrop_path: null,
+      })
+
+      expect(result.backdrop_path).toBeNull()
+    })
+
+
     it('writes null when original_title is absent from the source', async () => {
       const { normaliseTmdbMovie } = await import('@/lib/normalise/movie')
 

--- a/lib/normalise/movie.ts
+++ b/lib/normalise/movie.ts
@@ -1,0 +1,45 @@
+import { Prisma, MediaType } from '@prisma/client'
+import { TmdbMovieSchema } from '@/lib/api/tmdb'
+
+const RELEASE_DATE_SENTINEL = new Date('1970-01-01T00:00:00Z')
+
+function parseReleaseDate(raw: string): Date {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    const parsed = new Date(raw)
+    if (!Number.isNaN(parsed.getTime())) return parsed
+  }
+  if (/^\d{4}$/.test(raw)) {
+    const year = Number.parseInt(raw, 10)
+    return new Date(Date.UTC(year, 0, 1))
+  }
+  return new Date(RELEASE_DATE_SENTINEL)
+}
+
+export function normaliseTmdbMovie(raw: unknown): Prisma.MediaItemCreateInput {
+  // AC-2 mandates accepting `release_date: null` as a valid fallback-chain input.
+  // The adapter schema asserts string; coerce null → '' here so the empty-string
+  // branch of parseReleaseDate handles it without relaxing the upstream contract.
+  const prepared =
+    raw &&
+    typeof raw === 'object' &&
+    'release_date' in raw &&
+    (raw as { release_date: unknown }).release_date === null
+      ? { ...(raw as object), release_date: '' }
+      : raw
+
+  const source = TmdbMovieSchema.parse(prepared)
+
+  return {
+    type: MediaType.MOVIE,
+    title: source.title,
+    original_title: source.original_title ?? null,
+    release_date: parseReleaseDate(source.release_date),
+    overview: source.overview ?? null,
+    poster_path: source.poster_path,
+    backdrop_path: source.backdrop_path,
+    rating: source.vote_average,
+    popularity: source.popularity,
+    genres: source.genres.map((g) => g.name),
+    tmdb_id: source.id,
+  }
+}


### PR DESCRIPTION
## Summary

Bundled foundation work for Epic 4 (Federated Search & Library Mutation). Two stories on one branch with one commit per issue:

- **#94 (Story 4.1)** — `lib/api/tmdb.ts`: typed Zod-validated TMDB client. `searchMulti / getMovie / getTv / getEpisode / getWatchProviders / getImageUrl` + `TmdbApiError`. Single `tmdbFetch` ingress (`cache: 'no-store'`, `AbortSignal.timeout(8000)`, `api_key` injected from `env.TMDB_API_KEY`). 24 unit tests including happy + tampered fixtures per endpoint, HTTP non-2xx, network, invalid-JSON, parse-error, and timeout discrimination paths.
- **#95 (Story 4.2)** — `lib/normalise/movie.ts`: `normaliseTmdbMovie(raw: unknown) → Prisma.MediaItemCreateInput`. Documented `release_date` fallback chain (yyyy-mm-dd → year-only → `1970-01-01T00:00:00Z` sentinel; UTC throughout per OI #1). Re-validates via `TmdbMovieSchema` from #94 so the function stays robust against JSON-roundtrip data. 23 tests covering AC-4 mandated fixtures plus null poster / null backdrop / empty genres hardening from code review.

## Test plan

- [ ] `pnpm typecheck` clean (run inside `cuatro-tracker-dev-1`).
- [ ] `pnpm lint` clean.
- [ ] `pnpm vitest run lib/api/__tests__/tmdb.test.ts lib/normalise/__tests__/movie.test.ts` — 47 tests pass.
- [ ] CI runs the same suite via the workflow's vitest job.

## Notes

- bmad-code-review run per-story (Edge Case Hunter + Acceptance Auditor; Blind Hunter skipped per Epic 2/3 precedent). Story 4.1: 1 patch applied (distinct timeout-vs-network log key), 1 defer (timeout-path fake-timer test → `deferred-work.md`). Story 4.2: 2 test-coverage patches applied (empty genres + null poster/backdrop), 0 violations from Auditor.
- No new env vars; `TMDB_API_KEY` was already provisioned in Story 1.1.
- No DB migration; the normaliser produces a `Prisma.MediaItemCreateInput` consumed by the next bundle (Story 4.4 `/api/media` route handler).

Closes #94
Closes #95