### PR TITLE
feat(search): GlobalSearch organism + /search page UI (#101)

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -828,3 +828,520 @@ body {
     gap: 16px;
   }
 }
+
+/* ============================================================
+   GlobalSearch (Story 4.6) — /search page styles. Bundle source:
+   _bmad-output/design-bundles/cuatro-tracker-2026-04-26/07-search/cuatro-tracker/project/search-styles.css
+   ============================================================ */
+
+.gs {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - 64px);
+  background: var(--ground-base);
+}
+
+/* Sticky search header */
+.gs-header {
+  position: sticky;
+  top: 64px;
+  z-index: 5;
+  padding: 24px 64px 20px;
+  background: var(--ground-base);
+  border-bottom: 1px solid rgba(239, 230, 212, 0.08);
+}
+.gs-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+.gs-title {
+  font-family: var(--font-bitmap);
+  font-size: 26px;
+  letter-spacing: 0.04em;
+  color: var(--phosphor-cream);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  line-height: 1;
+  margin: 0;
+}
+.gs-blocks {
+  display: inline-flex;
+  gap: 1px;
+}
+.gs-b1 { color: #5dd46b; }
+.gs-b2 { color: #ffe556; }
+.gs-b3 { color: #ffb347; }
+.gs-label { padding: 0 8px; }
+.gs-tag {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-ghost);
+}
+
+/* SearchInput molecule */
+.si {
+  margin-bottom: 14px;
+}
+.si-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+  margin-bottom: 6px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.si-hint {
+  font-weight: 400;
+  letter-spacing: 0.18em;
+  color: var(--phosphor-cream-ghost);
+}
+.si-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  border-bottom: 1px solid var(--phosphor-cream-ghost);
+  padding: 8px 2px 10px;
+  transition: border-color 120ms linear, box-shadow 120ms linear;
+}
+.si-wrap[data-focused='true'] {
+  border-bottom: 2px solid var(--neon-blue);
+  box-shadow: 0 1px 0 0 var(--neon-blue),
+    0 6px 12px -6px rgba(63, 169, 255, 0.4),
+    0 0 6px rgba(63, 169, 255, 0.4);
+  padding-bottom: 9px;
+}
+.si-caret {
+  font-family: var(--font-mono);
+  font-size: 22px;
+  color: var(--phosphor-cream-dim);
+  padding-right: 12px;
+  line-height: 1;
+}
+.si-field {
+  flex: 1;
+  background: transparent;
+  border: 0;
+  outline: none;
+  font-family: var(--font-mono);
+  font-size: 22px;
+  color: var(--phosphor-cream);
+  letter-spacing: 0.01em;
+  caret-color: transparent;
+  padding: 0;
+}
+.si-field::placeholder { color: var(--phosphor-cream-ghost); }
+.si-field::selection { background: rgba(63, 169, 255, 0.35); }
+.si-cursor {
+  display: none;
+  width: 10px;
+  height: 22px;
+  background: var(--phosphor-cream);
+  margin-left: 2px;
+  vertical-align: middle;
+  animation: si-blink 1s steps(1) infinite;
+}
+.si-wrap[data-focused='true'] .si-cursor {
+  display: inline-block;
+}
+@keyframes si-blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .si-wrap[data-rm='true'] .si-cursor,
+  .si-wrap:not([data-rm='false']) .si-cursor {
+    animation: none;
+    opacity: 1;
+  }
+}
+.si-wrap[data-rm='false'][data-focused='true'] .si-cursor {
+  animation: si-blink 1s steps(1) infinite;
+  opacity: 1;
+}
+.si-wrap[data-rm='true'] .si-cursor {
+  animation: none;
+  opacity: 1;
+}
+
+/* FilterChips molecule */
+.fcs {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+.fcs-chip {
+  position: relative;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+  padding: 8px 14px 10px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+}
+.fcs-chip:hover { color: var(--phosphor-cream); }
+.fcs-chip[data-active='true'] { color: var(--phosphor-cream); }
+.fcs-chip[data-active='true']::after {
+  content: '';
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  bottom: 4px;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    #5dd46b 0 16.66%,
+    #ffe556 16.66% 33.32%,
+    #ffb347 33.32% 49.98%,
+    #ff6fcf 49.98% 66.64%,
+    #7b5cff 66.64% 83.3%,
+    #3fa9ff 83.3% 100%
+  );
+}
+.fcs-chip[data-muted='true'] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.fcs-soon {
+  display: inline-block;
+  margin-left: 6px;
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  color: var(--phosphor-cream-ghost);
+  text-transform: uppercase;
+  font-style: italic;
+  font-family: var(--font-body);
+}
+
+/* Results region */
+.gs-results {
+  flex: 1;
+  padding: 16px 64px 64px;
+  overflow-y: auto;
+}
+.gs-section { margin-bottom: 24px; }
+.gs-section-header {
+  display: flex;
+  align-items: end;
+  gap: 16px;
+  padding-top: 12px;
+  margin-bottom: 4px;
+}
+.gs-section-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+  flex: 0 0 auto;
+  padding-bottom: 6px;
+}
+.gs-section-count {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  color: var(--phosphor-cream-ghost);
+  font-variant-numeric: tabular-nums;
+  padding-bottom: 6px;
+}
+.gs-section-rule {
+  flex: 1;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    #5dd46b 0 16.66%,
+    #ffe556 16.66% 33.32%,
+    #ffb347 33.32% 49.98%,
+    #ff6fcf 49.98% 66.64%,
+    #7b5cff 66.64% 83.3%,
+    #3fa9ff 83.3% 100%
+  );
+  align-self: end;
+  margin-bottom: 6px;
+}
+.gs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* SearchResultRow */
+.sr-row {
+  display: grid;
+  grid-template-columns: 80px 1fr auto auto;
+  column-gap: 24px;
+  align-items: center;
+  padding: 12px 6px;
+  border-bottom: 1px solid var(--phosphor-cream-ghost);
+  outline: none;
+  position: relative;
+}
+.sr-row:last-child { border-bottom: 0; }
+.sr-row[data-focused='true'] {
+  outline: 2px solid var(--neon-blue);
+  outline-offset: -2px;
+  box-shadow: 0 0 0 1px rgba(63, 169, 255, 0.5),
+    0 6px 16px -6px rgba(63, 169, 255, 0.4),
+    0 0 8px rgba(63, 169, 255, 0.35);
+}
+.sr-cover {
+  width: 80px;
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.sr-cover-fallback {
+  width: 72px;
+  height: 104px;
+  background: var(--plum-dim);
+  font-family: var(--font-bitmap);
+  font-size: 36px;
+  color: var(--phosphor-cream-dim);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--phosphor-cream-ghost);
+}
+.sr-body {
+  min-width: 0;
+}
+.sr-title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 22px;
+  line-height: 1.15;
+  color: var(--phosphor-cream);
+  margin: 0 0 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  letter-spacing: -0.005em;
+}
+.sr-meta {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+  font-variant-numeric: tabular-nums;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.sr-meta .sr-sep { color: var(--phosphor-cream-ghost); }
+.sr-overview {
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 14px;
+  line-height: 1.4;
+  color: var(--phosphor-cream-ghost);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.sr-chips {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: stretch;
+}
+.sr-chip {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+  border: 1px solid var(--phosphor-cream-ghost);
+  padding: 4px 10px;
+  text-align: center;
+  background: transparent;
+  font-variant-numeric: tabular-nums;
+}
+.sr-action {
+  display: flex;
+  align-items: center;
+}
+.sr-action .cpb {
+  min-width: 152px;
+  width: auto;
+}
+
+/* Empty state */
+.gs-empty {
+  padding: 80px 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+}
+.gs-empty-headline {
+  font-family: var(--font-bitmap);
+  font-size: 26px;
+  letter-spacing: 0.04em;
+  color: var(--phosphor-cream);
+  text-shadow: 0 0 8px rgba(239, 230, 212, 0.4);
+  line-height: 1;
+}
+.gs-empty-sub {
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 15px;
+  color: var(--phosphor-cream-ghost);
+  max-width: 540px;
+  line-height: 1.45;
+  margin: 0;
+}
+
+/* Skeleton rows */
+.gs-skel-list { list-style: none; margin: 0; padding: 0; }
+.gs-skel-row {
+  display: grid;
+  grid-template-columns: 80px 1fr auto auto;
+  column-gap: 24px;
+  align-items: center;
+  padding: 12px 6px;
+  border-bottom: 1px solid rgba(122, 116, 104, 0.4);
+}
+.gs-skel-cover {
+  width: 80px;
+  height: 120px;
+  background: rgba(122, 116, 104, 0.35);
+}
+.gs-skel-body { display: flex; flex-direction: column; gap: 8px; }
+.gs-skel-title {
+  height: 22px;
+  width: 60%;
+  background: rgba(122, 116, 104, 0.35);
+}
+.gs-skel-meta {
+  height: 11px;
+  width: 32%;
+  background: rgba(122, 116, 104, 0.35);
+}
+.gs-skel-line {
+  height: 12px;
+  width: 70%;
+  background: rgba(122, 116, 104, 0.35);
+}
+.gs-skel-line.short { width: 50%; }
+.gs-skel-chip {
+  width: 60px;
+  height: 22px;
+  background: rgba(122, 116, 104, 0.35);
+}
+.gs-skel-button {
+  width: 152px;
+  height: 38px;
+  background: rgba(122, 116, 104, 0.35);
+}
+
+/* Partial-failure banner */
+.gs-banner {
+  border-top: 3px solid var(--magenta);
+  background: linear-gradient(
+    180deg,
+    rgba(214, 53, 124, 0.18),
+    rgba(214, 53, 124, 0.06)
+  );
+  padding: 14px 20px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-bottom: 12px;
+}
+.gs-banner-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.gs-banner-title {
+  font-family: var(--font-bitmap);
+  font-size: 22px;
+  color: var(--magenta);
+  text-shadow: 0 0 8px rgba(214, 53, 124, 0.55);
+  letter-spacing: 0.04em;
+  line-height: 1;
+}
+.gs-banner-sub {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+}
+.gs-banner .cpb { min-width: 110px; font-size: 14px; padding: 8px 12px; }
+
+/* Footer keyboard hint */
+.gs-footer {
+  position: sticky;
+  bottom: 0;
+  padding: 8px 64px;
+  background: linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.5));
+  display: flex;
+  gap: 18px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-ghost);
+  font-variant-numeric: tabular-nums;
+  align-items: center;
+  pointer-events: none;
+}
+.gs-kbd {
+  display: inline-block;
+  border: 1px solid var(--phosphor-cream-ghost);
+  padding: 1px 5px;
+  margin-right: 4px;
+  color: var(--phosphor-cream-dim);
+  letter-spacing: 0.1em;
+}
+
+/* Sonner toast skin — override the default Sonner palette to match
+   the cuatro-tracker dark phosphor design. */
+[data-sonner-toast] {
+  background: var(--ground-base) !important;
+  border: 1px solid var(--phosphor-cream-ghost) !important;
+  border-left: 3px solid var(--led-completed) !important;
+  border-radius: 0 !important;
+  padding: 14px 18px 14px 16px !important;
+  box-shadow: 0 12px 32px -8px rgba(0, 0, 0, 0.65) !important;
+  color: var(--phosphor-cream) !important;
+}
+[data-sonner-toast][data-type='error'] {
+  border-left-color: var(--magenta) !important;
+}
+[data-sonner-toast] [data-title] {
+  font-family: var(--font-mono) !important;
+  font-size: 10px !important;
+  letter-spacing: 0.18em !important;
+  text-transform: uppercase !important;
+  color: var(--phosphor-cream-dim) !important;
+}
+[data-sonner-toast] [data-description] {
+  font-family: var(--font-body) !important;
+  font-style: italic !important;
+  font-size: 15px !important;
+  color: var(--phosphor-cream) !important;
+  margin-top: 4px !important;
+}

--- a/app/global.css
+++ b/app/global.css
@@ -837,15 +837,18 @@ body {
 .gs {
   display: flex;
   flex-direction: column;
-  min-height: calc(100vh - 64px);
+  /* Fixed height so the inner `.gs-results` is the scroll container; otherwise
+   * the page-level scroll runs and MainNav (regular flow, not fixed) scrolls
+   * away, leaving a gap at the viewport top. 64px = MainNav height. */
+  height: calc(100vh - 64px);
   background: var(--ground-base);
 }
 
-/* Sticky search header */
+/* Search header sits in normal flow above `.gs-results`. It is NOT sticky
+ * because `.gs-results` owns the scrollable region — the header stays in
+ * view by virtue of being outside that region. */
 .gs-header {
-  position: sticky;
-  top: 64px;
-  z-index: 5;
+  flex: 0 0 auto;
   padding: 24px 64px 20px;
   background: var(--ground-base);
   border-bottom: 1px solid rgba(239, 230, 212, 0.08);
@@ -1293,8 +1296,7 @@ body {
 
 /* Footer keyboard hint */
 .gs-footer {
-  position: sticky;
-  bottom: 0;
+  flex: 0 0 auto;
   padding: 8px 64px;
   background: linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.5));
   display: flex;

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -6,6 +6,7 @@ import { SessionProvider } from 'next-auth/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { useState, type ReactNode } from 'react'
+import { Toaster } from 'sonner'
 import { LenisProvider } from '@/components/atoms/LenisProvider'
 import { SentryErrorFallback } from '@/components/atoms/SentryErrorFallback'
 
@@ -30,6 +31,12 @@ export function Providers({
       <SessionProvider session={session}>
         <QueryClientProvider client={queryClient}>
           <LenisProvider>{children}</LenisProvider>
+          <Toaster
+            position='bottom-right'
+            theme='dark'
+            richColors={false}
+            closeButton={false}
+          />
           <ReactQueryDevtools initialIsOpen={false} />
         </QueryClientProvider>
       </SessionProvider>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,5 @@
+import { GlobalSearch } from '@/components/organisms/GlobalSearch'
+
+export default function SearchPage() {
+  return <GlobalSearch />
+}

--- a/components/molecules/FilterChips/FilterChips.tsx
+++ b/components/molecules/FilterChips/FilterChips.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+export type FilterId = 'ALL' | 'MOVIES' | 'TV' | 'ANIME' | 'GAMES'
+
+export type FilterChipsProps = {
+  active: FilterId
+  onChange: (next: FilterId) => void
+}
+
+type ChipDef = { id: FilterId; label: string; muted: boolean }
+
+const CHIPS: readonly ChipDef[] = [
+  { id: 'ALL', label: 'All', muted: false },
+  { id: 'MOVIES', label: 'Movies', muted: false },
+  { id: 'TV', label: 'TV', muted: false },
+  { id: 'ANIME', label: 'Anime', muted: true },
+  { id: 'GAMES', label: 'Games', muted: true },
+] as const
+
+export function FilterChips({ active, onChange }: FilterChipsProps) {
+  return (
+    <div className='fcs' role='tablist' aria-label='Filter by media type'>
+      {CHIPS.map((c) => {
+        const isActive = c.id === active
+        return (
+          <button
+            key={c.id}
+            type='button'
+            role='tab'
+            className='fcs-chip'
+            data-active={isActive ? 'true' : 'false'}
+            data-muted={c.muted ? 'true' : 'false'}
+            aria-selected={isActive}
+            aria-disabled={c.muted}
+            onClick={() => {
+              if (!c.muted) onChange(c.id)
+            }}
+          >
+            {c.label.toUpperCase()}
+            {c.muted ? <em className='fcs-soon'>(soon)</em> : null}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/molecules/FilterChips/__tests__/FilterChips.test.tsx
+++ b/components/molecules/FilterChips/__tests__/FilterChips.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { FilterChips } from '../FilterChips'
+
+describe('FilterChips', () => {
+  beforeEach(() => {
+    cleanup()
+  })
+
+  it('renders 5 chips: ALL, MOVIES, TV, ANIME, GAMES', () => {
+    render(<FilterChips active='ALL' onChange={() => {}} />)
+
+    expect(screen.getByRole('tab', { name: /^ALL/ })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /^MOVIES/ })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /^TV/ })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /^ANIME/ })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /^GAMES/ })).toBeInTheDocument()
+  })
+
+  it('marks the active chip with aria-selected + data-active', () => {
+    render(<FilterChips active='MOVIES' onChange={() => {}} />)
+
+    const active = screen.getByRole('tab', { name: /^MOVIES/ })
+    expect(active.getAttribute('aria-selected')).toBe('true')
+    expect(active.getAttribute('data-active')).toBe('true')
+
+    const inactive = screen.getByRole('tab', { name: /^TV/ })
+    expect(inactive.getAttribute('aria-selected')).toBe('false')
+    expect(inactive.getAttribute('data-active')).toBe('false')
+  })
+
+  it('renders the (soon) suffix on muted chips (ANIME, GAMES)', () => {
+    render(<FilterChips active='ALL' onChange={() => {}} />)
+
+    const anime = screen.getByRole('tab', { name: /^ANIME/ })
+    const games = screen.getByRole('tab', { name: /^GAMES/ })
+    const movies = screen.getByRole('tab', { name: /^MOVIES/ })
+
+    expect(anime.textContent).toContain('(soon)')
+    expect(games.textContent).toContain('(soon)')
+    expect(movies.textContent).not.toContain('(soon)')
+  })
+
+  it('marks muted chips with aria-disabled + data-muted', () => {
+    render(<FilterChips active='ALL' onChange={() => {}} />)
+
+    const anime = screen.getByRole('tab', { name: /^ANIME/ })
+    expect(anime.getAttribute('aria-disabled')).toBe('true')
+    expect(anime.getAttribute('data-muted')).toBe('true')
+
+    const all = screen.getByRole('tab', { name: /^ALL/ })
+    expect(all.getAttribute('aria-disabled')).toBe('false')
+    expect(all.getAttribute('data-muted')).toBe('false')
+  })
+
+  it('fires onChange when a non-muted chip is clicked', () => {
+    const onChange = vi.fn()
+    render(<FilterChips active='ALL' onChange={onChange} />)
+
+    screen.getByRole('tab', { name: /^TV/ }).click()
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith('TV')
+  })
+
+  it('does NOT fire onChange when a muted chip is clicked', () => {
+    const onChange = vi.fn()
+    render(<FilterChips active='ALL' onChange={onChange} />)
+
+    screen.getByRole('tab', { name: /^ANIME/ }).click()
+    screen.getByRole('tab', { name: /^GAMES/ }).click()
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/components/molecules/FilterChips/index.ts
+++ b/components/molecules/FilterChips/index.ts
@@ -1,0 +1,2 @@
+export { FilterChips } from './FilterChips'
+export type { FilterChipsProps, FilterId } from './FilterChips'

--- a/components/molecules/SearchInput/SearchInput.tsx
+++ b/components/molecules/SearchInput/SearchInput.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import {
+  forwardRef,
+  useEffect,
+  useId,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react'
+
+export type SearchInputProps = {
+  value: string
+  onChange: (next: string) => void
+  placeholder?: string
+  debounceMs?: number
+  reducedMotionOverride?: boolean
+}
+
+export type SearchInputHandle = {
+  focus: () => void
+}
+
+export const SearchInput = forwardRef<SearchInputHandle, SearchInputProps>(
+  function SearchInput(
+    {
+      value,
+      onChange,
+      placeholder = 'Title, year, keyword…',
+      debounceMs = 175,
+      reducedMotionOverride,
+    },
+    ref,
+  ) {
+    const reactId = useId()
+    const inputId = `si-${reactId}`
+    const inputRef = useRef<HTMLInputElement | null>(null)
+    const [draft, setDraft] = useState(value)
+    const [focused, setFocused] = useState(false)
+    const [debouncing, setDebouncing] = useState(false)
+
+    useImperativeHandle(ref, () => ({
+      focus: () => inputRef.current?.focus(),
+    }))
+
+    // Sync draft when parent forces a value change (e.g. ESC clears externally).
+    useEffect(() => {
+      setDraft(value)
+    }, [value])
+
+    // Debounced flush. Clears the debouncing flag when the timer fires or the
+    // draft already matches the parent value (no work to do).
+    useEffect(() => {
+      if (draft === value) {
+        setDebouncing(false)
+        return
+      }
+      setDebouncing(true)
+      const timer = setTimeout(() => {
+        setDebouncing(false)
+        onChange(draft)
+      }, debounceMs)
+      return () => clearTimeout(timer)
+    }, [draft, value, onChange, debounceMs])
+
+    function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setDraft('')
+        setDebouncing(false)
+        onChange('')
+      }
+    }
+
+    const rmValue =
+      reducedMotionOverride === undefined ? undefined : String(reducedMotionOverride)
+
+    return (
+      <div className='si'>
+        <label htmlFor={inputId} className='si-label'>
+          <span>SEARCH</span>
+          <span className='si-hint'>
+            {debouncing ? 'DEBOUNCING…' : 'PRESS ESC TO CLEAR'}
+          </span>
+        </label>
+        <div
+          className='si-wrap'
+          data-focused={focused ? 'true' : 'false'}
+          data-rm={rmValue}
+        >
+          <span className='si-caret' aria-hidden='true'>
+            &gt;
+          </span>
+          <input
+            ref={inputRef}
+            id={inputId}
+            type='search'
+            className='si-field'
+            value={draft}
+            placeholder={placeholder}
+            autoComplete='off'
+            spellCheck={false}
+            aria-label='Search'
+            onChange={(e) => setDraft(e.target.value)}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
+            onKeyDown={handleKeyDown}
+          />
+          <span className='si-cursor' aria-hidden='true' />
+        </div>
+      </div>
+    )
+  },
+)

--- a/components/molecules/SearchInput/SearchInput.tsx
+++ b/components/molecules/SearchInput/SearchInput.tsx
@@ -49,6 +49,14 @@ export const SearchInput = forwardRef<SearchInputHandle, SearchInputProps>(
       setDraft(value)
     }, [value])
 
+    // Pin onChange in a ref so debounce timer is not re-scheduled when callers
+    // pass a non-stable function identity. Defends against parent re-render
+    // churn restarting the timer and effectively disabling the debounce.
+    const onChangeRef = useRef(onChange)
+    useEffect(() => {
+      onChangeRef.current = onChange
+    })
+
     // Debounced flush. Clears the debouncing flag when the timer fires or the
     // draft already matches the parent value (no work to do).
     useEffect(() => {
@@ -59,10 +67,10 @@ export const SearchInput = forwardRef<SearchInputHandle, SearchInputProps>(
       setDebouncing(true)
       const timer = setTimeout(() => {
         setDebouncing(false)
-        onChange(draft)
+        onChangeRef.current(draft)
       }, debounceMs)
       return () => clearTimeout(timer)
-    }, [draft, value, onChange, debounceMs])
+    }, [draft, value, debounceMs])
 
     function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
       if (event.key === 'Escape') {

--- a/components/molecules/SearchInput/__tests__/SearchInput.test.tsx
+++ b/components/molecules/SearchInput/__tests__/SearchInput.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react'
+import { SearchInput } from '../SearchInput'
+
+describe('SearchInput', () => {
+  beforeEach(() => {
+    cleanup()
+  })
+
+  it('renders SEARCH label + hint + caret + input', () => {
+    render(<SearchInput value='' onChange={() => {}} />)
+
+    expect(screen.getByText('SEARCH')).toBeInTheDocument()
+    expect(screen.getByText('PRESS ESC TO CLEAR')).toBeInTheDocument()
+    expect(screen.getByRole('searchbox')).toBeInTheDocument()
+  })
+
+  it('debounces onChange by 175ms by default', () => {
+    vi.useFakeTimers()
+    try {
+      const onChange = vi.fn()
+      render(<SearchInput value='' onChange={onChange} />)
+      const input = screen.getByRole('searchbox') as HTMLInputElement
+
+      fireEvent.change(input, { target: { value: 'f' } })
+      fireEvent.change(input, { target: { value: 'fi' } })
+      fireEvent.change(input, { target: { value: 'fig' } })
+
+      expect(onChange).not.toHaveBeenCalled()
+      act(() => {
+        vi.advanceTimersByTime(170)
+      })
+      expect(onChange).not.toHaveBeenCalled()
+      act(() => {
+        vi.advanceTimersByTime(10)
+      })
+      expect(onChange).toHaveBeenCalledExactlyOnceWith('fig')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('flips the hint to DEBOUNCING… while the debounce timer is pending', () => {
+    vi.useFakeTimers()
+    try {
+      render(<SearchInput value='' onChange={() => {}} />)
+      const input = screen.getByRole('searchbox')
+
+      fireEvent.change(input, { target: { value: 'foo' } })
+
+      expect(screen.getByText('DEBOUNCING…')).toBeInTheDocument()
+
+      act(() => {
+        vi.advanceTimersByTime(180)
+      })
+
+      expect(screen.queryByText('DEBOUNCING…')).toBeNull()
+      expect(screen.getByText('PRESS ESC TO CLEAR')).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('Escape clears the draft and fires onChange("") immediately (no debounce wait)', () => {
+    const onChange = vi.fn()
+    render(<SearchInput value='fight' onChange={onChange} />)
+    const input = screen.getByRole('searchbox') as HTMLInputElement
+    expect(input.value).toBe('fight')
+
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith('')
+    expect(input.value).toBe('')
+  })
+
+  it('mirrors external value updates into the draft', () => {
+    const { rerender } = render(<SearchInput value='fight' onChange={() => {}} />)
+    expect((screen.getByRole('searchbox') as HTMLInputElement).value).toBe('fight')
+
+    rerender(<SearchInput value='matrix' onChange={() => {}} />)
+    expect((screen.getByRole('searchbox') as HTMLInputElement).value).toBe('matrix')
+  })
+
+  it('reflects focused state via the data-focused attribute on the wrap', () => {
+    const { container } = render(<SearchInput value='' onChange={() => {}} />)
+    const wrap = container.querySelector('.si-wrap')
+    expect(wrap?.getAttribute('data-focused')).toBe('false')
+
+    fireEvent.focus(screen.getByRole('searchbox'))
+    expect(wrap?.getAttribute('data-focused')).toBe('true')
+
+    fireEvent.blur(screen.getByRole('searchbox'))
+    expect(wrap?.getAttribute('data-focused')).toBe('false')
+  })
+})

--- a/components/molecules/SearchInput/index.ts
+++ b/components/molecules/SearchInput/index.ts
@@ -1,0 +1,2 @@
+export { SearchInput } from './SearchInput'
+export type { SearchInputProps, SearchInputHandle } from './SearchInput'

--- a/components/molecules/SearchResultRow/SearchResultRow.tsx
+++ b/components/molecules/SearchResultRow/SearchResultRow.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { type KeyboardEvent, useMemo, useRef, useEffect } from 'react'
+import { CRTPixelButton } from '@/components/atoms/CRTPixelButton'
+import { PhosphorLED, type PhosphorLEDStatus } from '@/components/atoms/PhosphorLED'
+import { FramedCover } from '@/components/molecules/FramedCover'
+import { getImageUrl } from '@/lib/api/tmdb'
+import type { UnifiedSearchResult } from '@/lib/search/federation'
+
+type WatchStatus = 'PLAN_TO_WATCH' | 'WATCHING' | 'COMPLETED' | 'ON_HOLD' | 'DROPPED'
+
+export type SearchResultRowProps = {
+  result: UnifiedSearchResult
+  inLibrary: boolean
+  watchStatus?: WatchStatus
+  isFocused: boolean
+  addingPending: boolean
+  onAdd: () => void
+  onOpenDetail: () => void
+}
+
+const COVER_MEDIUM: Record<UnifiedSearchResult['type'], 'movies' | 'tv' | 'anime' | 'games'> = {
+  movie: 'movies',
+  tv: 'tv',
+  anime: 'anime',
+  game: 'games',
+}
+
+const WATCH_STATUS_TO_LED: Record<WatchStatus, PhosphorLEDStatus> = {
+  PLAN_TO_WATCH: 'backlog',
+  WATCHING: 'in-progress',
+  COMPLETED: 'completed',
+  ON_HOLD: 'on-hold',
+  DROPPED: 'dropped',
+}
+
+function collectSourceChips(result: UnifiedSearchResult): string[] {
+  const chips: string[] = []
+  if (result.tmdb_id !== undefined) chips.push('TMDB')
+  if (result.anilist_id !== undefined) chips.push('ANILIST')
+  if (result.igdb_id !== undefined) chips.push('IGDB')
+  if (result.steam_id !== undefined) chips.push('STEAM')
+  return chips
+}
+
+export function SearchResultRow({
+  result,
+  inLibrary,
+  watchStatus,
+  isFocused,
+  addingPending,
+  onAdd,
+  onOpenDetail,
+}: SearchResultRowProps) {
+  const liRef = useRef<HTMLLIElement | null>(null)
+  const posterUrl = getImageUrl(result.poster_path ?? null, 'w185')
+  const chips = useMemo(() => collectSourceChips(result), [result])
+
+  // When this row becomes focused via keyboard nav, scroll it into view + focus
+  // the underlying <li> so screen readers + visible-focus ring align.
+  useEffect(() => {
+    if (isFocused && liRef.current) {
+      liRef.current.focus()
+      // scrollIntoView is missing in jsdom; guard so tests don't crash.
+      liRef.current.scrollIntoView?.({ block: 'nearest', behavior: 'auto' })
+    }
+  }, [isFocused])
+
+  function handleKeyDown(event: KeyboardEvent<HTMLLIElement>) {
+    if (event.key === 'Enter' && !(event.metaKey || event.ctrlKey)) {
+      event.preventDefault()
+      if (inLibrary) onOpenDetail()
+      else onOpenDetail()
+    } else if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault()
+      if (!inLibrary && !addingPending) onAdd()
+    }
+  }
+
+  const actionLabel = addingPending
+    ? '> ADDING…'
+    : inLibrary
+      ? '✓ IN LIBRARY'
+      : '> ADD TO LIBRARY'
+
+  return (
+    <li
+      ref={liRef}
+      className='sr-row'
+      data-focused={isFocused ? 'true' : 'false'}
+      data-medium={result.type}
+      role='option'
+      aria-selected={isFocused}
+      tabIndex={isFocused ? 0 : -1}
+      onKeyDown={handleKeyDown}
+    >
+      <div className='sr-cover'>
+        {posterUrl ? (
+          <FramedCover
+            medium={COVER_MEDIUM[result.type]}
+            size='thumb'
+            src={posterUrl}
+            alt={result.title}
+          />
+        ) : (
+          <div className='sr-cover-fallback' aria-hidden='true'>
+            ?
+          </div>
+        )}
+      </div>
+      <div className='sr-body'>
+        <h3 className='sr-title'>{result.title}</h3>
+        <div className='sr-meta'>
+          <span>{result.type.toUpperCase()}</span>
+          <span className='sr-sep'>·</span>
+          <span>{result.release_year ?? '—'}</span>
+          {inLibrary && watchStatus ? (
+            <>
+              <span className='sr-sep'>·</span>
+              <PhosphorLED
+                status={WATCH_STATUS_TO_LED[watchStatus]}
+                size={8}
+                label={watchStatus.replace(/_/g, ' ')}
+              />
+              <span>{watchStatus.replace(/_/g, ' ')}</span>
+            </>
+          ) : null}
+        </div>
+        {result.overview ? <p className='sr-overview'>{result.overview}</p> : null}
+      </div>
+      <div className='sr-chips'>
+        {chips.map((chip) => (
+          <span key={chip} className='sr-chip'>
+            {chip}
+          </span>
+        ))}
+      </div>
+      <div className='sr-action'>
+        <CRTPixelButton
+          fullWidth={false}
+          disabled={addingPending}
+          onClick={() => {
+            if (inLibrary) onOpenDetail()
+            else if (!addingPending) onAdd()
+          }}
+        >
+          {actionLabel}
+        </CRTPixelButton>
+      </div>
+    </li>
+  )
+}

--- a/components/molecules/SearchResultRow/SearchResultRow.tsx
+++ b/components/molecules/SearchResultRow/SearchResultRow.tsx
@@ -4,7 +4,7 @@ import { type KeyboardEvent, useMemo, useRef, useEffect } from 'react'
 import { CRTPixelButton } from '@/components/atoms/CRTPixelButton'
 import { PhosphorLED, type PhosphorLEDStatus } from '@/components/atoms/PhosphorLED'
 import { FramedCover } from '@/components/molecules/FramedCover'
-import { getImageUrl } from '@/lib/api/tmdb'
+import { getImageUrl } from '@/lib/api/tmdb-images'
 import type { UnifiedSearchResult } from '@/lib/search/federation'
 
 type WatchStatus = 'PLAN_TO_WATCH' | 'WATCHING' | 'COMPLETED' | 'ON_HOLD' | 'DROPPED'

--- a/components/molecules/SearchResultRow/SearchResultRow.tsx
+++ b/components/molecules/SearchResultRow/SearchResultRow.tsx
@@ -53,7 +53,9 @@ export function SearchResultRow({
   onOpenDetail,
 }: SearchResultRowProps) {
   const liRef = useRef<HTMLLIElement | null>(null)
-  const posterUrl = getImageUrl(result.poster_path ?? null, 'w185')
+  // TMDB schema allows `null` but tests can pass `''` — treat empty as null.
+  const posterPath = result.poster_path?.trim() ? result.poster_path : null
+  const posterUrl = getImageUrl(posterPath, 'w185')
   const chips = useMemo(() => collectSourceChips(result), [result])
 
   // When this row becomes focused via keyboard nav, scroll it into view + focus
@@ -67,13 +69,12 @@ export function SearchResultRow({
   }, [isFocused])
 
   function handleKeyDown(event: KeyboardEvent<HTMLLIElement>) {
-    if (event.key === 'Enter' && !(event.metaKey || event.ctrlKey)) {
-      event.preventDefault()
-      if (inLibrary) onOpenDetail()
-      else onOpenDetail()
-    } else if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
-      event.preventDefault()
+    if (event.key !== 'Enter') return
+    event.preventDefault()
+    if (event.metaKey || event.ctrlKey) {
       if (!inLibrary && !addingPending) onAdd()
+    } else {
+      onOpenDetail()
     }
   }
 

--- a/components/molecules/SearchResultRow/__tests__/SearchResultRow.test.tsx
+++ b/components/molecules/SearchResultRow/__tests__/SearchResultRow.test.tsx
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { SearchResultRow } from '../SearchResultRow'
+import type { UnifiedSearchResult } from '@/lib/search/federation'
+
+function makeResult(overrides: Partial<UnifiedSearchResult> = {}): UnifiedSearchResult {
+  return {
+    type: 'movie',
+    title: 'Fight Club',
+    release_year: 1999,
+    poster_path: '/poster.jpg',
+    overview: 'A ticking-time-bomb insomniac...',
+    primary_source: 'tmdb',
+    tmdb_id: 550,
+    confidence: 1.0,
+    ...overrides,
+  }
+}
+
+describe('SearchResultRow', () => {
+  beforeEach(() => {
+    cleanup()
+  })
+
+  it('renders title, type/year metadata, and overview', () => {
+    render(
+      <SearchResultRow
+        result={makeResult()}
+        inLibrary={false}
+        isFocused={false}
+        addingPending={false}
+        onAdd={() => {}}
+        onOpenDetail={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Fight Club' })).toBeInTheDocument()
+    expect(screen.getByText('MOVIE')).toBeInTheDocument()
+    expect(screen.getByText('1999')).toBeInTheDocument()
+    expect(screen.getByText(/A ticking-time-bomb/)).toBeInTheDocument()
+  })
+
+  it('omits the overview block when overview is null', () => {
+    const { container } = render(
+      <SearchResultRow
+        result={makeResult({ overview: null })}
+        inLibrary={false}
+        isFocused={false}
+        addingPending={false}
+        onAdd={() => {}}
+        onOpenDetail={() => {}}
+      />,
+    )
+    expect(container.querySelector('.sr-overview')).toBeNull()
+  })
+
+  it("renders '—' when release_year is missing", () => {
+    render(
+      <SearchResultRow
+        result={makeResult({ release_year: undefined })}
+        inLibrary={false}
+        isFocused={false}
+        addingPending={false}
+        onAdd={() => {}}
+        onOpenDetail={() => {}}
+      />,
+    )
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('renders the source chips for every present source ID', () => {
+    render(
+      <SearchResultRow
+        result={makeResult({ tmdb_id: 550, anilist_id: 1234 })}
+        inLibrary={false}
+        isFocused={false}
+        addingPending={false}
+        onAdd={() => {}}
+        onOpenDetail={() => {}}
+      />,
+    )
+    expect(screen.getByText('TMDB')).toBeInTheDocument()
+    expect(screen.getByText('ANILIST')).toBeInTheDocument()
+  })
+
+  it('shows "> ADD TO LIBRARY" when not in library, fires onAdd on click', () => {
+    const onAdd = vi.fn()
+    render(
+      <SearchResultRow
+        result={makeResult()}
+        inLibrary={false}
+        isFocused={false}
+        addingPending={false}
+        onAdd={onAdd}
+        onOpenDetail={() => {}}
+      />,
+    )
+    const button = screen.getByRole('button', { name: /ADD TO LIBRARY/ })
+    button.click()
+    expect(onAdd).toHaveBeenCalledOnce()
+  })
+
+  it('shows "> ADDING…" when addingPending is true, button is disabled', () => {
+    const onAdd = vi.fn()
+    render(
+      <SearchResultRow
+        result={makeResult()}
+        inLibrary={false}
+        isFocused={false}
+        addingPending={true}
+        onAdd={onAdd}
+        onOpenDetail={() => {}}
+      />,
+    )
+    const button = screen.getByRole('button', { name: /ADDING/ })
+    expect(button).toBeDisabled()
+    button.click()
+    expect(onAdd).not.toHaveBeenCalled()
+  })
+
+  it('shows "✓ IN LIBRARY" when inLibrary is true, navigates to detail on click', () => {
+    const onOpenDetail = vi.fn()
+    render(
+      <SearchResultRow
+        result={makeResult()}
+        inLibrary={true}
+        watchStatus='PLAN_TO_WATCH'
+        isFocused={false}
+        addingPending={false}
+        onAdd={() => {}}
+        onOpenDetail={onOpenDetail}
+      />,
+    )
+    const button = screen.getByRole('button', { name: /IN LIBRARY/ })
+    button.click()
+    expect(onOpenDetail).toHaveBeenCalledOnce()
+  })
+
+  it('shows PhosphorLED + WatchStatus in the meta line when inLibrary', () => {
+    render(
+      <SearchResultRow
+        result={makeResult()}
+        inLibrary={true}
+        watchStatus='WATCHING'
+        isFocused={false}
+        addingPending={false}
+        onAdd={() => {}}
+        onOpenDetail={() => {}}
+      />,
+    )
+    expect(screen.getByText('WATCHING')).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'WATCHING' })).toBeInTheDocument()
+  })
+
+  it('reflects focus state via data-focused on the <li>', () => {
+    const { container, rerender } = render(
+      <SearchResultRow
+        result={makeResult()}
+        inLibrary={false}
+        isFocused={false}
+        addingPending={false}
+        onAdd={() => {}}
+        onOpenDetail={() => {}}
+      />,
+    )
+    expect(container.querySelector('li')?.getAttribute('data-focused')).toBe('false')
+    rerender(
+      <SearchResultRow
+        result={makeResult()}
+        inLibrary={false}
+        isFocused={true}
+        addingPending={false}
+        onAdd={() => {}}
+        onOpenDetail={() => {}}
+      />,
+    )
+    expect(container.querySelector('li')?.getAttribute('data-focused')).toBe('true')
+  })
+
+  it('fires onOpenDetail on Enter, onAdd on ⌘+Enter', () => {
+    const onAdd = vi.fn()
+    const onOpenDetail = vi.fn()
+    const { container } = render(
+      <SearchResultRow
+        result={makeResult()}
+        inLibrary={false}
+        isFocused={true}
+        addingPending={false}
+        onAdd={onAdd}
+        onOpenDetail={onOpenDetail}
+      />,
+    )
+    const li = container.querySelector('li')!
+
+    fireEvent.keyDown(li, { key: 'Enter' })
+    expect(onOpenDetail).toHaveBeenCalledOnce()
+    expect(onAdd).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(li, { key: 'Enter', metaKey: true })
+    expect(onAdd).toHaveBeenCalledOnce()
+  })
+
+  it('renders the fallback ? glyph when poster_path is null', () => {
+    const { container } = render(
+      <SearchResultRow
+        result={makeResult({ poster_path: null })}
+        inLibrary={false}
+        isFocused={false}
+        addingPending={false}
+        onAdd={() => {}}
+        onOpenDetail={() => {}}
+      />,
+    )
+    expect(container.querySelector('.sr-cover-fallback')?.textContent).toBe('?')
+  })
+})

--- a/components/molecules/SearchResultRow/index.ts
+++ b/components/molecules/SearchResultRow/index.ts
@@ -1,0 +1,2 @@
+export { SearchResultRow } from './SearchResultRow'
+export type { SearchResultRowProps } from './SearchResultRow'

--- a/components/organisms/GlobalSearch/GlobalSearch.tsx
+++ b/components/organisms/GlobalSearch/GlobalSearch.tsx
@@ -69,7 +69,12 @@ const SECTION_ORDER: ReadonlyArray<UnifiedSearchResult['type']> = [
 function getResultKey(result: UnifiedSearchResult): string {
   const sourceId =
     result.tmdb_id ?? result.anilist_id ?? result.igdb_id ?? result.steam_id
-  return `${result.primary_source}:${sourceId ?? 'unknown'}`
+  // Fallback to title + year keeps the key unique when every source ID is
+  // missing (malformed federation result). React duplicate-key warning ducked.
+  if (sourceId === undefined) {
+    return `${result.primary_source}:title:${result.title}:${result.release_year ?? 'na'}`
+  }
+  return `${result.primary_source}:${sourceId}`
 }
 
 function getSourceId(result: UnifiedSearchResult): number | undefined {
@@ -185,15 +190,19 @@ export function GlobalSearch() {
   const data = searchQuery.data
   const variant: Variant = useMemo(() => {
     if (query.length === 0) return 'idle'
-    if (searchQuery.isPending || searchQuery.isFetching) return 'loading'
-    if (searchQuery.isError) return 'zero'
-    if (!data) return 'loading'
+    // Keep prior data visible during background re-fetch — only show skeleton
+    // when there is genuinely nothing cached yet. Avoids the screen flashing
+    // skeleton on every filter change with cached results.
+    if (!data) {
+      if (searchQuery.isError) return 'zero'
+      return 'loading'
+    }
     if (data.partialFailure && data.results.length > 0)
       return 'partial-failure-with-results'
     if (data.partialFailure) return 'partial-failure-empty'
     if (data.results.length === 0) return 'zero'
     return 'results'
-  }, [query, data, searchQuery.isPending, searchQuery.isFetching, searchQuery.isError])
+  }, [query, data, searchQuery.isError])
 
   const flatOrder = useMemo<UnifiedSearchResult[]>(() => {
     if (!data?.results.length) return []
@@ -246,6 +255,15 @@ export function GlobalSearch() {
       event.preventDefault()
       setQuery('')
       inputRef.current?.focus()
+      return
+    }
+    // Arrow keys inside the search input should move the text caret, not row
+    // focus. Let the input handle them natively.
+    const target = event.target as HTMLElement | null
+    if (
+      target?.tagName === 'INPUT' &&
+      (event.key === 'ArrowUp' || event.key === 'ArrowDown')
+    ) {
       return
     }
     if (flatOrder.length === 0) return

--- a/components/organisms/GlobalSearch/GlobalSearch.tsx
+++ b/components/organisms/GlobalSearch/GlobalSearch.tsx
@@ -1,0 +1,431 @@
+'use client'
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react'
+import { useRouter } from 'next/navigation'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { CRTPixelButton } from '@/components/atoms/CRTPixelButton'
+import { SearchInput, type SearchInputHandle } from '@/components/molecules/SearchInput'
+import { FilterChips, type FilterId } from '@/components/molecules/FilterChips'
+import { SearchResultRow } from '@/components/molecules/SearchResultRow'
+import type { UnifiedSearchResult } from '@/lib/search/federation'
+
+type SearchResponse = {
+  results: UnifiedSearchResult[]
+  partialFailure: boolean
+}
+
+type SearchApiType = 'movie' | 'tv' | 'anime' | 'game'
+
+type AddBody = {
+  source: UnifiedSearchResult['primary_source']
+  sourceId: number
+  type: 'MOVIE' | 'TV_SHOW' | 'ANIME' | 'GAME'
+}
+
+type Variant =
+  | 'idle'
+  | 'loading'
+  | 'results'
+  | 'partial-failure-with-results'
+  | 'partial-failure-empty'
+  | 'zero'
+
+const TYPE_TO_API: Record<Exclude<FilterId, 'ALL'>, SearchApiType> = {
+  MOVIES: 'movie',
+  TV: 'tv',
+  ANIME: 'anime',
+  GAMES: 'game',
+}
+
+const SEARCH_TYPE_TO_MEDIA: Record<UnifiedSearchResult['type'], AddBody['type']> = {
+  movie: 'MOVIE',
+  tv: 'TV_SHOW',
+  anime: 'ANIME',
+  game: 'GAME',
+}
+
+const SECTION_LABELS: Record<UnifiedSearchResult['type'], string> = {
+  movie: 'MOVIES',
+  tv: 'TV',
+  anime: 'ANIME',
+  game: 'GAMES',
+}
+
+const SECTION_ORDER: ReadonlyArray<UnifiedSearchResult['type']> = [
+  'movie',
+  'tv',
+  'anime',
+  'game',
+] as const
+
+function getResultKey(result: UnifiedSearchResult): string {
+  const sourceId =
+    result.tmdb_id ?? result.anilist_id ?? result.igdb_id ?? result.steam_id
+  return `${result.primary_source}:${sourceId ?? 'unknown'}`
+}
+
+function getSourceId(result: UnifiedSearchResult): number | undefined {
+  switch (result.primary_source) {
+    case 'tmdb':
+      return result.tmdb_id
+    case 'anilist':
+      return result.anilist_id
+    case 'igdb':
+      return result.igdb_id
+    case 'steam':
+      return result.steam_id
+  }
+}
+
+function filterToApiType(filter: FilterId): SearchApiType | undefined {
+  if (filter === 'ALL') return undefined
+  return TYPE_TO_API[filter]
+}
+
+async function fetchSearch(
+  query: string,
+  type: SearchApiType | undefined,
+): Promise<SearchResponse> {
+  const params = new URLSearchParams({ q: query })
+  if (type) params.set('type', type)
+  const res = await fetch(`/api/search?${params.toString()}`, {
+    credentials: 'include',
+  })
+  if (!res.ok) {
+    throw new Error(`search_failed:${res.status}`)
+  }
+  return (await res.json()) as SearchResponse
+}
+
+async function addToLibrary(body: AddBody): Promise<unknown> {
+  const res = await fetch('/api/media', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const payload = (await res.json().catch(() => ({}))) as { error?: string }
+    throw new Error(payload.error ?? `add_failed:${res.status}`)
+  }
+  return res.json()
+}
+
+export function GlobalSearch() {
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const inputRef = useRef<SearchInputHandle | null>(null)
+
+  const [query, setQuery] = useState('')
+  const [activeFilter, setActiveFilter] = useState<FilterId>('ALL')
+  const [focusedKey, setFocusedKey] = useState<string | null>(null)
+  const [pendingAdds, setPendingAdds] = useState<Set<string>>(() => new Set())
+
+  const apiType = filterToApiType(activeFilter)
+
+  const searchQuery = useQuery<SearchResponse, Error>({
+    queryKey: ['search', query, apiType ?? 'all'],
+    queryFn: () => fetchSearch(query, apiType),
+    enabled: query.length > 0,
+    staleTime: 0,
+    refetchOnWindowFocus: false,
+  })
+
+  const addMutation = useMutation<unknown, Error, AddBody, { key: string }>({
+    mutationFn: addToLibrary,
+    onMutate: (body) => {
+      const key = `${body.source}:${body.sourceId}`
+      setPendingAdds((prev) => {
+        const next = new Set(prev)
+        next.add(key)
+        return next
+      })
+      return { key }
+    },
+    onSuccess: (_data, body, ctx) => {
+      if (ctx?.key) {
+        setPendingAdds((prev) => {
+          const next = new Set(prev)
+          next.delete(ctx.key)
+          return next
+        })
+      }
+      const lowerType = body.type.toLowerCase().split('_')[0]
+      void queryClient.invalidateQueries({ queryKey: ['library', lowerType] })
+      toast.success('ADDED TO LIBRARY', {
+        description: `Source: ${body.source.toUpperCase()} · ${body.type.replace(/_/g, ' ')}`,
+      })
+    },
+    onError: (err, _body, ctx) => {
+      if (ctx?.key) {
+        setPendingAdds((prev) => {
+          const next = new Set(prev)
+          next.delete(ctx.key)
+          return next
+        })
+      }
+      const reason =
+        err.message.startsWith('add_failed:5') || err.message === 'upstream_failed'
+          ? 'Upstream unavailable. Please retry.'
+          : err.message === 'unsupported_source_type'
+            ? 'This media type is not wired yet.'
+            : 'Could not add to library.'
+      toast.error('COULD NOT ADD', { description: reason })
+    },
+  })
+
+  const data = searchQuery.data
+  const variant: Variant = useMemo(() => {
+    if (query.length === 0) return 'idle'
+    if (searchQuery.isPending || searchQuery.isFetching) return 'loading'
+    if (searchQuery.isError) return 'zero'
+    if (!data) return 'loading'
+    if (data.partialFailure && data.results.length > 0)
+      return 'partial-failure-with-results'
+    if (data.partialFailure) return 'partial-failure-empty'
+    if (data.results.length === 0) return 'zero'
+    return 'results'
+  }, [query, data, searchQuery.isPending, searchQuery.isFetching, searchQuery.isError])
+
+  const flatOrder = useMemo<UnifiedSearchResult[]>(() => {
+    if (!data?.results.length) return []
+    const order: UnifiedSearchResult[] = []
+    for (const type of SECTION_ORDER) {
+      for (const r of data.results) if (r.type === type) order.push(r)
+    }
+    return order
+  }, [data])
+
+  // Reset focus on new query / filter change.
+  useEffect(() => {
+    setFocusedKey(null)
+  }, [query, activeFilter])
+
+  const handleAdd = useCallback(
+    (result: UnifiedSearchResult) => {
+      const sourceId = getSourceId(result)
+      if (sourceId === undefined) return
+      addMutation.mutate({
+        source: result.primary_source,
+        sourceId,
+        type: SEARCH_TYPE_TO_MEDIA[result.type],
+      })
+    },
+    [addMutation],
+  )
+
+  const handleOpenDetail = useCallback(
+    (result: UnifiedSearchResult) => {
+      const sourceId = getSourceId(result)
+      if (sourceId === undefined) return
+      const path = `/${COVER_PATH_PREFIX[result.type]}/${sourceId}`
+      router.push(path)
+    },
+    [router],
+  )
+
+  const handleRetry = useCallback(() => {
+    void searchQuery.refetch()
+  }, [searchQuery])
+
+  const focusedResult = useMemo(
+    () => flatOrder.find((r) => getResultKey(r) === focusedKey) ?? null,
+    [flatOrder, focusedKey],
+  )
+
+  function handleKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      setQuery('')
+      inputRef.current?.focus()
+      return
+    }
+    if (flatOrder.length === 0) return
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      const currentIndex = focusedKey
+        ? flatOrder.findIndex((r) => getResultKey(r) === focusedKey)
+        : -1
+      const next = (currentIndex + 1) % flatOrder.length
+      setFocusedKey(getResultKey(flatOrder[next]))
+      return
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      const currentIndex = focusedKey
+        ? flatOrder.findIndex((r) => getResultKey(r) === focusedKey)
+        : flatOrder.length
+      const next = (currentIndex - 1 + flatOrder.length) % flatOrder.length
+      setFocusedKey(getResultKey(flatOrder[next]))
+      return
+    }
+    if (event.key === 'Enter') {
+      if (!focusedResult) return
+      event.preventDefault()
+      if (event.metaKey || event.ctrlKey) {
+        const key = getResultKey(focusedResult)
+        if (!pendingAdds.has(key)) handleAdd(focusedResult)
+      } else {
+        handleOpenDetail(focusedResult)
+      }
+    }
+  }
+
+  return (
+    <div className='gs' onKeyDown={handleKeyDown}>
+      <header className='gs-header'>
+        <div className='gs-heading'>
+          <h1 className='gs-title'>
+            <span className='gs-blocks'>
+              <span className='gs-b1'>▓</span>
+              <span className='gs-b2'>▓</span>
+              <span className='gs-b3'>▓</span>
+            </span>
+            <span className='gs-label'>SEARCH</span>
+            <span className='gs-blocks'>
+              <span className='gs-b3'>▓</span>
+              <span className='gs-b2'>▓</span>
+              <span className='gs-b1'>▓</span>
+            </span>
+          </h1>
+          <span className='gs-tag'>FIND · LOG · REMEMBER</span>
+        </div>
+        <SearchInput ref={inputRef} value={query} onChange={setQuery} />
+        <FilterChips active={activeFilter} onChange={setActiveFilter} />
+      </header>
+
+      <main className='gs-results' aria-live='polite'>
+        {variant === 'idle' && (
+          <EmptyState
+            headline='> START TYPING TO SEARCH'
+            sub='Search across TMDB · AniList · IGDB · Steam. Press ⌘+Enter on a result to add to library.'
+          />
+        )}
+        {variant === 'loading' && <SkeletonRows count={6} />}
+        {variant === 'zero' && (
+          <EmptyState
+            headline='> NO MATCHES FOUND'
+            sub='Try a different title, or remove the type filter.'
+          />
+        )}
+        {variant === 'partial-failure-empty' && (
+          <PartialFailureBanner onRetry={handleRetry} />
+        )}
+        {(variant === 'results' || variant === 'partial-failure-with-results') &&
+          data && (
+            <>
+              {variant === 'partial-failure-with-results' && (
+                <PartialFailureBanner onRetry={handleRetry} />
+              )}
+              {SECTION_ORDER.map((type) => {
+                const rows = data.results.filter((r) => r.type === type)
+                if (rows.length === 0) return null
+                return (
+                  <section key={type} className='gs-section'>
+                    <div className='gs-section-header'>
+                      <span className='gs-section-label'>{SECTION_LABELS[type]}</span>
+                      <span className='gs-section-count'>
+                        {rows.length} {rows.length === 1 ? 'result' : 'results'}
+                      </span>
+                      <span className='gs-section-rule' aria-hidden='true' />
+                    </div>
+                    <ul className='gs-list' role='listbox'>
+                      {rows.map((r) => {
+                        const key = getResultKey(r)
+                        return (
+                          <SearchResultRow
+                            key={key}
+                            result={r}
+                            inLibrary={false}
+                            isFocused={focusedKey === key}
+                            addingPending={pendingAdds.has(key)}
+                            onAdd={() => handleAdd(r)}
+                            onOpenDetail={() => handleOpenDetail(r)}
+                          />
+                        )
+                      })}
+                    </ul>
+                  </section>
+                )
+              })}
+            </>
+          )}
+      </main>
+
+      <footer className='gs-footer' aria-hidden='true'>
+        <span>
+          <span className='gs-kbd'>↑↓</span>Navigate
+        </span>
+        <span>
+          <span className='gs-kbd'>↵</span>Open detail
+        </span>
+        <span>
+          <span className='gs-kbd'>⌘ ↵</span>Add to library
+        </span>
+        <span>
+          <span className='gs-kbd'>Esc</span>Clear
+        </span>
+      </footer>
+    </div>
+  )
+}
+
+const COVER_PATH_PREFIX: Record<UnifiedSearchResult['type'], string> = {
+  movie: 'movies',
+  tv: 'tv',
+  anime: 'anime',
+  game: 'games',
+}
+
+function EmptyState({ headline, sub }: { headline: string; sub: string }) {
+  return (
+    <div className='gs-empty' role='status'>
+      <div className='gs-empty-headline'>{headline}</div>
+      <p className='gs-empty-sub'>{sub}</p>
+    </div>
+  )
+}
+
+function SkeletonRows({ count }: { count: number }) {
+  return (
+    <ul className='gs-skel-list' aria-hidden='true'>
+      {Array.from({ length: count }).map((_, i) => (
+        <li key={i} className='gs-skel-row'>
+          <div className='gs-skel-cover' />
+          <div className='gs-skel-body'>
+            <div className='gs-skel-title' />
+            <div className='gs-skel-meta' />
+            <div className='gs-skel-line' />
+            <div className='gs-skel-line short' />
+          </div>
+          <div className='gs-skel-chip' />
+          <div className='gs-skel-button' />
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function PartialFailureBanner({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className='gs-banner' role='alert'>
+      <div className='gs-banner-body'>
+        <div className='gs-banner-title'>⚠ SOME SOURCES UNAVAILABLE</div>
+        <div className='gs-banner-sub'>
+          Showing partial results. Retry to fetch again.
+        </div>
+      </div>
+      <CRTPixelButton fullWidth={false} onClick={onRetry}>
+        &gt; RETRY
+      </CRTPixelButton>
+    </div>
+  )
+}

--- a/components/organisms/GlobalSearch/__tests__/GlobalSearch.test.tsx
+++ b/components/organisms/GlobalSearch/__tests__/GlobalSearch.test.tsx
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  cleanup,
+  waitFor,
+} from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { GlobalSearch } from '../GlobalSearch'
+import type { UnifiedSearchResult } from '@/lib/search/federation'
+
+const pushMock = vi.hoisted(() => vi.fn())
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}))
+
+const toastMock = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+}))
+vi.mock('sonner', () => ({
+  toast: toastMock,
+  Toaster: () => null,
+}))
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function renderGS() {
+  const client = makeQueryClient()
+  return render(
+    <QueryClientProvider client={client}>
+      <GlobalSearch />
+    </QueryClientProvider>,
+  )
+}
+
+function fightResults(): UnifiedSearchResult[] {
+  return [
+    {
+      type: 'movie',
+      title: 'Fight Club',
+      release_year: 1999,
+      poster_path: '/fightclub.jpg',
+      overview: 'A ticking-time-bomb insomniac...',
+      primary_source: 'tmdb',
+      tmdb_id: 550,
+      confidence: 1.0,
+    },
+    {
+      type: 'tv',
+      title: 'Cobra Kai',
+      release_year: 2018,
+      poster_path: '/cobra.jpg',
+      overview: 'Decades later the rivalry reignites.',
+      primary_source: 'tmdb',
+      tmdb_id: 77169,
+      confidence: 1.0,
+    },
+  ]
+}
+
+function flushQuery(value: string) {
+  vi.useFakeTimers()
+  const input = screen.getByRole('searchbox') as HTMLInputElement
+  fireEvent.change(input, { target: { value } })
+  act(() => {
+    vi.advanceTimersByTime(200)
+  })
+  vi.useRealTimers()
+}
+
+describe('GlobalSearch', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the idle empty state when query is empty', () => {
+    vi.stubGlobal('fetch', vi.fn())
+    renderGS()
+    expect(screen.getByText(/START TYPING TO SEARCH/)).toBeInTheDocument()
+  })
+
+  it('fires GET /api/search and renders results grouped by media type', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ results: fightResults(), partialFailure: false }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    renderGS()
+
+    flushQuery('fight')
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Fight Club' }),
+      ).toBeInTheDocument()
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/search?q=fight'),
+      expect.objectContaining({ credentials: 'include' }),
+    )
+    expect(
+      screen.getByRole('heading', { name: 'Cobra Kai' }),
+    ).toBeInTheDocument()
+    // FilterChip + section header both render MOVIES/TV; scope to the section
+    // header via its sibling rule element's parent.
+    const sectionLabels = screen
+      .getAllByText('MOVIES')
+      .filter((el) => el.classList.contains('gs-section-label'))
+    expect(sectionLabels).toHaveLength(1)
+  })
+
+  it('shows the partial-failure banner when the API flags partialFailure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ results: fightResults(), partialFailure: true }),
+          { status: 200 },
+        ),
+      ),
+    )
+    renderGS()
+
+    flushQuery('fight')
+
+    await waitFor(() => {
+      expect(screen.getByText(/SOME SOURCES UNAVAILABLE/)).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /RETRY/ })).toBeInTheDocument()
+  })
+
+  it('shows the zero-results empty state when results are empty', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ results: [], partialFailure: false }),
+          { status: 200 },
+        ),
+      ),
+    )
+    renderGS()
+
+    flushQuery('zzz')
+
+    await waitFor(() => {
+      expect(screen.getByText(/NO MATCHES FOUND/)).toBeInTheDocument()
+    })
+  })
+
+  it('handles network error as zero results', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('boom', { status: 500 })),
+    )
+    renderGS()
+
+    flushQuery('fight')
+
+    await waitFor(() => {
+      expect(screen.getByText(/NO MATCHES FOUND/)).toBeInTheDocument()
+    })
+  })
+
+  it('arrow-down cycles focus through results', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ results: fightResults(), partialFailure: false }),
+          { status: 200 },
+        ),
+      ),
+    )
+    const { container } = renderGS()
+
+    flushQuery('fight')
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Fight Club' }),
+      ).toBeInTheDocument()
+    })
+
+    const root = container.querySelector('.gs')!
+    fireEvent.keyDown(root, { key: 'ArrowDown' })
+    let focusedRow = container.querySelector('li[data-focused="true"]')
+    expect(focusedRow?.textContent).toContain('Fight Club')
+
+    fireEvent.keyDown(root, { key: 'ArrowDown' })
+    focusedRow = container.querySelector('li[data-focused="true"]')
+    expect(focusedRow?.textContent).toContain('Cobra Kai')
+  })
+
+  it('Escape clears the input', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ results: fightResults(), partialFailure: false }),
+          { status: 200 },
+        ),
+      ),
+    )
+    const { container } = renderGS()
+    flushQuery('fight')
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Fight Club' }),
+      ).toBeInTheDocument()
+    })
+
+    const root = container.querySelector('.gs')!
+    fireEvent.keyDown(root, { key: 'Escape' })
+
+    const input = screen.getByRole('searchbox') as HTMLInputElement
+    expect(input.value).toBe('')
+    await waitFor(() => {
+      expect(screen.getByText(/START TYPING TO SEARCH/)).toBeInTheDocument()
+    })
+  })
+
+  it('POST /api/media on add click + fires success toast', async () => {
+    let postBody: unknown = null
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (typeof url === 'string' && url.includes('/api/search')) {
+        return new Response(
+          JSON.stringify({ results: fightResults(), partialFailure: false }),
+          { status: 200 },
+        )
+      }
+      postBody = init?.body ? JSON.parse(init.body as string) : null
+      return new Response(
+        JSON.stringify({ mediaItem: { id: 'x' }, merged: false }),
+        { status: 201 },
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderGS()
+    flushQuery('fight')
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { name: 'Fight Club' }),
+      ).toBeInTheDocument(),
+    )
+
+    const buttons = screen.getAllByRole('button', { name: /ADD TO LIBRARY/ })
+    buttons[0].click()
+
+    await waitFor(() => {
+      expect(toastMock.success).toHaveBeenCalled()
+    })
+    expect(postBody).toEqual({
+      source: 'tmdb',
+      sourceId: 550,
+      type: 'MOVIE',
+    })
+  })
+
+  it('fires destructive toast on add failure', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/api/search')) {
+        return new Response(
+          JSON.stringify({ results: fightResults(), partialFailure: false }),
+          { status: 200 },
+        )
+      }
+      return new Response(
+        JSON.stringify({ error: 'upstream_failed' }),
+        { status: 502 },
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderGS()
+    flushQuery('fight')
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { name: 'Fight Club' }),
+      ).toBeInTheDocument(),
+    )
+
+    const buttons = screen.getAllByRole('button', { name: /ADD TO LIBRARY/ })
+    buttons[0].click()
+
+    await waitFor(() => {
+      expect(toastMock.error).toHaveBeenCalled()
+    })
+  })
+
+  it('sends type=movie when MOVIES filter is active', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ results: [], partialFailure: false }),
+        { status: 200 },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderGS()
+
+    screen.getByRole('tab', { name: /^MOVIES/ }).click()
+    flushQuery('fight')
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('type=movie'),
+        expect.any(Object),
+      )
+    })
+  })
+
+  it('Enter on a focused row navigates to the detail route stub', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ results: fightResults(), partialFailure: false }),
+          { status: 200 },
+        ),
+      ),
+    )
+    const { container } = renderGS()
+    flushQuery('fight')
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { name: 'Fight Club' }),
+      ).toBeInTheDocument(),
+    )
+
+    const root = container.querySelector('.gs')!
+    fireEvent.keyDown(root, { key: 'ArrowDown' })
+    fireEvent.keyDown(root, { key: 'Enter' })
+
+    expect(pushMock).toHaveBeenCalledWith('/movies/550')
+  })
+})

--- a/components/organisms/GlobalSearch/index.ts
+++ b/components/organisms/GlobalSearch/index.ts
@@ -1,0 +1,1 @@
+export { GlobalSearch } from './GlobalSearch'

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,7 +49,7 @@ const eslintConfig = [
     },
   },
   {
-    files: ['lib/env.ts', 'lib/__tests__/env.test.ts'],
+    files: ['lib/env.ts', 'lib/__tests__/env.test.ts', 'tests/setup.ts'],
     rules: {
       'no-restricted-syntax': 'off',
       'no-console': 'off',

--- a/lib/api/tmdb-images.ts
+++ b/lib/api/tmdb-images.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+
+/* Pure URL-construction helper for TMDB image CDN paths. Lives in its own
+ * module so client components (e.g. SearchResultRow) can import it WITHOUT
+ * pulling in `lib/api/tmdb.ts`'s adapter dependencies (env, logger, pino,
+ * sonic-boom → fs) — that chain breaks the browser bundle.
+ *
+ * `lib/api/tmdb.ts` re-exports these names so existing server-side callers
+ * (route handlers, future BullMQ jobs) keep working unchanged.
+ */
+
+export const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p'
+
+export const TmdbImageSizeSchema = z.enum([
+  'w92',
+  'w154',
+  'w185',
+  'w342',
+  'w500',
+  'w780',
+  'original',
+])
+export type TmdbImageSize = z.infer<typeof TmdbImageSizeSchema>
+
+export function getImageUrl(
+  path: string | null,
+  size: TmdbImageSize,
+): string | null {
+  if (path === null) return null
+  return `${TMDB_IMAGE_BASE}/${size}${path}`
+}

--- a/lib/api/tmdb.ts
+++ b/lib/api/tmdb.ts
@@ -1,10 +1,21 @@
 import { z } from 'zod'
 import { env } from '@/lib/env'
 import { logger } from '@/lib/logger'
+import {
+  TmdbImageSizeSchema,
+  getImageUrl,
+  type TmdbImageSize,
+} from '@/lib/api/tmdb-images'
 
 const TMDB_BASE = 'https://api.themoviedb.org/3'
-const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p'
 const TMDB_TIMEOUT_MS = 8000
+
+// Re-export the image-URL helper so server-side callers can keep importing
+// `getImageUrl` / `TmdbImageSize` from `@/lib/api/tmdb`. Client components
+// should import from `@/lib/api/tmdb-images` directly to avoid pulling in
+// logger / env / pino into the browser bundle.
+export { TmdbImageSizeSchema, getImageUrl }
+export type { TmdbImageSize }
 
 export class TmdbApiError extends Error {
   readonly endpoint: string
@@ -27,17 +38,6 @@ export class TmdbApiError extends Error {
     this.fieldPath = opts.fieldPath
   }
 }
-
-export const TmdbImageSizeSchema = z.enum([
-  'w92',
-  'w154',
-  'w185',
-  'w342',
-  'w500',
-  'w780',
-  'original',
-])
-export type TmdbImageSize = z.infer<typeof TmdbImageSizeSchema>
 
 const TmdbGenreSchema = z.object({
   id: z.number(),
@@ -291,12 +291,4 @@ export async function getWatchProviders(
     TmdbWatchProvidersResponseSchema,
   )
   return response.results[country] ?? null
-}
-
-export function getImageUrl(
-  path: string | null,
-  size: TmdbImageSize,
-): string | null {
-  if (path === null) return null
-  return `${TMDB_IMAGE_BASE}/${size}${path}`
 }

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,6 +2,33 @@ import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
 import { afterEach, vi } from 'vitest'
 
+/* Pre-populate process.env with valid defaults so component tests that
+ * transitively load `@/lib/env` (via adapters, federation, normalisers) don't
+ * crash at module-load time. Tests that need to vary env values still use
+ * `vi.stubEnv` per-test; those overrides take precedence and unstub cleanly
+ * in their own `afterEach`. */
+const DEFAULT_ENV: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+for (const [k, v] of Object.entries(DEFAULT_ENV)) {
+  if (process.env[k] === undefined) process.env[k] = v
+}
+
 afterEach(() => {
   cleanup()
 })


### PR DESCRIPTION
## Summary

Implements the federated search UI per the 2026-05-13 claude.ai/design bundle at `_bmad-output/design-bundles/cuatro-tracker-2026-04-26/07-search/`. The `/search` route renders a `GlobalSearch` organism that wires `SearchInput` (debounced) + `FilterChips` + `SearchResultRow` rows to the Story 4.3 `GET /api/search` and Story 4.4 `POST /api/media` route handlers via TanStack Query, with Sonner toasts.

**New components:**
- `app/search/page.tsx` — thin route shell.
- `components/organisms/GlobalSearch/` — page composition + state machine + keyboard nav.
- `components/molecules/SearchInput/` — debounced search input molecule with terminal `>` caret + blink cursor.
- `components/molecules/FilterChips/` — ALL/MOVIES/TV active; ANIME/GAMES muted `(soon)` per E4 scope.
- `components/molecules/SearchResultRow/` — one result row with FramedCover thumb + title/meta/overview + stacked source chips + CRT-pixel action button.

**Global changes:**
- `app/providers.tsx` — Sonner `<Toaster />` mounted globally (OI #2).
- `app/global.css` — search-screen styles + Sonner toast skin overrides (~450 lines).
- `tests/setup.ts` — pre-populates `process.env` defaults for component tests transitively loading `lib/env`. `eslint.config.mjs` adds an exemption.

## Test plan

- [ ] CI: typecheck + lint clean.
- [ ] CI: vitest 34 new tests pass (SearchInput 6, FilterChips 6, SearchResultRow 11, GlobalSearch 11). Full suite 389/391 pass — the 2 worker.test.ts failures are pre-existing environment-specific (Redis localhost vs container hostname) and unrelated to this PR.
- [ ] Browser verification (Cuatro, per workspace `feedback_post_impl_review_then_handoff`): hit `http://127.0.0.1:3000/search`, type "fight", arrow-down to a result, press ⌘+Enter to add → expect Sonner toast + button flip; press Escape to clear; click "MOVIES" filter chip → expect TV results to disappear; type a TMDB-unknown term like "zzzasdf" → expect "NO MATCHES FOUND" empty state.

## Notes

- bmad-code-review (Edge Case Hunter + Acceptance Auditor; Blind Hunter skipped) — 5 patches applied (debounce ref-pin, variant cache-preserve, getResultKey fallback, arrow-key guard, poster empty-string), 2 defers (typing-variant visual polish, pendingAdds GC), 24 dismissed.
- **Size note:** ~2075 lines (~1200 prod inc. CSS / ~875 tests). Exceeds the workspace's 1.5K PR-size ceiling per `feedback_pr_size_ceiling`. ~450 of the production LOC is CSS lifted from the bundle's `search-styles.css` and adapted to the cuatro-tracker token system; the actual TSX surface is ~750 lines across 4 new components. Happy to sub-bundle if review-together feels heavy: split into (a) atoms+styles+Toaster setup, (b) GlobalSearch organism + page wiring.
- **Deferred:** typing-variant (Frame B "ghost `>`" line during 175ms debounce) and `pendingAdds` Set GC — both logged to `deferred-work.md`. Neither is user-blocking.
- **Forward-compat stubs:** `inLibrary` is permanently `false` in E4 (E5 wires real data via `/api/library`); detail page routes (`/movies/<id>` etc.) 404 in E4 (E6/E7 implement).

Closes #101