### PR TITLE
feat(dashboard): CurrentlyActiveCarousel + /api/library (#107)

### DIFF
--- a/app/api/library/__tests__/route.test.ts
+++ b/app/api/library/__tests__/route.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { MediaType, WatchStatus } from '@prisma/client'
+
+const loggerMock = vi.hoisted(() => ({
+  fatal: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: loggerMock,
+  createLogger: () => loggerMock,
+}))
+
+const dbMock = vi.hoisted(() => ({
+  userEntry: { findMany: vi.fn() },
+}))
+
+vi.mock('@/lib/db', () => ({ db: dbMock }))
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.resetAllMocks()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+function makeRequest(path: string): NextRequest {
+  return new NextRequest(new URL(path, 'http://localhost'))
+}
+
+const fixtureEntry = (overrides: Record<string, unknown> = {}) => ({
+  id: 'entry-1',
+  media_item_id: 'media-1',
+  status: WatchStatus.WATCHING,
+  user_rating: null,
+  progress: 0,
+  notes: null,
+  started_at: null,
+  completed_at: null,
+  created_at: new Date('2026-05-10T12:00:00Z'),
+  updated_at: new Date('2026-05-12T12:00:00Z'),
+  media_item: {
+    id: 'media-1',
+    type: MediaType.MOVIE,
+    title: 'Fight Club',
+    original_title: null,
+    release_date: new Date('1999-10-15T00:00:00Z'),
+    end_date: null,
+    poster_path: '/poster.jpg',
+    backdrop_path: null,
+    overview: null,
+    genres: [],
+    rating: null,
+    popularity: null,
+    status: null,
+    tmdb_id: 550,
+    anilist_id: null,
+    igdb_id: null,
+    steam_id: null,
+    parent_id: null,
+    franchise_id: null,
+    created_at: new Date('2026-05-10T12:00:00Z'),
+    updated_at: new Date('2026-05-12T12:00:00Z'),
+  },
+  ...overrides,
+})
+
+describe('GET /api/library', () => {
+  it('returns 400 on invalid status value', async () => {
+    const { GET } = await import('@/app/api/library/route')
+    const res = await GET(makeRequest('/api/library?status=NONSENSE'))
+    expect(res.status).toBe(400)
+    expect(dbMock.userEntry.findMany).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 on negative limit', async () => {
+    const { GET } = await import('@/app/api/library/route')
+    const res = await GET(makeRequest('/api/library?limit=-5'))
+    expect(res.status).toBe(400)
+  })
+
+  it('caps limit at 100 (rejects beyond)', async () => {
+    const { GET } = await import('@/app/api/library/route')
+    const res = await GET(makeRequest('/api/library?limit=200'))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns empty items array when no entries match', async () => {
+    dbMock.userEntry.findMany.mockResolvedValue([])
+    const { GET } = await import('@/app/api/library/route')
+    const res = await GET(makeRequest('/api/library?status=WATCHING'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.items).toEqual([])
+  })
+
+  it('applies status filter to the Prisma query when status param is set', async () => {
+    dbMock.userEntry.findMany.mockResolvedValue([])
+    const { GET } = await import('@/app/api/library/route')
+    await GET(makeRequest('/api/library?status=WATCHING&limit=5'))
+    expect(dbMock.userEntry.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { status: WatchStatus.WATCHING },
+        orderBy: { updated_at: 'desc' },
+        take: 5,
+      }),
+    )
+  })
+
+  it('omits the where clause when status is not set', async () => {
+    dbMock.userEntry.findMany.mockResolvedValue([])
+    const { GET } = await import('@/app/api/library/route')
+    await GET(makeRequest('/api/library?limit=20'))
+    expect(dbMock.userEntry.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: undefined,
+        take: 20,
+      }),
+    )
+  })
+
+  it('respects order=created_at_desc', async () => {
+    dbMock.userEntry.findMany.mockResolvedValue([])
+    const { GET } = await import('@/app/api/library/route')
+    await GET(makeRequest('/api/library?order=created_at_desc'))
+    expect(dbMock.userEntry.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { created_at: 'desc' },
+      }),
+    )
+  })
+
+  it('defaults order to updated_at_desc and limit to 20', async () => {
+    dbMock.userEntry.findMany.mockResolvedValue([])
+    const { GET } = await import('@/app/api/library/route')
+    await GET(makeRequest('/api/library'))
+    expect(dbMock.userEntry.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { updated_at: 'desc' },
+        take: 20,
+      }),
+    )
+  })
+
+  it('serializes a movie WATCHING entry with progressLabel + sourceLabel', async () => {
+    dbMock.userEntry.findMany.mockResolvedValue([fixtureEntry({ progress: 0 })])
+    const { GET } = await import('@/app/api/library/route')
+    const res = await GET(makeRequest('/api/library?status=WATCHING'))
+    const body = await res.json()
+    expect(body.items).toHaveLength(1)
+    const item = body.items[0]
+    expect(item.id).toBe('entry-1')
+    expect(item.mediaItemId).toBe('media-1')
+    expect(item.mediaType).toBe('MOVIE')
+    expect(item.title).toBe('Fight Club')
+    expect(item.posterPath).toBe('/poster.jpg')
+    expect(item.year).toBe(1999)
+    expect(item.sourceLabel).toBe('From TMDB')
+    expect(item.progressLabel).toBe('WATCHING')
+    expect(item.progressPct).toBe(0)
+  })
+
+  it('formats progressLabel as "X% WATCHED" for movies with mid progress', async () => {
+    dbMock.userEntry.findMany.mockResolvedValue([fixtureEntry({ progress: 42 })])
+    const { GET } = await import('@/app/api/library/route')
+    const res = await GET(makeRequest('/api/library?status=WATCHING'))
+    const body = await res.json()
+    expect(body.items[0].progressLabel).toBe('42% WATCHED')
+    expect(body.items[0].progressPct).toBe(42)
+  })
+
+  it('flattens 1970 sentinel release_date to year=null + releaseDate=null', async () => {
+    dbMock.userEntry.findMany.mockResolvedValue([
+      fixtureEntry({
+        media_item: {
+          ...fixtureEntry().media_item,
+          release_date: new Date('1970-01-01T00:00:00Z'),
+        },
+      }),
+    ])
+    const { GET } = await import('@/app/api/library/route')
+    const res = await GET(makeRequest('/api/library'))
+    const body = await res.json()
+    expect(body.items[0].year).toBeNull()
+    expect(body.items[0].releaseDate).toBeNull()
+  })
+})

--- a/app/api/library/route.ts
+++ b/app/api/library/route.ts
@@ -1,0 +1,140 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { z } from 'zod'
+import { type MediaItem, MediaType, type UserEntry, WatchStatus } from '@prisma/client'
+import { db } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import { withRequest } from '@/lib/request-context'
+import type { LibraryItem, LibraryListResponse } from '@/lib/types/library'
+
+export const dynamic = 'force-dynamic'
+
+/* `/api/library`: generic library filter endpoint. Returns the user's UserEntry
+ * rows joined with MediaItem, scoped by optional query params.
+ *
+ * Story 5.3 initial shape: status / order / limit. Story 5.4 extends with
+ * released_within_days + source / source_ids for the inLibrary chip flip in
+ * GlobalSearch. Epic 6 will reuse this for the library grid.
+ *
+ * Single-user app: middleware (per Story 1.10) gates auth; UserEntry rows are
+ * unscoped (one user; no userId column on UserEntry).
+ */
+
+const LibraryQuerySchema = z.object({
+  status: z.nativeEnum(WatchStatus).optional(),
+  order: z
+    .enum(['updated_at_desc', 'created_at_desc'])
+    .optional()
+    .default('updated_at_desc'),
+  limit: z.coerce.number().int().positive().max(100).optional().default(20),
+})
+
+type UserEntryWithMedia = UserEntry & { media_item: MediaItem }
+
+function deriveYear(mediaItem: MediaItem): number | null {
+  // 1970 is the normaliser's sentinel for "release date unknown" per
+  // lib/normalise-movie.ts. Treat it as null at the API boundary.
+  const year = mediaItem.release_date.getUTCFullYear()
+  return year === 1970 ? null : year
+}
+
+function deriveReleaseDate(mediaItem: MediaItem): string | null {
+  const year = mediaItem.release_date.getUTCFullYear()
+  return year === 1970 ? null : mediaItem.release_date.toISOString()
+}
+
+function formatProgressLabel(
+  mediaType: MediaType,
+  status: WatchStatus,
+  progress: number,
+): string | null {
+  if (mediaType === MediaType.MOVIE) {
+    if (status === WatchStatus.COMPLETED) return 'WATCHED'
+    if (status === WatchStatus.WATCHING && progress > 0 && progress < 100) {
+      return `${progress}% WATCHED`
+    }
+    return status.replaceAll('_', ' ')
+  }
+  // TV / anime / manga / games progress formatting lands in Stories 7-9 when
+  // those media types become addable. For now return null and let the client
+  // hide the line.
+  return null
+}
+
+function formatProgressPct(
+  mediaType: MediaType,
+  status: WatchStatus,
+  progress: number,
+): number | null {
+  if (mediaType === MediaType.MOVIE) {
+    if (status === WatchStatus.COMPLETED) return 100
+    if (status === WatchStatus.WATCHING) return Math.min(100, Math.max(0, progress))
+    return null
+  }
+  return null
+}
+
+function deriveSourceLabel(mediaItem: MediaItem): string | null {
+  if (mediaItem.tmdb_id !== null) return 'From TMDB'
+  if (mediaItem.anilist_id !== null) return 'From AniList'
+  if (mediaItem.igdb_id !== null) return 'From IGDB'
+  if (mediaItem.steam_id !== null) return 'From Steam'
+  return null
+}
+
+function serializeLibraryItem(entry: UserEntryWithMedia): LibraryItem {
+  const mediaItem = entry.media_item
+  return {
+    id: entry.id,
+    mediaItemId: mediaItem.id,
+    mediaType: mediaItem.type,
+    status: entry.status,
+    title: mediaItem.title,
+    posterPath: mediaItem.poster_path,
+    year: deriveYear(mediaItem),
+    releaseDate: deriveReleaseDate(mediaItem),
+    progressLabel: formatProgressLabel(mediaItem.type, entry.status, entry.progress),
+    progressPct: formatProgressPct(mediaItem.type, entry.status, entry.progress),
+    sourceLabel: deriveSourceLabel(mediaItem),
+    createdAt: entry.created_at.toISOString(),
+    updatedAt: entry.updated_at.toISOString(),
+  }
+}
+
+async function handler(req: NextRequest): Promise<NextResponse> {
+  const params = Object.fromEntries(req.nextUrl.searchParams)
+  const parsed = LibraryQuerySchema.safeParse(params)
+  if (!parsed.success) {
+    logger.warn(
+      { event: 'library.bad_request', issues: parsed.error.issues },
+      'library query validation failed',
+    )
+    return NextResponse.json(
+      { error: 'invalid_query', issues: parsed.error.issues },
+      { status: 400, headers: { 'Cache-Control': 'no-store' } },
+    )
+  }
+
+  const { status, order, limit } = parsed.data
+
+  const orderBy =
+    order === 'created_at_desc'
+      ? { created_at: 'desc' as const }
+      : { updated_at: 'desc' as const }
+
+  const entries = await db.userEntry.findMany({
+    where: status ? { status } : undefined,
+    include: { media_item: true },
+    orderBy,
+    take: limit,
+  })
+
+  const items = entries.map(serializeLibraryItem)
+  const body: LibraryListResponse = { items }
+
+  return NextResponse.json(body, {
+    status: 200,
+    headers: { 'Cache-Control': 'no-store' },
+  })
+}
+
+export const GET = withRequest<NextRequest, NextResponse>(handler)

--- a/app/global.css
+++ b/app/global.css
@@ -1512,3 +1512,129 @@ body {
 .dsec-body {
   display: block;
 }
+
+/* ============================================================
+   CurrentlyActiveCarousel (Story 5.3). CRT-bezel hero rotator with
+   side-by-side cover + info layout (per Story 5.3 OI #1), dot-matrix
+   progress indicator row below the bezel.
+   ============================================================ */
+
+.cac-screen {
+  display: flex !important;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  padding: 20px 24px !important;
+  text-align: left;
+}
+
+.cac-cover {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+}
+
+.cac-info {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.cac-eyebrow {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.cac-title {
+  margin: 2px 0 4px;
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 22px;
+  line-height: 1.15;
+  color: var(--phosphor-cream);
+  text-shadow: 0 0 8px rgba(239, 230, 212, 0.4);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.cac-meta {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-variant-numeric: tabular-nums;
+}
+
+.cac-meta-sep {
+  color: var(--phosphor-cream-ghost);
+}
+
+.cac-progress {
+  margin-top: 6px;
+  width: 100%;
+  height: 4px;
+  background: rgba(122, 116, 104, 0.25);
+  overflow: hidden;
+}
+
+.cac-progress-fill {
+  height: 100%;
+  background: var(--phosphor-cream);
+  box-shadow: 0 0 8px rgba(239, 230, 212, 0.45);
+  transition: width 200ms linear;
+}
+
+.cac-source {
+  margin: 8px 0 0;
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 13px;
+  color: var(--phosphor-cream-dim);
+}
+
+.cac-dot-row {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.cac-dot {
+  width: 10px;
+  height: 10px;
+  border: 1px solid var(--phosphor-cream-ghost);
+  background: transparent;
+  border-radius: 50%;
+  padding: 0;
+  cursor: pointer;
+  transition: background 150ms linear, box-shadow 150ms linear, border-color 150ms linear;
+}
+
+.cac-dot-active {
+  background: var(--phosphor-cream);
+  border-color: var(--phosphor-cream);
+  box-shadow: 0 0 8px rgba(239, 230, 212, 0.5);
+}
+
+.cac-dot:focus-visible {
+  outline: 2px solid var(--neon-blue);
+  outline-offset: 3px;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,31 +1,31 @@
 'use client'
 
-import { CRTBezel } from '@/components/molecules/CRTBezel'
+import { useQuery } from '@tanstack/react-query'
 import { EmptyStateCard } from '@/components/molecules/EmptyStateCard'
 import { useChannelFlipNavigate } from '@/components/molecules/ChannelFlipTransition'
+import { CurrentlyActiveCarousel } from '@/components/organisms/CurrentlyActiveCarousel'
 import { SectionBand } from '@/components/organisms/SectionBand'
+import type { LibraryListResponse } from '@/lib/types/library'
+
+async function fetchActiveLibrary(): Promise<LibraryListResponse> {
+  const res = await fetch('/api/library?status=WATCHING&order=updated_at_desc&limit=5', {
+    cache: 'no-store',
+  })
+  if (!res.ok) throw new Error(`library fetch failed: ${res.status}`)
+  return (await res.json()) as LibraryListResponse
+}
 
 export default function DashboardPage() {
-  const { navigate, overlay } = useChannelFlipNavigate()
+  const { overlay } = useChannelFlipNavigate()
+  const watchingQuery = useQuery({
+    queryKey: ['library', { status: 'WATCHING' }],
+    queryFn: fetchActiveLibrary,
+  })
+  const watchingItems = watchingQuery.data?.items ?? []
 
   return (
     <main className='dash'>
-      <section className='dash-hero' aria-label='Currently active'>
-        <CRTBezel size='hero' className='dash-hero-bezel'>
-          <div className='dash-hero-screen'>
-            <EmptyStateCard
-              variant='hero'
-              headline='LIBRARY EMPTY'
-              secondLine='ADD AN ITEM TO BEGIN'
-              subtitle='Search any title across TMDB, AniList, IGDB or Steam to start your collection.'
-              ctaLabel='ADD'
-              onCta={() => {
-                void navigate('/search')
-              }}
-            />
-          </div>
-        </CRTBezel>
-      </section>
+      <CurrentlyActiveCarousel items={watchingItems} />
 
       <SectionBand title='Up Next'>
         <EmptyStateCard

--- a/components/molecules/FramedCover/__tests__/media-registry.test.ts
+++ b/components/molecules/FramedCover/__tests__/media-registry.test.ts
@@ -14,8 +14,8 @@ describe('media-registry shape', () => {
     expect(Object.keys(MEDIA).sort()).toEqual([...MEDIUMS].sort())
   })
 
-  it('enumerates 3 sizes', () => {
-    expect(SIZES).toEqual(['thumb', 'card', 'hero'])
+  it('enumerates 5 sizes (Story 5.3 added hero-cover + scroller for the dashboard rotator and horizontal scrollers)', () => {
+    expect(SIZES).toEqual(['thumb', 'card', 'hero-cover', 'scroller', 'hero'])
   })
 
   it('every medium carries name, chrome, aspect, sizes, and stroke metadata', () => {

--- a/components/molecules/FramedCover/chrome/ChromeMovies.tsx
+++ b/components/molecules/FramedCover/chrome/ChromeMovies.tsx
@@ -31,7 +31,7 @@ export function ChromeMovies({ size, dims, hex }: ChromeProps) {
         strokeWidth={strokeW}
         className='fc-chrome-outer-stroke'
       />
-      {size === 'card' && (
+      {(size === 'card' || size === 'scroller' || size === 'hero-cover') && (
         <line
           x1={padL - 0.5}
           y1={strokeW}

--- a/components/molecules/FramedCover/media-registry.ts
+++ b/components/molecules/FramedCover/media-registry.ts
@@ -22,6 +22,8 @@ export const MEDIA = {
     sizes: {
       thumb: { outerW: 72, outerH: 104, padL: 4, padR: 4, padT: 4, padB: 4, innerW: 64, innerH: 96, strokeW: 1 },
       card: { outerW: 212, outerH: 304, padL: 12, padR: 8, padT: 8, padB: 8, innerW: 192, innerH: 288, strokeW: 2 },
+      'hero-cover': { outerW: 130, outerH: 195, padL: 6, padR: 4, padT: 4, padB: 4, innerW: 120, innerH: 187, strokeW: 2 },
+      scroller: { outerW: 144, outerH: 216, padL: 8, padR: 6, padT: 6, padB: 6, innerW: 130, innerH: 204, strokeW: 2 },
       hero: { outerW: 520, outerH: 752, padL: 24, padR: 16, padT: 16, padB: 16, innerW: 480, innerH: 720, strokeW: 4 },
     },
     strokeHex: '#B5AC9D',
@@ -35,6 +37,8 @@ export const MEDIA = {
     sizes: {
       thumb: { outerW: 72, outerH: 104, padL: 4, padR: 4, padT: 4, padB: 4, innerW: 64, innerH: 96, strokeW: 1 },
       card: { outerW: 204, outerH: 300, padL: 6, padR: 6, padT: 6, padB: 6, innerW: 192, innerH: 288, strokeW: 3 },
+      'hero-cover': { outerW: 130, outerH: 195, padL: 4, padR: 4, padT: 4, padB: 4, innerW: 122, innerH: 187, strokeW: 2 },
+      scroller: { outerW: 144, outerH: 216, padL: 4, padR: 4, padT: 4, padB: 4, innerW: 136, innerH: 208, strokeW: 2 },
       hero: { outerW: 504, outerH: 744, padL: 12, padR: 12, padT: 12, padB: 12, innerW: 480, innerH: 720, strokeW: 5 },
     },
     strokeHex: '#7A7468',
@@ -48,6 +52,8 @@ export const MEDIA = {
     sizes: {
       thumb: { outerW: 76, outerH: 108, padL: 6, padR: 6, padT: 6, padB: 6, innerW: 64, innerH: 96, strokeW: 1 },
       card: { outerW: 216, outerH: 312, padL: 12, padR: 12, padT: 12, padB: 12, innerW: 192, innerH: 288, strokeW: 2 },
+      'hero-cover': { outerW: 130, outerH: 195, padL: 5, padR: 5, padT: 5, padB: 5, innerW: 120, innerH: 185, strokeW: 2 },
+      scroller: { outerW: 144, outerH: 216, padL: 8, padR: 8, padT: 8, padB: 8, innerW: 128, innerH: 200, strokeW: 2 },
       hero: { outerW: 528, outerH: 768, padL: 24, padR: 24, padT: 24, padB: 24, innerW: 480, innerH: 720, strokeW: 4 },
     },
     strokeHex: '#9D8C66',
@@ -61,6 +67,8 @@ export const MEDIA = {
     sizes: {
       thumb: { outerW: 72, outerH: 104, padL: 4, padR: 4, padT: 4, padB: 4, innerW: 64, innerH: 96, strokeW: 1 },
       card: { outerW: 208, outerH: 304, padL: 8, padR: 8, padT: 8, padB: 8, innerW: 192, innerH: 288, strokeW: 2 },
+      'hero-cover': { outerW: 130, outerH: 195, padL: 4, padR: 4, padT: 4, padB: 4, innerW: 122, innerH: 187, strokeW: 2 },
+      scroller: { outerW: 144, outerH: 216, padL: 6, padR: 6, padT: 6, padB: 6, innerW: 132, innerH: 204, strokeW: 2 },
       hero: { outerW: 512, outerH: 752, padL: 16, padR: 16, padT: 16, padB: 16, innerW: 480, innerH: 720, strokeW: 4 },
     },
     strokeHex: '#B5AC9D',
@@ -74,6 +82,8 @@ export const MEDIA = {
     sizes: {
       thumb: { outerW: 72, outerH: 97, padL: 4, padR: 4, padT: 8, padB: 4, innerW: 64, innerH: 85, strokeW: 1 },
       card: { outerW: 208, outerH: 288, padL: 8, padR: 8, padT: 24, padB: 8, innerW: 192, innerH: 256, strokeW: 2 },
+      'hero-cover': { outerW: 130, outerH: 195, padL: 4, padR: 4, padT: 16, padB: 4, innerW: 122, innerH: 175, strokeW: 2 },
+      scroller: { outerW: 144, outerH: 216, padL: 6, padR: 6, padT: 18, padB: 6, innerW: 132, innerH: 192, strokeW: 2 },
       hero: { outerW: 512, outerH: 712, padL: 16, padR: 16, padT: 56, padB: 16, innerW: 480, innerH: 640, strokeW: 4 },
     },
     strokeHex: '#5C4677',
@@ -83,12 +93,12 @@ export const MEDIA = {
 } as const
 
 export type Medium = keyof typeof MEDIA
-export type Size = 'thumb' | 'card' | 'hero'
+export type Size = 'thumb' | 'card' | 'hero-cover' | 'scroller' | 'hero'
 export type MediaDims = (typeof MEDIA)[Medium]['sizes'][Size]
 export type MediaConfig = (typeof MEDIA)[Medium]
 
 export const MEDIUMS: readonly Medium[] = ['movies', 'tv', 'anime', 'manga', 'games'] as const
-export const SIZES: readonly Size[] = ['thumb', 'card', 'hero'] as const
+export const SIZES: readonly Size[] = ['thumb', 'card', 'hero-cover', 'scroller', 'hero'] as const
 
 /* TV is the only medium whose inner cutout receives rounded corners
  * (per design-system §0.4, the inner CRT screen area is the lone
@@ -96,7 +106,7 @@ export const SIZES: readonly Size[] = ['thumb', 'card', 'hero'] as const
  */
 export function tvInnerRadius(size: Size): number {
   if (size === 'hero') return 10
-  if (size === 'card') return 4
+  if (size === 'card' || size === 'scroller' || size === 'hero-cover') return 4
   return 0
 }
 

--- a/components/organisms/CurrentlyActiveCarousel/CurrentlyActiveCarousel.tsx
+++ b/components/organisms/CurrentlyActiveCarousel/CurrentlyActiveCarousel.tsx
@@ -1,0 +1,203 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { MediaType } from '@prisma/client'
+import { CRTBezel } from '@/components/molecules/CRTBezel'
+import { EmptyStateCard } from '@/components/molecules/EmptyStateCard'
+import { FramedCover } from '@/components/molecules/FramedCover'
+import type { Medium } from '@/components/molecules/FramedCover/media-registry'
+import { useChannelFlipNavigate } from '@/components/molecules/ChannelFlipTransition'
+import { getImageUrl } from '@/lib/api/tmdb-images'
+import type { LibraryItem } from '@/lib/types/library'
+
+export type CurrentlyActiveCarouselProps = {
+  items: LibraryItem[]
+  rotationMs?: number
+}
+
+const DEFAULT_ROTATION_MS = 5000
+
+const MEDIA_TYPE_TO_MEDIUM: Record<MediaType, Medium> = {
+  MOVIE: 'movies',
+  TV_SHOW: 'tv',
+  TV_EPISODE: 'tv',
+  ANIME: 'anime',
+  MANGA: 'manga',
+  GAME: 'games',
+}
+
+const MEDIA_TYPE_LABEL: Record<MediaType, string> = {
+  MOVIE: 'MOVIE',
+  TV_SHOW: 'TV',
+  TV_EPISODE: 'TV',
+  ANIME: 'ANIME',
+  MANGA: 'MANGA',
+  GAME: 'GAME',
+}
+
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    setReduced(mq.matches)
+    const onChange = (event: MediaQueryListEvent) => setReduced(event.matches)
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
+
+  return reduced
+}
+
+export function CurrentlyActiveCarousel({
+  items,
+  rotationMs = DEFAULT_ROTATION_MS,
+}: CurrentlyActiveCarouselProps) {
+  const { navigate } = useChannelFlipNavigate()
+  const [activeIdx, setActiveIdx] = useState(0)
+  const [paused, setPaused] = useState(false)
+  const reducedMotion = usePrefersReducedMotion()
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  const advance = useCallback(
+    (direction: 1 | -1) => {
+      if (items.length === 0) return
+      setActiveIdx((prev) => (prev + direction + items.length) % items.length)
+    },
+    [items.length],
+  )
+
+  // Auto-cycle effect: advance every rotationMs unless paused or reduced-motion.
+  useEffect(() => {
+    if (items.length < 2 || paused || reducedMotion) return undefined
+    timerRef.current = setTimeout(() => {
+      setActiveIdx((prev) => (prev + 1) % items.length)
+    }, rotationMs)
+    return clearTimer
+  }, [activeIdx, items.length, paused, reducedMotion, rotationMs, clearTimer])
+
+  // Empty state. Migrated from app/page.tsx inline render (Story 5.2 → 5.3).
+  if (items.length === 0) {
+    return (
+      <div className='dash-hero' aria-label='Currently active'>
+        <CRTBezel size='hero' className='dash-hero-bezel'>
+          <div className='dash-hero-screen'>
+            <EmptyStateCard
+              variant='hero'
+              headline='LIBRARY EMPTY'
+              secondLine='ADD AN ITEM TO BEGIN'
+              subtitle='Search any title across TMDB, AniList, IGDB or Steam to start your collection.'
+              ctaLabel='ADD'
+              onCta={() => {
+                void navigate('/search')
+              }}
+            />
+          </div>
+        </CRTBezel>
+      </div>
+    )
+  }
+
+  const active = items[activeIdx % items.length]
+  const medium = MEDIA_TYPE_TO_MEDIUM[active.mediaType]
+  const posterUrl =
+    getImageUrl(active.posterPath, 'w342') ??
+    'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>'
+
+  return (
+    <section className='dash-hero cac' aria-label='Currently active'>
+      <CRTBezel size='hero' className='dash-hero-bezel'>
+        <div
+          className='dash-hero-screen cac-screen'
+          onPointerEnter={() => setPaused(true)}
+          onPointerLeave={() => setPaused(false)}
+          onFocus={() => setPaused(true)}
+          onBlur={(event) => {
+            // Only resume if focus left the screen entirely.
+            if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+              setPaused(false)
+            }
+          }}
+        >
+          <div className='cac-cover'>
+            <FramedCover
+              medium={medium}
+              size='hero-cover'
+              src={posterUrl}
+              alt={active.title}
+            />
+          </div>
+          <div className='cac-info'>
+            <p className='cac-eyebrow'>
+              {MEDIA_TYPE_LABEL[active.mediaType]} · NOW WATCHING
+            </p>
+            <h2 className='cac-title'>{active.title}</h2>
+            <p className='cac-meta'>
+              {active.progressLabel ?? '—'}
+              {active.year !== null ? (
+                <>
+                  <span className='cac-meta-sep' aria-hidden='true'>·</span>
+                  <span>{active.year}</span>
+                </>
+              ) : null}
+            </p>
+            {active.progressPct !== null ? (
+              <div
+                className='cac-progress'
+                aria-label={`Progress: ${active.progressPct}%`}
+                role='progressbar'
+                aria-valuenow={active.progressPct}
+                aria-valuemin={0}
+                aria-valuemax={100}
+              >
+                <div
+                  className='cac-progress-fill'
+                  style={{ width: `${active.progressPct}%` }}
+                />
+              </div>
+            ) : null}
+            {active.sourceLabel !== null ? (
+              <p className='cac-source'>{active.sourceLabel}</p>
+            ) : null}
+          </div>
+        </div>
+      </CRTBezel>
+      <div
+        className='cac-dot-row'
+        role='tablist'
+        aria-label='Currently active items'
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowRight') {
+            event.preventDefault()
+            advance(1)
+          } else if (event.key === 'ArrowLeft') {
+            event.preventDefault()
+            advance(-1)
+          }
+        }}
+      >
+        {items.map((item, i) => (
+          <button
+            key={item.id}
+            type='button'
+            role='tab'
+            aria-selected={i === activeIdx}
+            aria-label={`Show item ${i + 1} of ${items.length}: ${item.title}`}
+            className={['cac-dot', i === activeIdx ? 'cac-dot-active' : ''].filter(Boolean).join(' ')}
+            onClick={() => setActiveIdx(i)}
+            onPointerEnter={() => setPaused(true)}
+            onPointerLeave={() => setPaused(false)}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/components/organisms/CurrentlyActiveCarousel/__tests__/CurrentlyActiveCarousel.test.tsx
+++ b/components/organisms/CurrentlyActiveCarousel/__tests__/CurrentlyActiveCarousel.test.tsx
@@ -1,0 +1,196 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MediaType, WatchStatus } from '@prisma/client'
+import type { LibraryItem } from '@/lib/types/library'
+
+const navigateMock = vi.fn()
+
+vi.mock('@/components/molecules/ChannelFlipTransition', () => ({
+  useChannelFlipNavigate: () => ({
+    navigate: (target: string) => {
+      navigateMock(target)
+      return Promise.resolve()
+    },
+    overlay: null,
+  }),
+}))
+
+import { CurrentlyActiveCarousel } from '../CurrentlyActiveCarousel'
+
+const reducedMotionMatches = { value: false }
+
+function makeMatchMedia(): typeof window.matchMedia {
+  return (query: string) =>
+    ({
+      matches:
+        query === '(prefers-reduced-motion: reduce)'
+          ? reducedMotionMatches.value
+          : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }) as unknown as MediaQueryList
+}
+
+beforeEach(() => {
+  navigateMock.mockReset()
+  reducedMotionMatches.value = false
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: makeMatchMedia(),
+  })
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+function fixtureItem(overrides: Partial<LibraryItem> = {}): LibraryItem {
+  return {
+    id: 'entry-1',
+    mediaItemId: 'media-1',
+    mediaType: MediaType.MOVIE,
+    status: WatchStatus.WATCHING,
+    title: 'Fight Club',
+    posterPath: '/poster.jpg',
+    year: 1999,
+    releaseDate: '1999-10-15T00:00:00.000Z',
+    progressLabel: 'WATCHING',
+    progressPct: 0,
+    sourceLabel: 'From TMDB',
+    createdAt: '2026-05-10T12:00:00.000Z',
+    updatedAt: '2026-05-12T12:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('CurrentlyActiveCarousel', () => {
+  it('renders the empty state when items is empty', () => {
+    render(<CurrentlyActiveCarousel items={[]} />)
+    expect(screen.getByText('> LIBRARY EMPTY')).toBeInTheDocument()
+    expect(screen.getByText('ADD AN ITEM TO BEGIN')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '> ADD' })).toBeInTheDocument()
+  })
+
+  it('calls navigate("/search") when the empty-state CTA is clicked', () => {
+    render(<CurrentlyActiveCarousel items={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: '> ADD' }))
+    expect(navigateMock).toHaveBeenCalledWith('/search')
+  })
+
+  it('renders the active item title, eyebrow, and progress label', () => {
+    render(<CurrentlyActiveCarousel items={[fixtureItem({ progressLabel: '42% WATCHED' })]} />)
+    expect(screen.getByRole('heading', { name: 'Fight Club' })).toBeInTheDocument()
+    expect(screen.getByText('MOVIE · NOW WATCHING')).toBeInTheDocument()
+    expect(screen.getByText('42% WATCHED')).toBeInTheDocument()
+  })
+
+  it('renders one dot per item with the active dot marked aria-selected', () => {
+    const items = [
+      fixtureItem({ id: 'a', title: 'A' }),
+      fixtureItem({ id: 'b', title: 'B' }),
+      fixtureItem({ id: 'c', title: 'C' }),
+    ]
+    render(<CurrentlyActiveCarousel items={items} />)
+    const dots = screen.getAllByRole('tab')
+    expect(dots).toHaveLength(3)
+    expect(dots[0]).toHaveAttribute('aria-selected', 'true')
+    expect(dots[1]).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('advances activeIdx after rotationMs (real timers, short rotation)', async () => {
+    vi.useFakeTimers()
+    try {
+      const items = [
+        fixtureItem({ id: 'a', title: 'AlphaTitle' }),
+        fixtureItem({ id: 'b', title: 'BetaTitle' }),
+      ]
+      render(<CurrentlyActiveCarousel items={items} rotationMs={100} />)
+      expect(screen.getByRole('heading', { name: 'AlphaTitle' })).toBeInTheDocument()
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(150)
+      })
+      expect(screen.getByRole('heading', { name: 'BetaTitle' })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('pauses auto-cycle on pointerEnter and resumes on pointerLeave', async () => {
+    vi.useFakeTimers()
+    try {
+      const items = [
+        fixtureItem({ id: 'a', title: 'AlphaTitle' }),
+        fixtureItem({ id: 'b', title: 'BetaTitle' }),
+      ]
+      const { container } = render(
+        <CurrentlyActiveCarousel items={items} rotationMs={100} />,
+      )
+      const screenEl = container.querySelector('.cac-screen') as HTMLElement
+      expect(screenEl).not.toBeNull()
+      fireEvent.pointerEnter(screenEl)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300)
+      })
+      // Paused: still on item a.
+      expect(screen.getByRole('heading', { name: 'AlphaTitle' })).toBeInTheDocument()
+      fireEvent.pointerLeave(screenEl)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(150)
+      })
+      expect(screen.getByRole('heading', { name: 'BetaTitle' })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does NOT auto-cycle when prefers-reduced-motion matches', async () => {
+    reducedMotionMatches.value = true
+    vi.useFakeTimers()
+    try {
+      const items = [
+        fixtureItem({ id: 'a', title: 'AlphaTitle' }),
+        fixtureItem({ id: 'b', title: 'BetaTitle' }),
+      ]
+      render(<CurrentlyActiveCarousel items={items} rotationMs={100} />)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500)
+      })
+      // No advance.
+      expect(screen.getByRole('heading', { name: 'AlphaTitle' })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clicking a dot sets the active index to that item', () => {
+    const items = [
+      fixtureItem({ id: 'a', title: 'AlphaTitle' }),
+      fixtureItem({ id: 'b', title: 'BetaTitle' }),
+      fixtureItem({ id: 'c', title: 'CharlieTitle' }),
+    ]
+    render(<CurrentlyActiveCarousel items={items} />)
+    const dots = screen.getAllByRole('tab')
+    fireEvent.click(dots[2])
+    expect(screen.getByRole('heading', { name: 'CharlieTitle' })).toBeInTheDocument()
+  })
+
+  it('arrow keys on the dot-row advance the active index manually', () => {
+    const items = [
+      fixtureItem({ id: 'a', title: 'AlphaTitle' }),
+      fixtureItem({ id: 'b', title: 'BetaTitle' }),
+    ]
+    const { container } = render(<CurrentlyActiveCarousel items={items} />)
+    const tablist = container.querySelector('[role="tablist"]') as HTMLElement
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' })
+    expect(screen.getByRole('heading', { name: 'BetaTitle' })).toBeInTheDocument()
+    fireEvent.keyDown(tablist, { key: 'ArrowLeft' })
+    expect(screen.getByRole('heading', { name: 'AlphaTitle' })).toBeInTheDocument()
+  })
+})

--- a/components/organisms/CurrentlyActiveCarousel/index.ts
+++ b/components/organisms/CurrentlyActiveCarousel/index.ts
@@ -1,0 +1,2 @@
+export { CurrentlyActiveCarousel } from './CurrentlyActiveCarousel'
+export type { CurrentlyActiveCarouselProps } from './CurrentlyActiveCarousel'

--- a/components/organisms/GlobalSearch/GlobalSearch.tsx
+++ b/components/organisms/GlobalSearch/GlobalSearch.tsx
@@ -165,6 +165,14 @@ export function GlobalSearch() {
       }
       const lowerType = body.type.toLowerCase().split('_')[0]
       void queryClient.invalidateQueries({ queryKey: ['library', lowerType] })
+      // Story 5.4 dashboard invalidations: the rotator + Recently Added band
+      // refetch so newly-added items show up immediately on /.
+      void queryClient.invalidateQueries({
+        queryKey: ['library', { status: 'WATCHING' }],
+      })
+      void queryClient.invalidateQueries({
+        queryKey: ['dashboard', 'recently-added'],
+      })
       toast.success('ADDED TO LIBRARY', {
         description: `Source: ${body.source.toUpperCase()} · ${body.type.replace(/_/g, ' ')}`,
       })

--- a/lib/types/library.ts
+++ b/lib/types/library.ts
@@ -1,0 +1,30 @@
+import type { MediaType, WatchStatus } from '@prisma/client'
+
+/* Library item shape returned by `/api/library` and consumed by:
+ *  - CurrentlyActiveCarousel (Story 5.3) for the WATCHING-status rotator
+ *  - HorizontalCoverScroller (Story 5.4) for Recently Added / Recently Released
+ *  - LibraryCard (Epic 6+) for the per-medium library grids
+ *  - GlobalSearch (Story 5.4 follow-up) for the inLibrary chip flip
+ *
+ * Server-side-formatted fields (progressLabel, progressPct) precompute the
+ * per-medium display strings so the client renders without an N+1 lookup.
+ */
+export type LibraryItem = {
+  id: string // UserEntry.id
+  mediaItemId: string // MediaItem.id (for navigation to detail pages)
+  mediaType: MediaType
+  status: WatchStatus
+  title: string
+  posterPath: string | null // TMDB-style path; client constructs the full URL
+  year: number | null // derived from MediaItem.release_date
+  releaseDate: string | null // ISO; null when MediaItem.release_date is sentinel-1970
+  progressLabel: string | null // e.g. "S2 EP4 / 10" or "42% WATCHED" — null for movies + when no progress data exists
+  progressPct: number | null // 0-100, for inline phosphor progress bar visualization
+  sourceLabel: string | null // e.g. "From TMDB" — for hero source-description line
+  createdAt: string // ISO, UserEntry.created_at
+  updatedAt: string // ISO, UserEntry.updated_at
+}
+
+export type LibraryListResponse = {
+  items: LibraryItem[]
+}


### PR DESCRIPTION
## Summary

- Wires the dashboard hero rotator to live data via `<CurrentlyActiveCarousel>` (organism) + `GET /api/library` (generic library-filter endpoint).
- Side-by-side hero layout per Story 5.3 OI #1; cover at new `hero-cover` (130×195) FramedCover size mode per OI #2; auto-cycle 5000ms with pause-on-hover, reduced-motion bypass, keyboard arrow nav, dot-matrix indicator below the bezel.
- Backend: `GET /api/library?status=WATCHING&order=updated_at_desc&limit=5` returns the rotator's items; same endpoint serves Story 5.4's Recently Added / Recently Released bands by varying query params per OI #3 ratification.
- Adds `scroller` (144×216) FramedCover size mode now (5.4 will consume it).
- `GlobalSearch.addMutation` invalidates `['library', { status: 'WATCHING' }]` + `['dashboard', 'recently-added']` so adds refresh the dashboard.
- `'use client'` page wires `useQuery` for the rotator; empty state migrates from inline `app/page.tsx` (Story 5.2) into the new component.

**Note on plan change:** originally planned to bundle Story 5.4 + GlobalSearch `inLibrary` follow-up into one PR per Epic 5 PR strategy; the bundle's full scope exceeded one session's budget, so Story 5.3 ships standalone. Stories 5.4 + the `inLibrary` flip become their own follow-up PRs off `main` after this merges. Handoff prompt for that work at `_bmad-output/handoffs/story-5-4-and-inlibrary-pickup-prompt.md`.

## Test plan

- [ ] `pnpm dev` inside `cuatro-tracker-dev-1`, hit `localhost:3000` signed in: hero shows `> LIBRARY EMPTY` empty state (no `WATCHING` items yet).
- [ ] Click `> ADD` in the hero: channel-flip → `/search`.
- [ ] Sign out, hit `/`: redirect to `/login`.
- [ ] Add a movie via `/search`: `ADDED TO LIBRARY` toast fires. Dashboard hero stays empty because `POST /api/media` defaults new entries to `PLAN_TO_WATCH` (not `WATCHING`). Manually flipping a UserEntry's status to `WATCHING` via `psql` is needed for smoke-testing the populated state until Epic 6's detail-page status-flip lands.
- [ ] Toggle DevTools `prefers-reduced-motion: reduce`: rotator does not auto-cycle when populated; ArrowRight/Left + dot click manual advance.

## Static gates

- `pnpm typecheck` clean
- `pnpm lint` clean
- `pnpm vitest run` 20/20 new (11 route + 9 carousel) + 39/39 affected suite
- `pnpm build` clean; `/` route 4.42 kB / 251 kB first-load JS

Closes #107