### PR TITLE
Epic 4 handlers: GET /api/search + POST /api/media (#97 #98)

### DIFF
--- a/__tests__/middleware-matcher.test.ts
+++ b/__tests__/middleware-matcher.test.ts
@@ -37,6 +37,7 @@ const cases: Case[] = [
   { path: '/dashboard', expected: 'gate' },
   { path: '/timeline', expected: 'gate' },
   { path: '/api/media', expected: 'gate' },
+  { path: '/api/media/foo', expected: 'gate' },
   { path: '/api/search', expected: 'gate' },
   { path: '/api/search/foo', expected: 'gate' },
 ]

--- a/__tests__/middleware-matcher.test.ts
+++ b/__tests__/middleware-matcher.test.ts
@@ -37,6 +37,8 @@ const cases: Case[] = [
   { path: '/dashboard', expected: 'gate' },
   { path: '/timeline', expected: 'gate' },
   { path: '/api/media', expected: 'gate' },
+  { path: '/api/search', expected: 'gate' },
+  { path: '/api/search/foo', expected: 'gate' },
 ]
 
 describe('middleware matcher', () => {

--- a/app/api/media/__tests__/route.test.ts
+++ b/app/api/media/__tests__/route.test.ts
@@ -1,0 +1,497 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { MediaType, Prisma, WatchStatus } from '@prisma/client'
+
+const loggerMock = vi.hoisted(() => ({
+  fatal: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: loggerMock,
+  createLogger: () => loggerMock,
+}))
+
+const tmdbMock = vi.hoisted(() => ({
+  getMovie: vi.fn(),
+}))
+
+vi.mock('@/lib/api/tmdb', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/lib/api/tmdb')>('@/lib/api/tmdb')
+  return {
+    ...actual,
+    getMovie: tmdbMock.getMovie,
+  }
+})
+
+const dbMock = vi.hoisted(() => ({
+  mediaItem: {
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+    update: vi.fn(),
+    create: vi.fn(),
+  },
+  userEntry: {
+    create: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/db', () => ({ db: dbMock }))
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.resetAllMocks()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+const validTmdbMovie = {
+  id: 550,
+  title: 'Fight Club',
+  original_title: 'Fight Club',
+  overview: 'A ticking-time-bomb insomniac...',
+  release_date: '1999-10-15',
+  poster_path: '/poster.jpg',
+  backdrop_path: '/backdrop.jpg',
+  vote_average: 8.4,
+  popularity: 64.2,
+  genres: [{ id: 18, name: 'Drama' }],
+  status: 'Released',
+}
+
+function postRequest(body: unknown): NextRequest {
+  return new NextRequest(new URL('http://localhost/api/media'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function newMediaItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'cm_test_1',
+    type: MediaType.MOVIE,
+    title: 'Fight Club',
+    original_title: 'Fight Club',
+    release_date: new Date('1999-10-15T00:00:00Z'),
+    end_date: null,
+    poster_path: '/poster.jpg',
+    backdrop_path: '/backdrop.jpg',
+    overview: 'A ticking-time-bomb insomniac...',
+    genres: ['Drama'],
+    rating: 8.4,
+    popularity: 64.2,
+    status: null,
+    tmdb_id: 550,
+    anilist_id: null,
+    igdb_id: null,
+    steam_id: null,
+    parent_id: null,
+    franchise_id: null,
+    created_at: new Date('2026-05-13T00:00:00Z'),
+    updated_at: new Date('2026-05-13T00:00:00Z'),
+    user_entry: null,
+    ...overrides,
+  }
+}
+
+function newUserEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'cm_ue_1',
+    media_item_id: 'cm_test_1',
+    status: WatchStatus.PLAN_TO_WATCH,
+    user_rating: null,
+    progress: 0,
+    notes: null,
+    started_at: null,
+    completed_at: null,
+    created_at: new Date('2026-05-13T00:00:00Z'),
+    updated_at: new Date('2026-05-13T00:00:00Z'),
+    ...overrides,
+  }
+}
+
+describe('POST /api/media', () => {
+  describe('body validation', () => {
+    it('returns 400 invalid_json when body is not parseable', async () => {
+      const { POST } = await import('@/app/api/media/route')
+
+      const req = new NextRequest(new URL('http://localhost/api/media'), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: 'not-json',
+      })
+      const res = await POST(req)
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('invalid_body')
+      expect(body.reason).toBe('invalid_json')
+    })
+
+    it('returns 400 when source is missing', async () => {
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ sourceId: 550, type: MediaType.MOVIE }),
+      )
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('invalid_body')
+      expect(body.issues).toBeDefined()
+    })
+
+    it('returns 400 when sourceId is negative', async () => {
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: -1, type: MediaType.MOVIE }),
+      )
+
+      expect(res.status).toBe(400)
+    })
+
+    it('coerces string sourceId to number', async () => {
+      tmdbMock.getMovie.mockResolvedValue(validTmdbMovie)
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      dbMock.mediaItem.findMany.mockResolvedValue([])
+      dbMock.mediaItem.create.mockResolvedValue(
+        newMediaItem({ user_entry: newUserEntry() }),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: '550', type: MediaType.MOVIE }),
+      )
+
+      expect(res.status).toBe(201)
+      expect(tmdbMock.getMovie).toHaveBeenCalledWith(550)
+    })
+  })
+
+  describe('dispatcher routing', () => {
+    it('returns 501 for unwired source (anilist)', async () => {
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({
+          source: 'anilist',
+          sourceId: 1234,
+          type: MediaType.ANIME,
+        }),
+      )
+
+      expect(res.status).toBe(501)
+      const body = await res.json()
+      expect(body.error).toBe('unsupported_source_type')
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'media.unsupported_source_type',
+          source: 'anilist',
+        }),
+        expect.any(String),
+      )
+    })
+
+    it('returns 501 for unwired type (tmdb + TV_SHOW)', async () => {
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({
+          source: 'tmdb',
+          sourceId: 1399,
+          type: MediaType.TV_SHOW,
+        }),
+      )
+
+      expect(res.status).toBe(501)
+    })
+  })
+
+  describe('happy path (create new MediaItem + UserEntry)', () => {
+    it('returns 201 with MediaItem + UserEntry when source ID is new', async () => {
+      tmdbMock.getMovie.mockResolvedValue(validTmdbMovie)
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      dbMock.mediaItem.findMany.mockResolvedValue([])
+      dbMock.mediaItem.create.mockResolvedValue(
+        newMediaItem({ user_entry: newUserEntry() }),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 550, type: MediaType.MOVIE }),
+      )
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.mediaItem.tmdb_id).toBe(550)
+      expect(body.mediaItem.user_entry.status).toBe(WatchStatus.PLAN_TO_WATCH)
+      expect(body.mediaItem.user_entry.progress).toBe(0)
+      expect(body.merged).toBe(false)
+    })
+
+    it('sets Cache-Control: no-store on success', async () => {
+      tmdbMock.getMovie.mockResolvedValue(validTmdbMovie)
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      dbMock.mediaItem.findMany.mockResolvedValue([])
+      dbMock.mediaItem.create.mockResolvedValue(
+        newMediaItem({ user_entry: newUserEntry() }),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 550, type: MediaType.MOVIE }),
+      )
+
+      expect(res.headers.get('Cache-Control')).toBe('no-store')
+    })
+
+    it('passes the nested user_entry create to db.mediaItem.create', async () => {
+      tmdbMock.getMovie.mockResolvedValue(validTmdbMovie)
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      dbMock.mediaItem.findMany.mockResolvedValue([])
+      dbMock.mediaItem.create.mockResolvedValue(
+        newMediaItem({ user_entry: newUserEntry() }),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      await POST(
+        postRequest({ source: 'tmdb', sourceId: 550, type: MediaType.MOVIE }),
+      )
+
+      const callArg = dbMock.mediaItem.create.mock.calls[0][0]
+      expect(callArg.data.user_entry).toEqual({
+        create: { status: WatchStatus.PLAN_TO_WATCH, progress: 0 },
+      })
+      expect(callArg.include).toEqual({ user_entry: true })
+    })
+  })
+
+  describe('idempotent (MediaItem already exists)', () => {
+    it('returns 200 with existing MediaItem + UserEntry when both exist', async () => {
+      const existing = newMediaItem({ user_entry: newUserEntry() })
+      dbMock.mediaItem.findUnique.mockResolvedValue(existing)
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 550, type: MediaType.MOVIE }),
+      )
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.mediaItem.id).toBe('cm_test_1')
+      expect(body.merged).toBe(false)
+      expect(dbMock.mediaItem.create).not.toHaveBeenCalled()
+      expect(dbMock.userEntry.create).not.toHaveBeenCalled()
+      expect(tmdbMock.getMovie).not.toHaveBeenCalled()
+    })
+
+    it('returns 201 when MediaItem exists but UserEntry does not (creates UserEntry only)', async () => {
+      const existing = newMediaItem({ user_entry: null })
+      dbMock.mediaItem.findUnique.mockResolvedValue(existing)
+      dbMock.userEntry.create.mockResolvedValue(newUserEntry())
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 550, type: MediaType.MOVIE }),
+      )
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.merged).toBe(false)
+      expect(dbMock.userEntry.create).toHaveBeenCalledWith({
+        data: {
+          media_item_id: 'cm_test_1',
+          status: WatchStatus.PLAN_TO_WATCH,
+          progress: 0,
+        },
+      })
+    })
+  })
+
+  describe('cross-source merge (AC-4)', () => {
+    it('patches new source ID onto existing row with matching title + year, returns merged: true', async () => {
+      tmdbMock.getMovie.mockResolvedValue(validTmdbMovie)
+      // No existing by tmdb_id
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      // But a cross-source match (anilist row with same title+year, tmdb_id null)
+      const anilistRow = newMediaItem({
+        id: 'cm_anilist_1',
+        tmdb_id: null,
+        anilist_id: 1234,
+        user_entry: newUserEntry({ media_item_id: 'cm_anilist_1' }),
+      })
+      dbMock.mediaItem.findMany.mockResolvedValue([anilistRow])
+      dbMock.mediaItem.update.mockResolvedValue({
+        ...anilistRow,
+        tmdb_id: 550,
+      })
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 550, type: MediaType.MOVIE }),
+      )
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.merged).toBe(true)
+      expect(body.mediaItem.tmdb_id).toBe(550)
+      expect(body.mediaItem.anilist_id).toBe(1234)
+      expect(dbMock.mediaItem.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'cm_anilist_1' },
+          data: { tmdb_id: 550 },
+        }),
+      )
+    })
+
+    it('does NOT cross-merge when title normalises differently (year matches but title does not)', async () => {
+      tmdbMock.getMovie.mockResolvedValue(validTmdbMovie)
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      dbMock.mediaItem.findMany.mockResolvedValue([
+        newMediaItem({
+          id: 'cm_other',
+          title: 'The Matrix',
+          tmdb_id: null,
+        }),
+      ])
+      dbMock.mediaItem.create.mockResolvedValue(
+        newMediaItem({ user_entry: newUserEntry() }),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 550, type: MediaType.MOVIE }),
+      )
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.merged).toBe(false)
+      expect(dbMock.mediaItem.update).not.toHaveBeenCalled()
+      expect(dbMock.mediaItem.create).toHaveBeenCalled()
+    })
+  })
+
+  describe('error paths', () => {
+    it('returns 502 when the adapter throws TmdbApiError', async () => {
+      const { TmdbApiError } = await import('@/lib/api/tmdb')
+      tmdbMock.getMovie.mockRejectedValue(
+        new TmdbApiError('TMDB HTTP 500: /movie/550', {
+          endpoint: '/movie/550',
+          httpStatus: 500,
+        }),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 550, type: MediaType.MOVIE }),
+      )
+
+      expect(res.status).toBe(502)
+      const body = await res.json()
+      expect(body.error).toBe('upstream_failed')
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'media.upstream_failed',
+          source: 'tmdb',
+          sourceId: 550,
+        }),
+        expect.any(String),
+      )
+    })
+
+    it('returns 422 when the normaliser throws ZodError (upstream payload shape drift)', async () => {
+      tmdbMock.getMovie.mockResolvedValue({ ...validTmdbMovie, title: 1234 })
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 550, type: MediaType.MOVIE }),
+      )
+
+      expect(res.status).toBe(422)
+      const body = await res.json()
+      expect(body.error).toBe('normalise_failed')
+      expect(body.issues).toBeDefined()
+    })
+
+    it('returns 400 on Prisma constraint violation (P2002 race lost → idempotent retry)', async () => {
+      tmdbMock.getMovie.mockResolvedValue(validTmdbMovie)
+      dbMock.mediaItem.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(newMediaItem({ user_entry: newUserEntry() }))
+      dbMock.mediaItem.findMany.mockResolvedValue([])
+      dbMock.mediaItem.create.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError(
+          'Unique constraint failed on the fields: (`tmdb_id`)',
+          { code: 'P2002', clientVersion: '6.0.0' },
+        ),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 550, type: MediaType.MOVIE }),
+      )
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.merged).toBe(false)
+    })
+
+    it('returns 400 on Prisma constraint violation (P2004 CHECK failure)', async () => {
+      tmdbMock.getMovie.mockResolvedValue(validTmdbMovie)
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      dbMock.mediaItem.findMany.mockResolvedValue([])
+      dbMock.mediaItem.create.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError(
+          'CHECK constraint failed: progress >= 0',
+          { code: 'P2004', clientVersion: '6.0.0' },
+        ),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 550, type: MediaType.MOVIE }),
+      )
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('constraint_violation')
+      expect(body.code).toBe('P2004')
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'media.constraint_violation',
+          code: 'P2004',
+        }),
+        expect.any(String),
+      )
+    })
+  })
+})

--- a/app/api/media/__tests__/route.test.ts
+++ b/app/api/media/__tests__/route.test.ts
@@ -428,6 +428,53 @@ describe('POST /api/media', () => {
       )
     })
 
+    it('returns idempotent 200 when ensureUserEntry hits P2002 (concurrent UserEntry create)', async () => {
+      const existing = newMediaItem({ user_entry: null })
+      dbMock.mediaItem.findUnique
+        .mockResolvedValueOnce(existing)
+        .mockResolvedValueOnce(
+          newMediaItem({ user_entry: newUserEntry() }),
+        )
+      dbMock.userEntry.create.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError(
+          'Unique constraint failed on the fields: (`media_item_id`)',
+          { code: 'P2002', clientVersion: '6.0.0' },
+        ),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 550, type: MediaType.MOVIE }),
+      )
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.merged).toBe(false)
+      expect(body.mediaItem.user_entry.status).toBe(WatchStatus.PLAN_TO_WATCH)
+    })
+
+    it('skips cross-merge when the normaliser fell back to the 1970 sentinel', async () => {
+      tmdbMock.getMovie.mockResolvedValue({
+        ...validTmdbMovie,
+        release_date: '',
+      })
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      dbMock.mediaItem.create.mockResolvedValue(
+        newMediaItem({
+          release_date: new Date('1970-01-01T00:00:00Z'),
+          user_entry: newUserEntry(),
+        }),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 550, type: MediaType.MOVIE }),
+      )
+
+      expect(res.status).toBe(201)
+      expect(dbMock.mediaItem.findMany).not.toHaveBeenCalled()
+    })
+
     it('returns 422 when the normaliser throws ZodError (upstream payload shape drift)', async () => {
       tmdbMock.getMovie.mockResolvedValue({ ...validTmdbMovie, title: 1234 })
       const { POST } = await import('@/app/api/media/route')
@@ -442,7 +489,7 @@ describe('POST /api/media', () => {
       expect(body.issues).toBeDefined()
     })
 
-    it('returns 400 on Prisma constraint violation (P2002 race lost → idempotent retry)', async () => {
+    it('returns 200 idempotent when P2002 race-loss is detected (concurrent POST won)', async () => {
       tmdbMock.getMovie.mockResolvedValue(validTmdbMovie)
       dbMock.mediaItem.findUnique
         .mockResolvedValueOnce(null)
@@ -485,6 +532,7 @@ describe('POST /api/media', () => {
       const body = await res.json()
       expect(body.error).toBe('constraint_violation')
       expect(body.code).toBe('P2004')
+      expect(body.message).toBeUndefined()
       expect(loggerMock.warn).toHaveBeenCalledWith(
         expect.objectContaining({
           event: 'media.constraint_violation',

--- a/app/api/media/route.ts
+++ b/app/api/media/route.ts
@@ -1,0 +1,284 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { z, ZodError } from 'zod'
+import { MediaType, Prisma, WatchStatus, type UserEntry } from '@prisma/client'
+import { db } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import { withRequest } from '@/lib/request-context'
+import { TmdbApiError } from '@/lib/api/tmdb'
+import {
+  getDispatcher,
+  type AddMediaSource,
+} from '@/lib/search/media-dispatcher'
+import { normaliseTitle } from '@/lib/search/federation'
+
+export const dynamic = 'force-dynamic'
+
+const AddMediaBodySchema = z.object({
+  source: z.enum(['tmdb', 'anilist', 'igdb', 'steam']),
+  sourceId: z.coerce.number().int().positive(),
+  type: z.nativeEnum(MediaType),
+})
+
+type MediaItemWithUserEntry = Prisma.MediaItemGetPayload<{
+  include: { user_entry: true }
+}>
+
+const NEW_USER_ENTRY = {
+  status: WatchStatus.PLAN_TO_WATCH,
+  progress: 0,
+} as const
+
+function findExistingBySourceId(
+  source: AddMediaSource,
+  sourceId: number,
+): Promise<MediaItemWithUserEntry | null> {
+  const include = { user_entry: true } as const
+  switch (source) {
+    case 'tmdb':
+      return db.mediaItem.findUnique({ where: { tmdb_id: sourceId }, include })
+    case 'anilist':
+      return db.mediaItem.findUnique({
+        where: { anilist_id: sourceId },
+        include,
+      })
+    case 'igdb':
+      return db.mediaItem.findUnique({ where: { igdb_id: sourceId }, include })
+    case 'steam':
+      return db.mediaItem.findUnique({
+        where: { steam_id: sourceId },
+        include,
+      })
+  }
+}
+
+function findCrossSourceCandidates(
+  source: AddMediaSource,
+  releaseYear: number,
+): Promise<MediaItemWithUserEntry[]> {
+  const include = { user_entry: true } as const
+  const yearStart = new Date(Date.UTC(releaseYear, 0, 1))
+  const yearEnd = new Date(Date.UTC(releaseYear + 1, 0, 1))
+  const release_date = { gte: yearStart, lt: yearEnd }
+  switch (source) {
+    case 'tmdb':
+      return db.mediaItem.findMany({
+        where: { tmdb_id: null, release_date },
+        include,
+        take: 50,
+      })
+    case 'anilist':
+      return db.mediaItem.findMany({
+        where: { anilist_id: null, release_date },
+        include,
+        take: 50,
+      })
+    case 'igdb':
+      return db.mediaItem.findMany({
+        where: { igdb_id: null, release_date },
+        include,
+        take: 50,
+      })
+    case 'steam':
+      return db.mediaItem.findMany({
+        where: { steam_id: null, release_date },
+        include,
+        take: 50,
+      })
+  }
+}
+
+function patchSourceId(
+  id: string,
+  source: AddMediaSource,
+  sourceId: number,
+): Promise<MediaItemWithUserEntry> {
+  const include = { user_entry: true } as const
+  const data: Prisma.MediaItemUpdateInput =
+    source === 'tmdb'
+      ? { tmdb_id: sourceId }
+      : source === 'anilist'
+        ? { anilist_id: sourceId }
+        : source === 'igdb'
+          ? { igdb_id: sourceId }
+          : { steam_id: sourceId }
+  return db.mediaItem.update({ where: { id }, data, include })
+}
+
+async function ensureUserEntry(
+  mediaItem: MediaItemWithUserEntry,
+): Promise<{ mediaItem: MediaItemWithUserEntry; created: boolean }> {
+  if (mediaItem.user_entry) return { mediaItem, created: false }
+  const userEntry: UserEntry = await db.userEntry.create({
+    data: { media_item_id: mediaItem.id, ...NEW_USER_ENTRY },
+  })
+  return {
+    mediaItem: { ...mediaItem, user_entry: userEntry },
+    created: true,
+  }
+}
+
+function jsonResponse(
+  body: unknown,
+  status: number,
+): NextResponse {
+  return NextResponse.json(body, {
+    status,
+    headers: { 'Cache-Control': 'no-store' },
+  })
+}
+
+async function handler(req: NextRequest): Promise<NextResponse> {
+  let rawBody: unknown
+  try {
+    rawBody = await req.json()
+  } catch {
+    logger.warn(
+      { event: 'media.bad_request', reason: 'invalid_json' },
+      'media body was not valid JSON',
+    )
+    return jsonResponse({ error: 'invalid_body', reason: 'invalid_json' }, 400)
+  }
+
+  const parsed = AddMediaBodySchema.safeParse(rawBody)
+  if (!parsed.success) {
+    logger.warn(
+      { event: 'media.bad_request', issues: parsed.error.issues },
+      'media body validation failed',
+    )
+    return jsonResponse(
+      { error: 'invalid_body', issues: parsed.error.issues },
+      400,
+    )
+  }
+
+  const { source, sourceId, type } = parsed.data
+
+  const dispatcher = getDispatcher(source, type)
+  if (!dispatcher) {
+    logger.warn(
+      { event: 'media.unsupported_source_type', source, type },
+      'no adapter wired for this (source, type) tuple',
+    )
+    return jsonResponse(
+      { error: 'unsupported_source_type', source, type },
+      501,
+    )
+  }
+
+  // Idempotent fast-path: if a MediaItem already has this exact source ID,
+  // skip the adapter fetch entirely. Saves a TMDB round-trip on retries.
+  const existingBySource = await findExistingBySourceId(source, sourceId)
+  if (existingBySource) {
+    const ensured = await ensureUserEntry(existingBySource)
+    return jsonResponse(
+      { mediaItem: ensured.mediaItem, merged: false },
+      ensured.created ? 201 : 200,
+    )
+  }
+
+  let raw: unknown
+  try {
+    raw = await dispatcher.fetch(sourceId)
+  } catch (err) {
+    if (err instanceof TmdbApiError) {
+      logger.warn(
+        {
+          event: 'media.upstream_failed',
+          source,
+          sourceId,
+          endpoint: err.endpoint,
+          httpStatus: err.httpStatus,
+          err,
+        },
+        'upstream adapter rejected',
+      )
+      return jsonResponse(
+        { error: 'upstream_failed', source, sourceId },
+        502,
+      )
+    }
+    throw err
+  }
+
+  let normalised: Prisma.MediaItemCreateInput
+  try {
+    normalised = dispatcher.normalise(raw)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      logger.warn(
+        {
+          event: 'media.normalise_failed',
+          source,
+          sourceId,
+          issues: err.issues,
+        },
+        'normaliser rejected upstream payload',
+      )
+      return jsonResponse(
+        { error: 'normalise_failed', issues: err.issues },
+        422,
+      )
+    }
+    throw err
+  }
+
+  try {
+    const releaseYear = normalised.release_date instanceof Date
+      ? normalised.release_date.getUTCFullYear()
+      : new Date(normalised.release_date as string).getUTCFullYear()
+    const normalisedKey = normaliseTitle(normalised.title)
+    const candidates = await findCrossSourceCandidates(source, releaseYear)
+    const crossMatch = candidates.find(
+      (c) => normaliseTitle(c.title) === normalisedKey,
+    )
+
+    if (crossMatch) {
+      const patched = await patchSourceId(crossMatch.id, source, sourceId)
+      const ensured = await ensureUserEntry(patched)
+      return jsonResponse(
+        { mediaItem: ensured.mediaItem, merged: true },
+        ensured.created ? 201 : 200,
+      )
+    }
+
+    const created: MediaItemWithUserEntry = await db.mediaItem.create({
+      data: {
+        ...normalised,
+        user_entry: { create: NEW_USER_ENTRY },
+      },
+      include: { user_entry: true },
+    })
+    return jsonResponse({ mediaItem: created, merged: false }, 201)
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError) {
+      if (err.code === 'P2002') {
+        const racedExisting = await findExistingBySourceId(source, sourceId)
+        if (racedExisting) {
+          const ensured = await ensureUserEntry(racedExisting)
+          return jsonResponse(
+            { mediaItem: ensured.mediaItem, merged: false },
+            200,
+          )
+        }
+      }
+      logger.warn(
+        {
+          event: 'media.constraint_violation',
+          source,
+          sourceId,
+          type,
+          code: err.code,
+          err,
+        },
+        'database constraint violation',
+      )
+      return jsonResponse(
+        { error: 'constraint_violation', code: err.code, message: err.message },
+        400,
+      )
+    }
+    throw err
+  }
+}
+
+export const POST = withRequest<NextRequest, NextResponse>(handler)

--- a/app/api/media/route.ts
+++ b/app/api/media/route.ts
@@ -108,12 +108,30 @@ async function ensureUserEntry(
   mediaItem: MediaItemWithUserEntry,
 ): Promise<{ mediaItem: MediaItemWithUserEntry; created: boolean }> {
   if (mediaItem.user_entry) return { mediaItem, created: false }
-  const userEntry: UserEntry = await db.userEntry.create({
-    data: { media_item_id: mediaItem.id, ...NEW_USER_ENTRY },
-  })
-  return {
-    mediaItem: { ...mediaItem, user_entry: userEntry },
-    created: true,
+  try {
+    const userEntry: UserEntry = await db.userEntry.create({
+      data: { media_item_id: mediaItem.id, ...NEW_USER_ENTRY },
+    })
+    return {
+      mediaItem: { ...mediaItem, user_entry: userEntry },
+      created: true,
+    }
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === 'P2002'
+    ) {
+      // Concurrent POST won the race on UserEntry.media_item_id @unique.
+      // Re-fetch the row + its entry and treat the response as idempotent.
+      const refetched = await db.mediaItem.findUnique({
+        where: { id: mediaItem.id },
+        include: { user_entry: true },
+      })
+      if (refetched?.user_entry) {
+        return { mediaItem: refetched, created: false }
+      }
+    }
+    throw err
   }
 }
 
@@ -227,7 +245,12 @@ async function handler(req: NextRequest): Promise<NextResponse> {
       ? normalised.release_date.getUTCFullYear()
       : new Date(normalised.release_date as string).getUTCFullYear()
     const normalisedKey = normaliseTitle(normalised.title)
-    const candidates = await findCrossSourceCandidates(source, releaseYear)
+    // Skip cross-merge when the normaliser fell back to the 1970 sentinel —
+    // every undated item shares that year bucket and would falsely collide.
+    const candidates =
+      releaseYear === 1970
+        ? []
+        : await findCrossSourceCandidates(source, releaseYear)
     const crossMatch = candidates.find(
       (c) => normaliseTitle(c.title) === normalisedKey,
     )
@@ -272,8 +295,9 @@ async function handler(req: NextRequest): Promise<NextResponse> {
         },
         'database constraint violation',
       )
+      // Omit err.message in the response to avoid leaking schema column names.
       return jsonResponse(
-        { error: 'constraint_violation', code: err.code, message: err.message },
+        { error: 'constraint_violation', code: err.code },
         400,
       )
     }

--- a/app/api/search/__tests__/route.test.ts
+++ b/app/api/search/__tests__/route.test.ts
@@ -102,6 +102,14 @@ describe('GET /api/search', () => {
       expect(res.status).toBe(400)
     })
 
+    it('returns 400 when q is whitespace-only (Zod .trim() then .min(1))', async () => {
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search?q=%20%20%20'))
+
+      expect(res.status).toBe(400)
+    })
+
     it('returns 400 when q exceeds 200 characters', async () => {
       const { GET } = await import('@/app/api/search/route')
 

--- a/app/api/search/__tests__/route.test.ts
+++ b/app/api/search/__tests__/route.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const loggerMock = vi.hoisted(() => ({
+  fatal: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: loggerMock,
+  createLogger: () => loggerMock,
+}))
+
+const tmdbMock = vi.hoisted(() => ({
+  searchMulti: vi.fn(),
+}))
+
+vi.mock('@/lib/api/tmdb', () => ({
+  searchMulti: tmdbMock.searchMulti,
+}))
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.resetAllMocks()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+function makeRequest(path: string): NextRequest {
+  return new NextRequest(new URL(path, 'http://localhost'))
+}
+
+const movieResult = {
+  media_type: 'movie',
+  id: 550,
+  title: 'Fight Club',
+  release_date: '1999-10-15',
+  poster_path: '/poster.jpg',
+  vote_average: 8.4,
+  popularity: 64.2,
+} as const
+
+const tvResult = {
+  media_type: 'tv',
+  id: 1399,
+  name: 'Game of Thrones',
+  first_air_date: '2011-04-17',
+  vote_average: 8.4,
+} as const
+
+const personResult = {
+  media_type: 'person',
+  id: 287,
+  name: 'Brad Pitt',
+  known_for_department: 'Acting',
+} as const
+
+describe('GET /api/search', () => {
+  describe('query validation', () => {
+    it('returns 400 when q is missing', async () => {
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search'))
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('invalid_query')
+      expect(body.issues[0].path).toEqual(['q'])
+    })
+
+    it('returns 400 when q is an empty string', async () => {
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search?q='))
+
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 when q exceeds 200 characters', async () => {
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(
+        makeRequest(`/api/search?q=${'a'.repeat(201)}`),
+      )
+
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 when type is not in the allowed enum', async () => {
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search?q=foo&type=podcast'))
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.issues[0].path).toEqual(['type'])
+    })
+
+    it('logs validation failures at warn level', async () => {
+      const { GET } = await import('@/app/api/search/route')
+
+      await GET(makeRequest('/api/search'))
+
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'search.bad_request' }),
+        expect.any(String),
+      )
+    })
+  })
+
+  describe('happy path', () => {
+    it('returns adapted movie + tv results from TMDB; filters person', async () => {
+      tmdbMock.searchMulti.mockResolvedValue({
+        page: 1,
+        results: [movieResult, tvResult, personResult],
+        total_pages: 1,
+        total_results: 3,
+      })
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search?q=foo'))
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.results).toHaveLength(2)
+      expect(body.partialFailure).toBe(false)
+      expect(body.results[0]).toMatchObject({
+        type: 'movie',
+        title: 'Fight Club',
+        tmdb_id: 550,
+        primary_source: 'tmdb',
+        release_year: 1999,
+        confidence: 1.0,
+      })
+      expect(body.results[1]).toMatchObject({
+        type: 'tv',
+        title: 'Game of Thrones',
+        tmdb_id: 1399,
+      })
+    })
+
+    it('sets Cache-Control: no-store on success', async () => {
+      tmdbMock.searchMulti.mockResolvedValue({
+        page: 1,
+        results: [],
+        total_pages: 1,
+        total_results: 0,
+      })
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search?q=foo'))
+
+      expect(res.headers.get('Cache-Control')).toBe('no-store')
+    })
+  })
+
+  describe('type filter', () => {
+    it('type=movie excludes the tv result', async () => {
+      tmdbMock.searchMulti.mockResolvedValue({
+        page: 1,
+        results: [movieResult, tvResult],
+        total_pages: 1,
+        total_results: 2,
+      })
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search?q=foo&type=movie'))
+
+      const body = await res.json()
+      expect(body.results).toHaveLength(1)
+      expect(body.results[0].type).toBe('movie')
+    })
+
+    it('type=tv excludes the movie result', async () => {
+      tmdbMock.searchMulti.mockResolvedValue({
+        page: 1,
+        results: [movieResult, tvResult],
+        total_pages: 1,
+        total_results: 2,
+      })
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search?q=foo&type=tv'))
+
+      const body = await res.json()
+      expect(body.results).toHaveLength(1)
+      expect(body.results[0].type).toBe('tv')
+    })
+
+    it('type=anime returns empty + partialFailure:false (no adapters wired in E4)', async () => {
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search?q=foo&type=anime'))
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body).toEqual({ results: [], partialFailure: false })
+      expect(tmdbMock.searchMulti).not.toHaveBeenCalled()
+    })
+
+    it('type=game returns empty + partialFailure:false (no adapters wired in E4)', async () => {
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search?q=foo&type=game'))
+
+      const body = await res.json()
+      expect(body).toEqual({ results: [], partialFailure: false })
+      expect(tmdbMock.searchMulti).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('partial failure', () => {
+    it('flags partialFailure: true when TMDB rejects, returns empty results', async () => {
+      tmdbMock.searchMulti.mockRejectedValue(new Error('boom'))
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search?q=foo'))
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.results).toEqual([])
+      expect(body.partialFailure).toBe(true)
+    })
+
+    it('logs each adapter rejection at warn with { source, durationMs, err }', async () => {
+      const failure = new Error('TMDB down')
+      tmdbMock.searchMulti.mockRejectedValue(failure)
+      const { GET } = await import('@/app/api/search/route')
+
+      await GET(makeRequest('/api/search?q=foo'))
+
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'search.adapter_failed',
+          source: 'tmdb',
+          err: failure,
+        }),
+        expect.any(String),
+      )
+    })
+  })
+})

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { z } from 'zod'
+import { logger } from '@/lib/logger'
+import { withRequest } from '@/lib/request-context'
+import {
+  ADAPTERS,
+  dedupResults,
+  type SearchType,
+  type UnifiedSearchResult,
+} from '@/lib/search/federation'
+
+export const dynamic = 'force-dynamic'
+
+const SearchQuerySchema = z.object({
+  q: z.string().min(1).max(200),
+  type: z.enum(['movie', 'tv', 'anime', 'game']).optional(),
+})
+
+async function handler(req: NextRequest): Promise<NextResponse> {
+  const params = Object.fromEntries(req.nextUrl.searchParams)
+  const parsed = SearchQuerySchema.safeParse(params)
+
+  if (!parsed.success) {
+    logger.warn(
+      { event: 'search.bad_request', issues: parsed.error.issues },
+      'search query validation failed',
+    )
+    return NextResponse.json(
+      { error: 'invalid_query', issues: parsed.error.issues },
+      { status: 400, headers: { 'Cache-Control': 'no-store' } },
+    )
+  }
+
+  const { q, type } = parsed.data
+
+  const dispatched = ADAPTERS.filter(
+    (adapter) => type === undefined || adapter.supportedTypes.includes(type),
+  )
+
+  const settled = await Promise.allSettled(
+    dispatched.map(async (adapter) => {
+      const startedAt = Date.now()
+      try {
+        const results = await adapter.search(q, type)
+        return { source: adapter.source, results }
+      } catch (err) {
+        logger.warn(
+          {
+            event: 'search.adapter_failed',
+            source: adapter.source,
+            durationMs: Date.now() - startedAt,
+            err,
+          },
+          'search adapter rejected',
+        )
+        throw err
+      }
+    }),
+  )
+
+  const successes: UnifiedSearchResult[] = []
+  let failureCount = 0
+  for (const outcome of settled) {
+    if (outcome.status === 'fulfilled') {
+      successes.push(...outcome.value.results)
+    } else {
+      failureCount += 1
+    }
+  }
+
+  const results = dedupResults(successes)
+  const partialFailure = failureCount > 0
+
+  return NextResponse.json(
+    { results, partialFailure },
+    { status: 200, headers: { 'Cache-Control': 'no-store' } },
+  )
+}
+
+export const GET = withRequest<NextRequest, NextResponse>(handler)
+export type { SearchType, UnifiedSearchResult }

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -12,7 +12,7 @@ import {
 export const dynamic = 'force-dynamic'
 
 const SearchQuerySchema = z.object({
-  q: z.string().min(1).max(200),
+  q: z.string().trim().min(1).max(200),
   type: z.enum(['movie', 'tv', 'anime', 'game']).optional(),
 })
 

--- a/lib/search/__tests__/federation.test.ts
+++ b/lib/search/__tests__/federation.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { UnifiedSearchResult } from '@/lib/search/federation'
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+function movie(
+  title: string,
+  year: number,
+  tmdbId: number,
+): UnifiedSearchResult {
+  return {
+    type: 'movie',
+    title,
+    release_year: year,
+    primary_source: 'tmdb',
+    tmdb_id: tmdbId,
+    confidence: 1.0,
+  }
+}
+
+describe('lib/search/federation: normaliseTitle', () => {
+  it('lowercases and strips non-alphanumeric characters', async () => {
+    const { normaliseTitle } = await import('@/lib/search/federation')
+
+    expect(normaliseTitle('Fight Club')).toBe('fightclub')
+    expect(normaliseTitle('Spider-Man: No Way Home')).toBe(
+      'spidermannowayhome',
+    )
+    expect(normaliseTitle("Schindler's List")).toBe('schindlerslist')
+  })
+
+  it('keeps numbers in titles', async () => {
+    const { normaliseTitle } = await import('@/lib/search/federation')
+
+    expect(normaliseTitle('Se7en')).toBe('se7en')
+    expect(normaliseTitle('Catch-22')).toBe('catch22')
+  })
+
+  it('treats different punctuation as the same key', async () => {
+    const { normaliseTitle } = await import('@/lib/search/federation')
+
+    expect(normaliseTitle('Fight Club')).toBe(normaliseTitle('fight-club'))
+    expect(normaliseTitle('Star Wars')).toBe(normaliseTitle('Star/Wars'))
+  })
+
+  it('keeps "The Office" (US) vs "The Office" (UK) distinct via year axis', async () => {
+    const { normaliseTitle } = await import('@/lib/search/federation')
+
+    expect(normaliseTitle('The Office')).toBe('theoffice')
+  })
+})
+
+describe('lib/search/federation: dedupResults', () => {
+  it('passes single-source results through unchanged with confidence 1.0', async () => {
+    const { dedupResults } = await import('@/lib/search/federation')
+    const input = [movie('Fight Club', 1999, 550)]
+
+    const result = dedupResults(input)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ tmdb_id: 550, confidence: 1.0 })
+  })
+
+  it('merges two-source matches with confidence 0.9', async () => {
+    const { dedupResults } = await import('@/lib/search/federation')
+    const tmdbResult = movie('Fight Club', 1999, 550)
+    const anilistResult: UnifiedSearchResult = {
+      ...movie('fight-club', 1999, 0),
+      tmdb_id: undefined,
+      anilist_id: 1234,
+      primary_source: 'anilist',
+    }
+
+    const result = dedupResults([tmdbResult, anilistResult])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      tmdb_id: 550,
+      anilist_id: 1234,
+      confidence: 0.9,
+    })
+  })
+
+  it('drops confidence to 0.8 on three-source matches', async () => {
+    const { dedupResults } = await import('@/lib/search/federation')
+    const a: UnifiedSearchResult = movie('Fight Club', 1999, 550)
+    const b: UnifiedSearchResult = {
+      ...movie('fight club', 1999, 0),
+      tmdb_id: undefined,
+      anilist_id: 1234,
+      primary_source: 'anilist',
+    }
+    const c: UnifiedSearchResult = {
+      ...movie('FightClub', 1999, 0),
+      tmdb_id: undefined,
+      igdb_id: 9999,
+      primary_source: 'igdb',
+    }
+
+    const result = dedupResults([a, b, c])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      tmdb_id: 550,
+      anilist_id: 1234,
+      igdb_id: 9999,
+      confidence: 0.8,
+    })
+  })
+
+  it('does NOT merge results whose release_year differs (The Office US vs UK)', async () => {
+    const { dedupResults } = await import('@/lib/search/federation')
+    const us = movie('The Office', 2005, 2316)
+    const uk = movie('The Office', 2001, 2606)
+
+    const result = dedupResults([us, uk])
+
+    expect(result).toHaveLength(2)
+  })
+
+  it('uses 0 as the year-key when release_year is undefined (still groups by title)', async () => {
+    const { dedupResults } = await import('@/lib/search/federation')
+    const a: UnifiedSearchResult = {
+      ...movie('Untitled', 0, 1),
+      release_year: undefined,
+    }
+    const b: UnifiedSearchResult = {
+      ...movie('untitled', 0, 0),
+      release_year: undefined,
+      tmdb_id: undefined,
+      anilist_id: 5,
+      primary_source: 'anilist',
+    }
+
+    const result = dedupResults([a, b])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ tmdb_id: 1, anilist_id: 5 })
+  })
+
+  it('does not mutate the input array entries', async () => {
+    const { dedupResults } = await import('@/lib/search/federation')
+    const input = [movie('Fight Club', 1999, 550)]
+    const inputCopy = JSON.parse(JSON.stringify(input))
+
+    dedupResults(input)
+
+    expect(input).toEqual(inputCopy)
+  })
+
+  it('returns an empty array when given empty input', async () => {
+    const { dedupResults } = await import('@/lib/search/federation')
+
+    expect(dedupResults([])).toEqual([])
+  })
+})

--- a/lib/search/__tests__/federation.test.ts
+++ b/lib/search/__tests__/federation.test.ts
@@ -74,6 +74,30 @@ describe('lib/search/federation: normaliseTitle', () => {
 
     expect(normaliseTitle('The Office')).toBe('theoffice')
   })
+
+  it('preserves non-Latin characters (Japanese / Korean / Chinese) for anime + manga matching', async () => {
+    const { normaliseTitle } = await import('@/lib/search/federation')
+
+    expect(normaliseTitle('進撃の巨人')).toBe('進撃の巨人')
+    expect(normaliseTitle('ワンピース')).toBe('ワンピース')
+    expect(normaliseTitle('진격의 거인')).toBe('진격의거인')
+  })
+
+  it('preserves accented characters via NFC (Pokémon stays Pokémon)', async () => {
+    const { normaliseTitle } = await import('@/lib/search/federation')
+
+    expect(normaliseTitle('Pokémon')).toBe('pokémon')
+    expect(normaliseTitle('Léon')).toBe('léon')
+    expect(normaliseTitle('Spinal Tap')).toBe('spinaltap')
+  })
+
+  it('treats canonically equivalent Unicode sequences as the same key (NFC)', async () => {
+    const { normaliseTitle } = await import('@/lib/search/federation')
+
+    const composed = 'café'
+    const decomposed = 'café'
+    expect(normaliseTitle(composed)).toBe(normaliseTitle(decomposed))
+  })
 })
 
 describe('lib/search/federation: dedupResults', () => {

--- a/lib/search/__tests__/media-dispatcher.test.ts
+++ b/lib/search/__tests__/media-dispatcher.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { MediaType } from '@prisma/client'
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('lib/search/media-dispatcher: getDispatcher', () => {
+  it('returns a dispatcher for (tmdb, MOVIE)', async () => {
+    const { getDispatcher } = await import('@/lib/search/media-dispatcher')
+
+    const result = getDispatcher('tmdb', MediaType.MOVIE)
+
+    expect(result).not.toBeNull()
+    expect(result?.sourceIdKey).toBe('tmdb_id')
+    expect(typeof result?.fetch).toBe('function')
+    expect(typeof result?.normalise).toBe('function')
+  })
+
+  it('returns null for every other (source, type) tuple in E4', async () => {
+    const { getDispatcher } = await import('@/lib/search/media-dispatcher')
+
+    const sources = ['tmdb', 'anilist', 'igdb', 'steam'] as const
+    const types: MediaType[] = [
+      MediaType.MOVIE,
+      MediaType.TV_SHOW,
+      MediaType.TV_EPISODE,
+      MediaType.ANIME,
+      MediaType.MANGA,
+      MediaType.GAME,
+    ]
+
+    for (const source of sources) {
+      for (const type of types) {
+        const dispatcher = getDispatcher(source, type)
+        if (source === 'tmdb' && type === MediaType.MOVIE) {
+          expect(dispatcher).not.toBeNull()
+        } else {
+          expect(dispatcher).toBeNull()
+        }
+      }
+    }
+  })
+})

--- a/lib/search/__tests__/media-dispatcher.test.ts
+++ b/lib/search/__tests__/media-dispatcher.test.ts
@@ -41,6 +41,20 @@ describe('lib/search/media-dispatcher: getDispatcher', () => {
     expect(typeof result?.normalise).toBe('function')
   })
 
+  it("the (tmdb, MOVIE) dispatcher's fetch calls getMovie with the source ID", async () => {
+    const { searchMulti: _ } = await import('@/lib/api/tmdb')
+    const { getDispatcher } = await import('@/lib/search/media-dispatcher')
+    const tmdb = await import('@/lib/api/tmdb')
+    const spy = vi
+      .spyOn(tmdb, 'getMovie')
+      .mockResolvedValue({} as never)
+
+    const dispatcher = getDispatcher('tmdb', MediaType.MOVIE)
+    await dispatcher?.fetch(550)
+
+    expect(spy).toHaveBeenCalledWith(550)
+  })
+
   it('returns null for every other (source, type) tuple in E4', async () => {
     const { getDispatcher } = await import('@/lib/search/media-dispatcher')
 

--- a/lib/search/federation.ts
+++ b/lib/search/federation.ts
@@ -28,7 +28,10 @@ export type AdapterCapability = {
 }
 
 export function normaliseTitle(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9]/g, '')
+  return s
+    .normalize('NFC')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]/gu, '')
 }
 
 function extractYear(dateString: string | undefined | null): number | undefined {

--- a/lib/search/federation.ts
+++ b/lib/search/federation.ts
@@ -1,0 +1,124 @@
+import { searchMulti, type TmdbSearchMultiResult } from '@/lib/api/tmdb'
+
+export type SearchType = 'movie' | 'tv' | 'anime' | 'game'
+
+export type SearchSource = 'tmdb' | 'anilist' | 'igdb' | 'steam'
+
+export type UnifiedSearchResult = {
+  type: Exclude<SearchType, never>
+  title: string
+  release_year?: number
+  poster_path?: string | null
+  overview?: string | null
+  primary_source: SearchSource
+  tmdb_id?: number
+  anilist_id?: number
+  igdb_id?: number
+  steam_id?: number
+  confidence: number
+}
+
+export type AdapterCapability = {
+  source: SearchSource
+  supportedTypes: readonly SearchType[]
+  search: (
+    query: string,
+    type: SearchType | undefined,
+  ) => Promise<UnifiedSearchResult[]>
+}
+
+export function normaliseTitle(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+function extractYear(dateString: string | undefined | null): number | undefined {
+  if (!dateString) return undefined
+  const match = /^(\d{4})/.exec(dateString)
+  return match ? Number.parseInt(match[1], 10) : undefined
+}
+
+function adaptTmdbResult(
+  result: TmdbSearchMultiResult,
+): UnifiedSearchResult | null {
+  if (result.media_type === 'person') return null
+
+  if (result.media_type === 'movie') {
+    return {
+      type: 'movie',
+      title: result.title,
+      release_year: extractYear(result.release_date),
+      poster_path: result.poster_path ?? null,
+      overview: result.overview ?? null,
+      primary_source: 'tmdb',
+      tmdb_id: result.id,
+      confidence: 1.0,
+    }
+  }
+
+  return {
+    type: 'tv',
+    title: result.name,
+    release_year: extractYear(result.first_air_date),
+    poster_path: result.poster_path ?? null,
+    overview: result.overview ?? null,
+    primary_source: 'tmdb',
+    tmdb_id: result.id,
+    confidence: 1.0,
+  }
+}
+
+const tmdbAdapter: AdapterCapability = {
+  source: 'tmdb',
+  supportedTypes: ['movie', 'tv'] as const,
+  async search(query, type) {
+    const response = await searchMulti(query)
+    const mapped = response.results
+      .map(adaptTmdbResult)
+      .filter((r): r is UnifiedSearchResult => r !== null)
+    if (type === undefined) return mapped
+    return mapped.filter((r) => r.type === type)
+  },
+}
+
+export const ADAPTERS: readonly AdapterCapability[] = [tmdbAdapter]
+
+const CONFIDENCE_LADDER: Record<number, number> = {
+  1: 1.0,
+  2: 0.9,
+}
+
+function confidenceFor(sourceCount: number): number {
+  if (sourceCount <= 1) return CONFIDENCE_LADDER[1]
+  if (sourceCount === 2) return CONFIDENCE_LADDER[2]
+  return 0.8
+}
+
+export function dedupResults(
+  results: UnifiedSearchResult[],
+): UnifiedSearchResult[] {
+  const byKey = new Map<string, UnifiedSearchResult>()
+  for (const result of results) {
+    const key = `${normaliseTitle(result.title)}::${result.release_year ?? 0}`
+    const existing = byKey.get(key)
+    if (!existing) {
+      byKey.set(key, { ...result })
+      continue
+    }
+    const merged: UnifiedSearchResult = {
+      ...existing,
+      tmdb_id: existing.tmdb_id ?? result.tmdb_id,
+      anilist_id: existing.anilist_id ?? result.anilist_id,
+      igdb_id: existing.igdb_id ?? result.igdb_id,
+      steam_id: existing.steam_id ?? result.steam_id,
+    }
+    const sourceCount = [
+      merged.tmdb_id,
+      merged.anilist_id,
+      merged.igdb_id,
+      merged.steam_id,
+    ].filter((id) => id !== undefined).length
+    merged.confidence = confidenceFor(sourceCount)
+    byKey.set(key, merged)
+  }
+  return Array.from(byKey.values())
+}

--- a/lib/search/media-dispatcher.ts
+++ b/lib/search/media-dispatcher.ts
@@ -1,0 +1,25 @@
+import { MediaType, type Prisma } from '@prisma/client'
+import { getMovie } from '@/lib/api/tmdb'
+import { normaliseTmdbMovie } from '@/lib/normalise/movie'
+
+export type AddMediaSource = 'tmdb' | 'anilist' | 'igdb' | 'steam'
+
+export type AddMediaDispatcher = {
+  fetch: (sourceId: number) => Promise<unknown>
+  normalise: (raw: unknown) => Prisma.MediaItemCreateInput
+  sourceIdKey: 'tmdb_id' | 'anilist_id' | 'igdb_id' | 'steam_id'
+}
+
+export function getDispatcher(
+  source: AddMediaSource,
+  type: MediaType,
+): AddMediaDispatcher | null {
+  if (source === 'tmdb' && type === MediaType.MOVIE) {
+    return {
+      fetch: (id) => getMovie(id),
+      normalise: (raw) => normaliseTmdbMovie(raw),
+      sourceIdKey: 'tmdb_id',
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

Bundled handlers for Epic 4. Federated search + add-to-library, both following the route-handler-as-pure-function pattern. New federation primitives module composes adapters; new dispatcher module routes `(source, type)` to `(fetch, normaliser)`.

- **#97 (Story 4.3)** — `GET /api/search?q&type` + `lib/search/federation.ts`. Adapter registry + Unicode-aware `normaliseTitle` (NFC + `\p{L}\p{N}`) + dedup-by-`(title, year)` with confidence ladder. `Promise.allSettled` semantics; `partialFailure: true` flag. Type-filter routing matrix (anime/game return empty + `partialFailure: false` since AniList/IGDB land in E8/E9). Middleware-matcher coverage assertion added.
- **#98 (Story 4.4)** — `POST /api/media` + `lib/search/media-dispatcher.ts`. Only `(tmdb, MOVIE)` wired in E4 per kickoff decision; all other tuples 501. Idempotent fast-path skips adapter fetch on retries. Cross-source merge code path wired (skips 1970-sentinel year to avoid false-collide on undated items); fires from tests only in E4 since single-source. Error taxonomy: 400 invalid_body / 422 normalise_failed / 502 upstream_failed / 400 constraint_violation (with P2002 race-loss → 200 idempotent re-query).

## Test plan

- [ ] `pnpm typecheck` clean (inside `cuatro-tracker-dev-1`).
- [ ] `pnpm lint` clean.
- [ ] `pnpm vitest run app/api/search app/api/media lib/search __tests__/middleware-matcher.test.ts` — 64 tests pass.
- [ ] CI green.

## Notes

- bmad-code-review run per story (Edge Case Hunter + Acceptance Auditor; Blind Hunter skipped per Epic 2/3 precedent). 4.3: 2 patches applied (trim `q`, NFC + Unicode-aware normalise), 3 defers, 15 dismiss, 0 Auditor violations. 4.4: 4 patches applied (P2002 race in `ensureUserEntry`, 1970-sentinel cross-merge skip, drop schema-leaking message, dispatcher invocation test) + 1 test rename, 2 defers, 11 dismiss, 0 Auditor violations.
- Total diff: ~1650 lines (~530 production / ~1120 tests). Slightly above the 1.5K size ceiling but the test:prod ratio is the bulk. Split into 4.3-only and 4.4-only PRs if reviewing the bundle together is uncomfortable.
- No env / DB migration. `tmdb_id`/`anilist_id`/etc are already on the schema from Story 1.12.
- All deferred items (5 across both stories) logged to `_bmad-output/implementation-artifacts/deferred-work.md`; mostly E8/E9-prep concerns around cross-source dedup that don't fire in single-source E4.

Closes #97
Closes #98