### PR TITLE
feat(dashboard): static scaffold with empty-library bands (#104)

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -1347,3 +1347,151 @@ body {
   color: var(--phosphor-cream) !important;
   margin-top: 4px !important;
 }
+
+/* ============================================================
+   Dashboard scaffold (Story 5.2). Page composition: hero placeholder
+   (CRT bezel + LIBRARY EMPTY state) + three SectionBand molecules each
+   wrapping an EmptyStateCard. DashboardSystemWidget deferred to 5.4.
+   ============================================================ */
+
+.dash {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px 96px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  color: var(--phosphor-cream);
+}
+
+.dash-hero {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 0 8px;
+}
+
+.dash-hero-bezel {
+  width: min(520px, 100%);
+}
+
+.dash-hero-screen {
+  position: absolute;
+  inset: 0;
+  padding: 28px 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: var(--phosphor-cream);
+  z-index: 2;
+}
+
+/* EmptyStateCard (molecule, Story 5.2). Bitmap headline + optional
+   second bitmap line + optional ghost workhorse-serif subtitle + optional
+   CRT-pixel CTA. Hero variant is centered with larger spacing; band variant
+   is compact and left-aligned. */
+
+.esc {
+  display: flex;
+  flex-direction: column;
+}
+
+.esc[data-variant='hero'] {
+  align-items: center;
+  text-align: center;
+  gap: 8px;
+}
+
+.esc[data-variant='band'] {
+  align-items: flex-start;
+  text-align: left;
+  gap: 6px;
+  padding: 24px 16px;
+}
+
+.esc-headline {
+  margin: 0;
+  letter-spacing: 0.04em;
+}
+
+.esc-second-line {
+  margin: 0;
+  letter-spacing: 0.04em;
+}
+
+.esc-subtitle {
+  margin: 4px 0 0;
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 15px;
+  line-height: 1.4;
+  color: var(--phosphor-cream-dim);
+  max-width: 36rem;
+}
+
+.esc[data-variant='band'] .esc-subtitle {
+  font-size: 14px;
+  max-width: 28rem;
+}
+
+.esc-cta {
+  margin-top: 16px;
+  min-width: 140px;
+  width: auto;
+}
+
+/* SectionBand (organism, Story 5.2). Display-serif title + optional count chip
+   + 4-band rainbow rule + body slot. Hosts the three dashboard bands and
+   future detail-page sections. */
+
+.dsec {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dsec-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.dsec-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 24px;
+  line-height: 1.1;
+  letter-spacing: 0.01em;
+  color: var(--phosphor-cream);
+}
+
+.dsec-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.dsec-rule {
+  display: flex;
+  width: 100%;
+  height: 4px;
+  margin: 0 0 8px;
+}
+
+.dsec-rule-band {
+  flex: 1 1 0;
+  height: 100%;
+}
+
+.dsec-body {
+  display: block;
+}

--- a/app/global.css
+++ b/app/global.css
@@ -401,6 +401,23 @@ body {
   align-items: center;
 }
 
+.mn-logo-link {
+  display: inline-flex;
+  align-items: center;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+
+.mn-logo-link:focus-visible {
+  outline: 2px solid var(--neon-blue);
+  outline-offset: 4px;
+}
+
 .mn-links {
   display: inline-flex;
   align-items: center;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,54 @@
-export default function Home() {
+'use client'
+
+import { CRTBezel } from '@/components/molecules/CRTBezel'
+import { EmptyStateCard } from '@/components/molecules/EmptyStateCard'
+import { useChannelFlipNavigate } from '@/components/molecules/ChannelFlipTransition'
+import { SectionBand } from '@/components/organisms/SectionBand'
+
+export default function DashboardPage() {
+  const { navigate, overlay } = useChannelFlipNavigate()
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24">
-      <h1 className="text-4xl font-bold tracking-tight">Cuatro Tracker</h1>
-      <p className="mt-4 text-sm text-gray-500">
-        Phase 0 - Scaffold complete
-      </p>
+    <main className='dash'>
+      <section className='dash-hero' aria-label='Currently active'>
+        <CRTBezel size='hero' className='dash-hero-bezel'>
+          <div className='dash-hero-screen'>
+            <EmptyStateCard
+              variant='hero'
+              headline='LIBRARY EMPTY'
+              secondLine='ADD AN ITEM TO BEGIN'
+              subtitle='Search any title across TMDB, AniList, IGDB or Steam to start your collection.'
+              ctaLabel='ADD'
+              onCta={() => {
+                void navigate('/search')
+              }}
+            />
+          </div>
+        </CRTBezel>
+      </section>
+
+      <SectionBand title='Up Next'>
+        <EmptyStateCard
+          headline='NOTHING IN PROGRESS'
+          subtitle='Start watching, reading, or playing to populate this band.'
+        />
+      </SectionBand>
+
+      <SectionBand title='Recently Added'>
+        <EmptyStateCard
+          headline='NOTHING ADDED YET'
+          subtitle='Items you add to your library appear here.'
+        />
+      </SectionBand>
+
+      <SectionBand title='Recently Released'>
+        <EmptyStateCard
+          headline='NO RECENT RELEASES'
+          subtitle='Items in your library released in the last 30 days appear here.'
+        />
+      </SectionBand>
+
+      {overlay}
     </main>
-  );
+  )
 }

--- a/components/molecules/EmptyStateCard/EmptyStateCard.tsx
+++ b/components/molecules/EmptyStateCard/EmptyStateCard.tsx
@@ -1,0 +1,46 @@
+import { BitmapText } from '@/components/atoms/BitmapText'
+import { CRTPixelButton } from '@/components/atoms/CRTPixelButton'
+
+export type EmptyStateCardVariant = 'hero' | 'band'
+
+export type EmptyStateCardProps = {
+  variant?: EmptyStateCardVariant
+  headline: string
+  secondLine?: string
+  subtitle?: string
+  ctaLabel?: string
+  onCta?: () => void
+  className?: string
+}
+
+export function EmptyStateCard({
+  variant = 'band',
+  headline,
+  secondLine,
+  subtitle,
+  ctaLabel,
+  onCta,
+  className,
+}: EmptyStateCardProps) {
+  const cls = className ? `esc ${className}` : 'esc'
+  const isHero = variant === 'hero'
+  const headlineSize = isHero ? 24 : 18
+  return (
+    <div className={cls} data-variant={variant}>
+      <BitmapText size={headlineSize} tone='cream' as='p' className='esc-headline'>
+        &gt; {headline}
+      </BitmapText>
+      {isHero && secondLine ? (
+        <BitmapText size={18} tone='cream-dim' as='p' className='esc-second-line'>
+          {secondLine}
+        </BitmapText>
+      ) : null}
+      {subtitle ? <p className='esc-subtitle'>{subtitle}</p> : null}
+      {isHero && ctaLabel ? (
+        <CRTPixelButton onClick={onCta} fullWidth={false} className='esc-cta'>
+          &gt; {ctaLabel}
+        </CRTPixelButton>
+      ) : null}
+    </div>
+  )
+}

--- a/components/molecules/EmptyStateCard/__tests__/EmptyStateCard.test.tsx
+++ b/components/molecules/EmptyStateCard/__tests__/EmptyStateCard.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { EmptyStateCard } from '../EmptyStateCard'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('EmptyStateCard rendering', () => {
+  it('defaults to band variant when no variant prop is passed', () => {
+    const { container } = render(<EmptyStateCard headline='NOTHING IN PROGRESS' />)
+    expect(container.querySelector('.esc')).toHaveAttribute('data-variant', 'band')
+  })
+
+  it('renders the bitmap headline with a > prefix', () => {
+    render(<EmptyStateCard headline='NOTHING ADDED YET' />)
+    expect(screen.getByText('> NOTHING ADDED YET')).toBeInTheDocument()
+  })
+
+  it('renders the optional subtitle when provided', () => {
+    render(
+      <EmptyStateCard
+        headline='NO RECENT RELEASES'
+        subtitle='Items in your library released in the last 30 days appear here.'
+      />,
+    )
+    expect(
+      screen.getByText('Items in your library released in the last 30 days appear here.'),
+    ).toBeInTheDocument()
+  })
+
+  it('omits the subtitle paragraph when not provided', () => {
+    const { container } = render(<EmptyStateCard headline='X' />)
+    expect(container.querySelector('.esc-subtitle')).toBeNull()
+  })
+
+  it('band variant omits the secondLine even when the prop is set', () => {
+    render(
+      <EmptyStateCard
+        variant='band'
+        headline='X'
+        secondLine='SHOULD NOT RENDER'
+      />,
+    )
+    expect(screen.queryByText('SHOULD NOT RENDER')).toBeNull()
+  })
+
+  it('band variant omits the CTA button even when ctaLabel is set', () => {
+    const onCta = vi.fn()
+    const { container } = render(
+      <EmptyStateCard variant='band' headline='X' ctaLabel='ADD' onCta={onCta} />,
+    )
+    expect(container.querySelector('.cpb')).toBeNull()
+  })
+
+  it('hero variant renders the secondLine when provided', () => {
+    render(
+      <EmptyStateCard
+        variant='hero'
+        headline='LIBRARY EMPTY'
+        secondLine='ADD AN ITEM TO BEGIN'
+      />,
+    )
+    expect(screen.getByText('ADD AN ITEM TO BEGIN')).toBeInTheDocument()
+  })
+
+  it('hero variant renders the CTA button with > prefix when ctaLabel is set', () => {
+    render(
+      <EmptyStateCard variant='hero' headline='LIBRARY EMPTY' ctaLabel='ADD' />,
+    )
+    expect(screen.getByRole('button', { name: '> ADD' })).toBeInTheDocument()
+  })
+
+  it('calls onCta when the hero CTA is clicked', () => {
+    const onCta = vi.fn()
+    render(
+      <EmptyStateCard
+        variant='hero'
+        headline='LIBRARY EMPTY'
+        ctaLabel='ADD'
+        onCta={onCta}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: '> ADD' }))
+    expect(onCta).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes the className prop through alongside the esc base', () => {
+    const { container } = render(
+      <EmptyStateCard headline='X' className='extra' />,
+    )
+    const esc = container.querySelector('.esc')
+    expect(esc).toHaveClass('esc')
+    expect(esc).toHaveClass('extra')
+  })
+})

--- a/components/molecules/EmptyStateCard/index.ts
+++ b/components/molecules/EmptyStateCard/index.ts
@@ -1,0 +1,5 @@
+export { EmptyStateCard } from './EmptyStateCard'
+export type {
+  EmptyStateCardProps,
+  EmptyStateCardVariant,
+} from './EmptyStateCard'

--- a/components/organisms/MainNav/MainNav.tsx
+++ b/components/organisms/MainNav/MainNav.tsx
@@ -30,7 +30,16 @@ export function MainNav() {
   return (
     <nav className='mn' aria-label='Primary navigation'>
       <div className='mn-left'>
-        <LogoMark />
+        <button
+          type='button'
+          onClick={() => {
+            void navigate('/')
+          }}
+          aria-label='Go to dashboard'
+          className='mn-logo-link'
+        >
+          <LogoMark />
+        </button>
       </div>
       <ul className='mn-links'>
         {NAV_LINKS.map((link) => {

--- a/components/organisms/MainNav/__tests__/MainNav.test.tsx
+++ b/components/organisms/MainNav/__tests__/MainNav.test.tsx
@@ -48,6 +48,13 @@ describe('MainNav rendering (AC-3)', () => {
     expect(screen.getByRole('button', { name: 'Admin' })).toBeInTheDocument()
   })
 
+  it('wraps the LogoMark in a button that navigates to /', () => {
+    render(<MainNav />)
+    const button = screen.getByRole('button', { name: 'Go to dashboard' })
+    fireEvent.click(button)
+    expect(navigateMock).toHaveBeenCalledWith('/')
+  })
+
   it('hides on /login', () => {
     pathnameRef.current = '/login'
     const { container } = render(<MainNav />)

--- a/components/organisms/SectionBand/SectionBand.tsx
+++ b/components/organisms/SectionBand/SectionBand.tsx
@@ -1,0 +1,51 @@
+import { useId, type ReactNode } from 'react'
+
+export type SectionBandProps = {
+  title: string
+  count?: number | null
+  children: ReactNode
+  className?: string
+}
+
+const RAINBOW_BANDS = [
+  'var(--rb-green)',
+  'var(--rb-yellow)',
+  'var(--rb-orange)',
+  'var(--rb-pink)',
+  'var(--rb-purple)',
+  'var(--rb-blue)',
+]
+
+export function SectionBand({
+  title,
+  count = null,
+  children,
+  className,
+}: SectionBandProps) {
+  const reactId = useId()
+  const headingId = `section-band-${reactId}`
+  const cls = className ? `dsec ${className}` : 'dsec'
+  const showCount = typeof count === 'number' && Number.isFinite(count)
+  return (
+    <section className={cls} aria-labelledby={headingId}>
+      <div className='dsec-head'>
+        <h2 id={headingId} className='dsec-title'>{title}</h2>
+        {showCount ? (
+          <span className='dsec-count'>
+            {count} {count === 1 ? 'item' : 'items'}
+          </span>
+        ) : null}
+      </div>
+      <span className='dsec-rule' aria-hidden='true'>
+        {RAINBOW_BANDS.map((color, i) => (
+          <span
+            key={i}
+            className='dsec-rule-band'
+            style={{ background: color }}
+          />
+        ))}
+      </span>
+      <div className='dsec-body'>{children}</div>
+    </section>
+  )
+}

--- a/components/organisms/SectionBand/__tests__/SectionBand.test.tsx
+++ b/components/organisms/SectionBand/__tests__/SectionBand.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { SectionBand } from '../SectionBand'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('SectionBand rendering', () => {
+  it('renders the title as a heading', () => {
+    render(
+      <SectionBand title='Up Next'>
+        <p>body</p>
+      </SectionBand>,
+    )
+    expect(screen.getByRole('heading', { name: 'Up Next' })).toBeInTheDocument()
+  })
+
+  it('passes children through to the body slot', () => {
+    render(
+      <SectionBand title='Up Next'>
+        <p data-testid='child'>scrolled content</p>
+      </SectionBand>,
+    )
+    expect(screen.getByTestId('child')).toHaveTextContent('scrolled content')
+  })
+
+  it('renders the 6-band rainbow rule with aria-hidden', () => {
+    const { container } = render(
+      <SectionBand title='Recently Added'>
+        <p>body</p>
+      </SectionBand>,
+    )
+    const rule = container.querySelector('.dsec-rule')
+    expect(rule).not.toBeNull()
+    expect(rule).toHaveAttribute('aria-hidden', 'true')
+    expect(container.querySelectorAll('.dsec-rule-band')).toHaveLength(6)
+  })
+
+  it('renders the count chip when count is a finite number', () => {
+    render(
+      <SectionBand title='Up Next' count={8}>
+        <p>body</p>
+      </SectionBand>,
+    )
+    expect(screen.getByText('8 items')).toBeInTheDocument()
+  })
+
+  it('singularizes the count chip when count is 1', () => {
+    render(
+      <SectionBand title='Up Next' count={1}>
+        <p>body</p>
+      </SectionBand>,
+    )
+    expect(screen.getByText('1 item')).toBeInTheDocument()
+  })
+
+  it('hides the count chip when count is null', () => {
+    const { container } = render(
+      <SectionBand title='Up Next' count={null}>
+        <p>body</p>
+      </SectionBand>,
+    )
+    expect(container.querySelector('.dsec-count')).toBeNull()
+  })
+
+  it('hides the count chip when count is undefined (default)', () => {
+    const { container } = render(
+      <SectionBand title='Up Next'>
+        <p>body</p>
+      </SectionBand>,
+    )
+    expect(container.querySelector('.dsec-count')).toBeNull()
+  })
+
+  it('wires aria-labelledby linking the section to the heading id', () => {
+    render(
+      <SectionBand title='Up Next'>
+        <p>body</p>
+      </SectionBand>,
+    )
+    const heading = screen.getByRole('heading', { name: 'Up Next' })
+    const section = heading.closest('section')
+    expect(section).not.toBeNull()
+    expect(section).toHaveAttribute('aria-labelledby', heading.id)
+    expect(heading.id).toMatch(/^section-band-/)
+  })
+
+  it('passes className through alongside the dsec base', () => {
+    const { container } = render(
+      <SectionBand title='Up Next' className='extra'>
+        <p>body</p>
+      </SectionBand>,
+    )
+    const section = container.querySelector('section')
+    expect(section).toHaveClass('dsec')
+    expect(section).toHaveClass('extra')
+  })
+})

--- a/components/organisms/SectionBand/index.ts
+++ b/components/organisms/SectionBand/index.ts
@@ -1,0 +1,2 @@
+export { SectionBand } from './SectionBand'
+export type { SectionBandProps } from './SectionBand'


### PR DESCRIPTION
## Summary

- Rewrites `app/page.tsx` from the 4-line scaffold-stub into the dashboard composition (CRT-bezel hero `> LIBRARY EMPTY` + 3 `<SectionBand>` molecules, each wrapping `<EmptyStateCard variant='band'>`). `MainNav` is already mounted by the root layout.
- Introduces `EmptyStateCard` (molecule) and `SectionBand` (organism). `DashboardSystemWidget` is deferred to Story 5.4 per impl-artifact OI #4.
- Hero `> ADD` CTA wires `useChannelFlipNavigate('/search')`.
- **Follow-up #106:** wraps the `MainNav` `LogoMark` in a button that channel-flips to `/`, so the logo links to the dashboard from every authenticated route.

## Test plan

- [ ] `pnpm dev` inside `cuatro-tracker-dev-1`, hit `localhost:3000` signed in: confirm empty-library hero + 3 empty bands with the per-band copy locked in Story 5.1 OI #4 (`NOTHING IN PROGRESS` / `NOTHING ADDED YET` / `NO RECENT RELEASES`).
- [ ] Click `> ADD`: channel-flip overlay plays, route lands on `/search`.
- [ ] Click the `CUATRO TRACKER` logo from `/search` (or any authed route): channel-flip lands on `/`.
- [ ] Sign out, hit `/`: redirect to `/login` (middleware contract; no dashboard chrome leaks; logo hidden because MainNav hides on `/login`).
- [ ] DevTools rendering → `prefers-reduced-motion: reduce`: channel-flip on `> ADD` + logo collapses to instant route change.
- [ ] AAA contrast: empty-state subtitles read in `--phosphor-cream-dim` (#B5AC9D, 8.24:1) against `--ground-base` — escalated from `cream-ghost` (3.85:1, would FAIL) per `bmad-code-review` decision-needed resolution.

Closes #104, closes #106