### PR TITLE
feat(dashboard): horizontal scrollers + Now Downloading shell (#109)

### DIFF
--- a/app/api/dashboard/up-next/__tests__/route.test.ts
+++ b/app/api/dashboard/up-next/__tests__/route.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+function makeRequest(path: string): NextRequest {
+  return new NextRequest(new URL(path, 'http://localhost'))
+}
+
+describe('GET /api/dashboard/up-next', () => {
+  it('returns 200 with empty items array (Epic 5 stub: movies have no next-X semantics)', async () => {
+    const { GET } = await import('@/app/api/dashboard/up-next/route')
+    const res = await GET(makeRequest('/api/dashboard/up-next'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ items: [] })
+  })
+
+  it('sets Cache-Control: no-store', async () => {
+    const { GET } = await import('@/app/api/dashboard/up-next/route')
+    const res = await GET(makeRequest('/api/dashboard/up-next'))
+    expect(res.headers.get('cache-control')).toBe('no-store')
+  })
+})

--- a/app/api/dashboard/up-next/route.ts
+++ b/app/api/dashboard/up-next/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { withRequest } from '@/lib/request-context'
+import type { LibraryItem } from '@/lib/types/library'
+
+export const dynamic = 'force-dynamic'
+
+/* `/api/dashboard/up-next`: returns the user's "next thing to consume" per
+ * medium. For Epic 5 the only addable medium is movies (TMDB, Epic 4); movies
+ * have no next-episode / next-chapter / near-completion-achievement semantics,
+ * so the band is intentionally empty until TV / anime / manga / games become
+ * addable in Epic 7+.
+ *
+ * The endpoint shape is stabilised now so the client subscription is fixed and
+ * future stories grow the SQL without touching app/page.tsx.
+ *
+ * TODO(epic 7+): join UserEntry → MediaItem.children to surface:
+ *  - TV: next unwatched episode for WATCHING shows (resolved via progress
+ *    cursor on the child MediaItem rows).
+ *  - Anime: same shape as TV.
+ *  - Manga: next unread chapter for in-progress series.
+ *  - Games: near-completion achievement (≥80% of an achievement set).
+ */
+
+type UpNextResponse = { items: LibraryItem[] }
+
+async function handler(_req: NextRequest): Promise<NextResponse> {
+  const body: UpNextResponse = { items: [] }
+  return NextResponse.json(body, {
+    status: 200,
+    headers: { 'Cache-Control': 'no-store' },
+  })
+}
+
+export const GET = withRequest<NextRequest, NextResponse>(handler)

--- a/app/api/library/__tests__/route.test.ts
+++ b/app/api/library/__tests__/route.test.ts
@@ -196,6 +196,53 @@ describe('GET /api/library', () => {
     expect(body.items[0].progressPct).toBe(42)
   })
 
+  it('applies release_date gte + lte filter when released_within_days is set', async () => {
+    dbMock.userEntry.findMany.mockResolvedValue([])
+    const before = Date.now()
+    const { GET } = await import('@/app/api/library/route')
+    await GET(makeRequest('/api/library?released_within_days=30&limit=20'))
+    const after = Date.now()
+    const call = dbMock.userEntry.findMany.mock.calls[0][0]
+    const filter = call.where.media_item.release_date
+    expect(filter.gte).toBeInstanceOf(Date)
+    expect(filter.lte).toBeInstanceOf(Date)
+
+    const floor: Date = filter.gte
+    const expectedFloor = before - 30 * 24 * 60 * 60 * 1000
+    const expectedFloorMax = after - 30 * 24 * 60 * 60 * 1000
+    expect(floor.getTime()).toBeGreaterThanOrEqual(expectedFloor)
+    expect(floor.getTime()).toBeLessThanOrEqual(expectedFloorMax)
+
+    // Upper bound clamps future-dated releases out of the "Recently Released"
+    // band; the lte must land between `before` and `after`.
+    const ceiling: Date = filter.lte
+    expect(ceiling.getTime()).toBeGreaterThanOrEqual(before)
+    expect(ceiling.getTime()).toBeLessThanOrEqual(after)
+  })
+
+  it('forces order release_date_desc when released_within_days is set, regardless of order param', async () => {
+    dbMock.userEntry.findMany.mockResolvedValue([])
+    const { GET } = await import('@/app/api/library/route')
+    await GET(makeRequest('/api/library?released_within_days=30&order=created_at_desc'))
+    expect(dbMock.userEntry.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { media_item: { release_date: 'desc' } },
+      }),
+    )
+  })
+
+  it('rejects released_within_days beyond 3650 (10 years)', async () => {
+    const { GET } = await import('@/app/api/library/route')
+    const res = await GET(makeRequest('/api/library?released_within_days=4000'))
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects negative released_within_days', async () => {
+    const { GET } = await import('@/app/api/library/route')
+    const res = await GET(makeRequest('/api/library?released_within_days=-10'))
+    expect(res.status).toBe(400)
+  })
+
   it('flattens 1970 sentinel release_date to year=null + releaseDate=null', async () => {
     dbMock.userEntry.findMany.mockResolvedValue([
       fixtureEntry({

--- a/app/api/library/route.ts
+++ b/app/api/library/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { z } from 'zod'
-import { type MediaItem, MediaType, type UserEntry, WatchStatus } from '@prisma/client'
+import { type MediaItem, MediaType, type Prisma, type UserEntry, WatchStatus } from '@prisma/client'
 import { db } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import { withRequest } from '@/lib/request-context'
@@ -22,10 +22,11 @@ export const dynamic = 'force-dynamic'
 const LibraryQuerySchema = z.object({
   status: z.nativeEnum(WatchStatus).optional(),
   order: z
-    .enum(['updated_at_desc', 'created_at_desc'])
+    .enum(['updated_at_desc', 'created_at_desc', 'release_date_desc'])
     .optional()
     .default('updated_at_desc'),
   limit: z.coerce.number().int().positive().max(100).optional().default(20),
+  released_within_days: z.coerce.number().int().positive().max(3650).optional(),
 })
 
 type UserEntryWithMedia = UserEntry & { media_item: MediaItem }
@@ -114,15 +115,36 @@ async function handler(req: NextRequest): Promise<NextResponse> {
     )
   }
 
-  const { status, order, limit } = parsed.data
+  const { status, order, limit, released_within_days } = parsed.data
+
+  // `released_within_days` filters by joined MediaItem.release_date and forces
+  // ordering by release_date DESC regardless of the `order` param. This matches
+  // the dashboard's "Recently Released" band semantics (Story 5.4 AC-5).
+  const effectiveOrder = released_within_days !== undefined ? 'release_date_desc' : order
+
+  const where: Prisma.UserEntryWhereInput = {}
+  if (status) where.status = status
+  if (released_within_days !== undefined) {
+    // AC-5 reads "released in the last 30 days" — past-tense. The lower bound
+    // (gte: floor) drops anything older than the window; the upper bound
+    // (lte: now) drops future-dated releases (TMDB returns unreleased movies
+    // with future release_date, and they should NOT surface as "recently
+    // released"). 1970 sentinel rows for "unknown release date" are naturally
+    // excluded by the floor (UNIX epoch < NOW - any positive N days).
+    const now = new Date()
+    const floor = new Date(now.getTime() - released_within_days * 24 * 60 * 60 * 1000)
+    where.media_item = { release_date: { gte: floor, lte: now } }
+  }
 
   const orderBy =
-    order === 'created_at_desc'
-      ? { created_at: 'desc' as const }
-      : { updated_at: 'desc' as const }
+    effectiveOrder === 'release_date_desc'
+      ? { media_item: { release_date: 'desc' as const } }
+      : effectiveOrder === 'created_at_desc'
+        ? { created_at: 'desc' as const }
+        : { updated_at: 'desc' as const }
 
   const entries = await db.userEntry.findMany({
-    where: status ? { status } : undefined,
+    where: Object.keys(where).length > 0 ? where : undefined,
     include: { media_item: true },
     orderBy,
     take: limit,

--- a/app/global.css
+++ b/app/global.css
@@ -1638,3 +1638,166 @@ body {
   outline: 2px solid var(--neon-blue);
   outline-offset: 3px;
 }
+
+/* ============================================================
+   HorizontalCoverScroller (Story 5.4). Bounded horizontal scroll of FramedCover
+   `scroller` cards (144×216) with snap, right-edge fade-to-ground, italic title
+   + small-caps medium-progress meta, ArrowLeft/Right roving-tabindex nav.
+   Bundle source: 02-dashboard/cuatro-tracker/project/dashboard-styles.css
+   lines 464-535 (.cover-scroller / .cover-cell), renamed to .hcs / .hcs-cell.
+   ============================================================ */
+
+.hcs-wrap {
+  position: relative;
+}
+
+.hcs-wrap::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 24px;
+  background: linear-gradient(90deg, transparent, var(--ground-base));
+  pointer-events: none;
+  z-index: 3;
+}
+
+.hcs {
+  display: flex;
+  gap: 16px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  padding: 4px 0 8px;
+  list-style: none;
+  margin: 0;
+}
+
+.hcs::-webkit-scrollbar { height: 6px; }
+.hcs::-webkit-scrollbar-track { background: transparent; }
+.hcs::-webkit-scrollbar-thumb { background: var(--phosphor-cream-ghost); }
+
+.hcs-cell {
+  flex: 0 0 auto;
+  width: 144px;
+  scroll-snap-align: start;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  outline: none;
+}
+
+.hcs-cell-frame {
+  width: 144px;
+  height: 216px;
+  position: relative;
+}
+
+.hcs-cell:focus-visible .hcs-cell-frame {
+  outline: 2px solid var(--neon-blue);
+  outline-offset: 2px;
+  box-shadow: 0 0 12px rgba(63, 169, 255, 0.45);
+}
+
+.hcs-cell-title {
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 14px;
+  line-height: 1.2;
+  color: var(--phosphor-cream);
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcs-cell-meta {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0;
+}
+
+/* ============================================================
+   DashboardSystemWidget (Story 5.4 OI #6). Zero state = ghost-bordered box
+   with `> NO ACTIVE DOWNLOADS · qBT · IDLE`. Active state = throughput meta +
+   one row per torrent (italic name + PhosphorBar + bitmap percentage). Epic 12
+   (Story 12.3) wires real qBittorrent data through.
+   Bundle source: dashboard-styles.css lines 560-625 (.now-downloading),
+   renamed to .dsw to match the in-repo widget identifier.
+   ============================================================ */
+
+.dsw {
+  margin-top: 8px;
+  border: 1px solid var(--phosphor-cream-ghost);
+  padding: 16px 20px;
+  background: var(--ground-base);
+}
+
+.dsw-head {
+  font-family: var(--font-bitmap);
+  font-size: 18px;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+}
+
+.dsw-label {
+  color: var(--phosphor-cream);
+}
+
+.dsw-zero .dsw-label {
+  color: var(--phosphor-cream-dim);
+}
+
+.dsw-meta {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-ghost);
+  font-variant-numeric: tabular-nums;
+}
+
+.dsw-rows {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dsw-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 220px 70px;
+  align-items: center;
+  gap: 16px;
+  padding: 6px 0;
+}
+
+.dsw-row-name {
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--phosphor-cream);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.dsw-row-pct {
+  font-family: var(--font-bitmap);
+  font-size: 18px;
+  color: var(--phosphor-cream);
+  text-align: right;
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,52 +1,84 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import { EmptyStateCard } from '@/components/molecules/EmptyStateCard'
 import { useChannelFlipNavigate } from '@/components/molecules/ChannelFlipTransition'
 import { CurrentlyActiveCarousel } from '@/components/organisms/CurrentlyActiveCarousel'
+import { DashboardSystemWidget } from '@/components/organisms/DashboardSystemWidget'
+import { HorizontalCoverScroller } from '@/components/organisms/HorizontalCoverScroller'
 import { SectionBand } from '@/components/organisms/SectionBand'
 import type { LibraryListResponse } from '@/lib/types/library'
 
-async function fetchActiveLibrary(): Promise<LibraryListResponse> {
-  const res = await fetch('/api/library?status=WATCHING&order=updated_at_desc&limit=5', {
-    cache: 'no-store',
-  })
-  if (!res.ok) throw new Error(`library fetch failed: ${res.status}`)
+async function fetchJson(url: string): Promise<LibraryListResponse> {
+  const res = await fetch(url, { cache: 'no-store' })
+  if (!res.ok) throw new Error(`fetch ${url} failed: ${res.status}`)
   return (await res.json()) as LibraryListResponse
 }
 
+const fetchActiveLibrary = () =>
+  fetchJson('/api/library?status=WATCHING&order=updated_at_desc&limit=5')
+const fetchUpNext = () => fetchJson('/api/dashboard/up-next')
+const fetchRecentlyAdded = () =>
+  fetchJson('/api/library?order=created_at_desc&limit=20')
+const fetchRecentlyReleased = () =>
+  fetchJson('/api/library?released_within_days=30&limit=20')
+
 export default function DashboardPage() {
   const { overlay } = useChannelFlipNavigate()
+
   const watchingQuery = useQuery({
     queryKey: ['library', { status: 'WATCHING' }],
     queryFn: fetchActiveLibrary,
   })
+  const upNextQuery = useQuery({
+    queryKey: ['dashboard', 'up-next'],
+    queryFn: fetchUpNext,
+  })
+  const recentlyAddedQuery = useQuery({
+    queryKey: ['dashboard', 'recently-added'],
+    queryFn: fetchRecentlyAdded,
+  })
+  const recentlyReleasedQuery = useQuery({
+    queryKey: ['dashboard', 'recently-released'],
+    queryFn: fetchRecentlyReleased,
+  })
+
   const watchingItems = watchingQuery.data?.items ?? []
+  const upNextItems = upNextQuery.data?.items ?? []
+  const recentlyAddedItems = recentlyAddedQuery.data?.items ?? []
+  const recentlyReleasedItems = recentlyReleasedQuery.data?.items ?? []
 
   return (
     <main className='dash'>
       <CurrentlyActiveCarousel items={watchingItems} />
 
       <SectionBand title='Up Next'>
-        <EmptyStateCard
-          headline='NOTHING IN PROGRESS'
-          subtitle='Start watching, reading, or playing to populate this band.'
+        <HorizontalCoverScroller
+          items={upNextItems}
+          emptyMessage='NOTHING IN PROGRESS'
+          emptySubtitle='Start watching, reading, or playing to populate this band.'
+          ariaLabel='Up Next'
         />
       </SectionBand>
 
       <SectionBand title='Recently Added'>
-        <EmptyStateCard
-          headline='NOTHING ADDED YET'
-          subtitle='Items you add to your library appear here.'
+        <HorizontalCoverScroller
+          items={recentlyAddedItems}
+          emptyMessage='NOTHING ADDED YET'
+          emptySubtitle='Items you add to your library appear here.'
+          ariaLabel='Recently Added'
         />
       </SectionBand>
 
       <SectionBand title='Recently Released'>
-        <EmptyStateCard
-          headline='NO RECENT RELEASES'
-          subtitle='Items in your library released in the last 30 days appear here.'
+        <HorizontalCoverScroller
+          items={recentlyReleasedItems}
+          emptyMessage='NO RECENT RELEASES'
+          emptySubtitle='Items in your library released in the last 30 days appear here.'
+          ariaLabel='Recently Released'
         />
       </SectionBand>
+
+      <DashboardSystemWidget />
 
       {overlay}
     </main>

--- a/components/organisms/DashboardSystemWidget/DashboardSystemWidget.tsx
+++ b/components/organisms/DashboardSystemWidget/DashboardSystemWidget.tsx
@@ -1,0 +1,73 @@
+import { PhosphorBar } from '@/components/atoms/PhosphorBar'
+
+export type Torrent = {
+  id: string
+  name: string
+  progress: number
+}
+
+export type DashboardSystemWidgetProps = {
+  torrents?: Torrent[]
+  throughput?: string | null
+}
+
+/* DashboardSystemWidget (organism, Story 5.4 OI #6).
+ * Visual chrome only — Epic 12 (Story 12.3) wires the real qBittorrent client
+ * subscription into the active-state prop shape. The widget renders:
+ *  - Zero state: `> NO ACTIVE DOWNLOADS` label LEFT + `qBT · IDLE` meta RIGHT.
+ *  - Active state: `> ACTIVE DOWNLOADS · <throughput>` (inline; no separate
+ *    right-side meta) + one row per torrent (italic name + PhosphorBar +
+ *    bitmap percentage). Per AC-2, the throughput lives in the inline label
+ *    for active state — the right-side meta is reserved for the zero-state
+ *    `qBT · IDLE` idle marker.
+ */
+
+function clampProgress(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(100, value))
+}
+
+export function DashboardSystemWidget({
+  torrents,
+  throughput = null,
+}: DashboardSystemWidgetProps) {
+  const isZero = torrents === undefined || torrents.length === 0
+  const hasThroughput = throughput !== null && throughput.length > 0
+  const headerLabel = isZero
+    ? '> NO ACTIVE DOWNLOADS'
+    : hasThroughput
+      ? `> ACTIVE DOWNLOADS · ${throughput}`
+      : '> ACTIVE DOWNLOADS'
+
+  return (
+    <div
+      className={`dsw${isZero ? ' dsw-zero' : ''}`}
+      role='region'
+      aria-label='Now downloading'
+    >
+      <div className='dsw-head'>
+        <span className='dsw-label'>{headerLabel}</span>
+        {isZero ? <span className='dsw-meta'>qBT · IDLE</span> : null}
+      </div>
+
+      {!isZero ? (
+        <div className='dsw-rows'>
+          {torrents!.map((t) => {
+            const safe = clampProgress(t.progress)
+            return (
+              <div key={t.id} className='dsw-row'>
+                <span className='dsw-row-name'>{t.name}</span>
+                <PhosphorBar
+                  value={safe}
+                  max={100}
+                  label={`${t.name} download progress`}
+                />
+                <span className='dsw-row-pct'>{Math.round(safe)}%</span>
+              </div>
+            )
+          })}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/components/organisms/DashboardSystemWidget/__tests__/DashboardSystemWidget.test.tsx
+++ b/components/organisms/DashboardSystemWidget/__tests__/DashboardSystemWidget.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DashboardSystemWidget } from '../DashboardSystemWidget'
+
+describe('DashboardSystemWidget', () => {
+  describe('zero state', () => {
+    it('renders > NO ACTIVE DOWNLOADS label + qBT · IDLE meta when torrents is undefined', () => {
+      render(<DashboardSystemWidget />)
+      expect(screen.getByText('> NO ACTIVE DOWNLOADS')).toBeInTheDocument()
+      expect(screen.getByText('qBT · IDLE')).toBeInTheDocument()
+    })
+
+    it('renders zero state when torrents is empty array', () => {
+      render(<DashboardSystemWidget torrents={[]} />)
+      expect(screen.getByText('> NO ACTIVE DOWNLOADS')).toBeInTheDocument()
+      expect(screen.getByText('qBT · IDLE')).toBeInTheDocument()
+    })
+
+    it('does not render any progress bars in zero state', () => {
+      render(<DashboardSystemWidget torrents={[]} />)
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    })
+
+    it('applies dsw-zero class in zero state', () => {
+      const { container } = render(<DashboardSystemWidget />)
+      const widget = container.querySelector('.dsw')
+      expect(widget).toHaveClass('dsw-zero')
+    })
+  })
+
+  describe('active state', () => {
+    const torrents = [
+      { id: 't1', name: 'fight.club.1999.1080p.mkv', progress: 42.3 },
+      { id: 't2', name: 'memento.2000.bluray.mkv', progress: 87.5 },
+    ]
+
+    it('renders > ACTIVE DOWNLOADS header with throughput', () => {
+      render(<DashboardSystemWidget torrents={torrents} throughput='3.2 MB/s' />)
+      expect(screen.getByText('> ACTIVE DOWNLOADS · 3.2 MB/s')).toBeInTheDocument()
+    })
+
+    it('renders one row per torrent with rounded percentage', () => {
+      render(<DashboardSystemWidget torrents={torrents} throughput='3.2 MB/s' />)
+      expect(screen.getByText('fight.club.1999.1080p.mkv')).toBeInTheDocument()
+      expect(screen.getByText('memento.2000.bluray.mkv')).toBeInTheDocument()
+      expect(screen.getByText('42%')).toBeInTheDocument()
+      expect(screen.getByText('88%')).toBeInTheDocument()
+    })
+
+    it('renders a PhosphorBar progressbar per torrent', () => {
+      render(<DashboardSystemWidget torrents={torrents} throughput='3.2 MB/s' />)
+      const bars = screen.getAllByRole('progressbar')
+      expect(bars).toHaveLength(2)
+      expect(bars[0]).toHaveAttribute('aria-valuenow', '42.3')
+      expect(bars[1]).toHaveAttribute('aria-valuenow', '87.5')
+    })
+
+    it('does not append the · separator when throughput is null', () => {
+      render(<DashboardSystemWidget torrents={torrents} throughput={null} />)
+      expect(screen.getByText('> ACTIVE DOWNLOADS')).toBeInTheDocument()
+      expect(screen.queryByText(/ACTIVE DOWNLOADS ·/)).not.toBeInTheDocument()
+    })
+
+    it('does not append the · separator when throughput is an empty string', () => {
+      render(<DashboardSystemWidget torrents={torrents} throughput='' />)
+      expect(screen.getByText('> ACTIVE DOWNLOADS')).toBeInTheDocument()
+      expect(screen.queryByText(/ACTIVE DOWNLOADS ·/)).not.toBeInTheDocument()
+    })
+
+    it('does NOT render the right-side meta span in active state (AC-2)', () => {
+      const { container } = render(
+        <DashboardSystemWidget torrents={torrents} throughput='3.2 MB/s' />,
+      )
+      expect(container.querySelector('.dsw-meta')).toBeNull()
+    })
+
+    it('omits dsw-zero class in active state', () => {
+      const { container } = render(
+        <DashboardSystemWidget torrents={torrents} throughput='3.2 MB/s' />,
+      )
+      const widget = container.querySelector('.dsw')
+      expect(widget).not.toHaveClass('dsw-zero')
+    })
+
+    it('clamps NaN progress to 0%', () => {
+      render(
+        <DashboardSystemWidget
+          torrents={[{ id: 't1', name: 'bad.mkv', progress: Number.NaN }]}
+          throughput='1 MB/s'
+        />,
+      )
+      expect(screen.getByText('0%')).toBeInTheDocument()
+      const bar = screen.getByRole('progressbar')
+      expect(bar).toHaveAttribute('aria-valuenow', '0')
+    })
+
+    it('clamps negative progress to 0%', () => {
+      render(
+        <DashboardSystemWidget
+          torrents={[{ id: 't1', name: 'bad.mkv', progress: -42 }]}
+          throughput='1 MB/s'
+        />,
+      )
+      expect(screen.getByText('0%')).toBeInTheDocument()
+    })
+
+    it('clamps progress above 100 to 100%', () => {
+      render(
+        <DashboardSystemWidget
+          torrents={[{ id: 't1', name: 'done.mkv', progress: 142 }]}
+          throughput='1 MB/s'
+        />,
+      )
+      expect(screen.getByText('100%')).toBeInTheDocument()
+    })
+  })
+})

--- a/components/organisms/DashboardSystemWidget/index.ts
+++ b/components/organisms/DashboardSystemWidget/index.ts
@@ -1,0 +1,2 @@
+export { DashboardSystemWidget } from './DashboardSystemWidget'
+export type { DashboardSystemWidgetProps, Torrent } from './DashboardSystemWidget'

--- a/components/organisms/HorizontalCoverScroller/HorizontalCoverScroller.tsx
+++ b/components/organisms/HorizontalCoverScroller/HorizontalCoverScroller.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { useCallback, useRef, type KeyboardEvent } from 'react'
+import { MediaType } from '@prisma/client'
+import { EmptyStateCard } from '@/components/molecules/EmptyStateCard'
+import { FramedCover } from '@/components/molecules/FramedCover'
+import type { Medium } from '@/components/molecules/FramedCover/media-registry'
+import { getImageUrl } from '@/lib/api/tmdb-images'
+import type { LibraryItem } from '@/lib/types/library'
+
+export type HorizontalCoverScrollerProps = {
+  items: LibraryItem[]
+  emptyMessage: string
+  emptySubtitle?: string
+  ariaLabel: string
+}
+
+const MEDIA_TYPE_TO_MEDIUM: Record<MediaType, Medium> = {
+  MOVIE: 'movies',
+  TV_SHOW: 'tv',
+  TV_EPISODE: 'tv',
+  ANIME: 'anime',
+  MANGA: 'manga',
+  GAME: 'games',
+}
+
+const MEDIA_TYPE_LABEL: Record<MediaType, string> = {
+  MOVIE: 'MOVIE',
+  TV_SHOW: 'TV',
+  TV_EPISODE: 'TV',
+  ANIME: 'ANIME',
+  MANGA: 'MANGA',
+  GAME: 'GAME',
+}
+
+const POSTER_PLACEHOLDER =
+  'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>'
+
+function metaLine(item: LibraryItem): string {
+  const medium = MEDIA_TYPE_LABEL[item.mediaType]
+  const progress = item.progressLabel
+  if (progress === null) return medium
+  return `${medium} · ${progress}`
+}
+
+export function HorizontalCoverScroller({
+  items,
+  emptyMessage,
+  emptySubtitle,
+  ariaLabel,
+}: HorizontalCoverScrollerProps) {
+  const listRef = useRef<HTMLUListElement | null>(null)
+
+  const focusCardAt = useCallback((idx: number) => {
+    const list = listRef.current
+    if (list === null) return
+    const cards = list.querySelectorAll<HTMLLIElement>('li.hcs-cell')
+    const target = cards.item(idx)
+    if (target === null) return
+    target.focus()
+    // scrollIntoView is missing in jsdom; guard so tests don't crash.
+    target.scrollIntoView?.({ behavior: 'smooth', block: 'nearest', inline: 'nearest' })
+  }, [])
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLUListElement>) => {
+      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
+      const list = listRef.current
+      if (list === null) return
+      const cards = Array.from(list.querySelectorAll<HTMLLIElement>('li.hcs-cell'))
+      const currentIdx = cards.findIndex((c) => c === document.activeElement)
+
+      // Entry case: keyboard nav reached the band from outside via Tab, then
+      // ArrowRight/Left fired on the list (not on a card). Land focus on the
+      // first card instead of advancing past it.
+      if (currentIdx === -1) {
+        event.preventDefault()
+        focusCardAt(0)
+        return
+      }
+
+      const delta = event.key === 'ArrowRight' ? 1 : -1
+      const nextIdx = currentIdx + delta
+      // Boundary: swallow the key so the overflow-x container doesn't scroll
+      // unexpectedly when the user tries to nav past the first/last card.
+      if (nextIdx < 0 || nextIdx >= cards.length) {
+        event.preventDefault()
+        return
+      }
+      event.preventDefault()
+      focusCardAt(nextIdx)
+    },
+    [focusCardAt],
+  )
+
+  if (items.length === 0) {
+    return (
+      <EmptyStateCard
+        variant='band'
+        headline={emptyMessage}
+        subtitle={emptySubtitle}
+      />
+    )
+  }
+
+  return (
+    <div className='hcs-wrap'>
+      <ul
+        ref={listRef}
+        className='hcs'
+        role='list'
+        aria-label={ariaLabel}
+        onKeyDown={onKeyDown}
+      >
+        {items.map((item, i) => {
+          const medium = MEDIA_TYPE_TO_MEDIUM[item.mediaType]
+          const posterUrl = getImageUrl(item.posterPath, 'w342') ?? POSTER_PLACEHOLDER
+          return (
+            <li
+              key={item.id}
+              className='hcs-cell'
+              tabIndex={i === 0 ? 0 : -1}
+            >
+              <div className='hcs-cell-frame'>
+                <FramedCover
+                  medium={medium}
+                  size='scroller'
+                  src={posterUrl}
+                  alt={item.title}
+                />
+              </div>
+              <p className='hcs-cell-title'>{item.title}</p>
+              <p className='hcs-cell-meta'>{metaLine(item)}</p>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/components/organisms/HorizontalCoverScroller/__tests__/HorizontalCoverScroller.test.tsx
+++ b/components/organisms/HorizontalCoverScroller/__tests__/HorizontalCoverScroller.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { MediaType, WatchStatus } from '@prisma/client'
+import { HorizontalCoverScroller } from '../HorizontalCoverScroller'
+import type { LibraryItem } from '@/lib/types/library'
+
+const baseItem = (overrides: Partial<LibraryItem> = {}): LibraryItem => ({
+  id: 'entry-x',
+  mediaItemId: 'media-x',
+  mediaType: MediaType.MOVIE,
+  status: WatchStatus.WATCHING,
+  title: 'Fight Club',
+  posterPath: '/poster.jpg',
+  year: 1999,
+  releaseDate: '1999-10-15T00:00:00.000Z',
+  progressLabel: '42% WATCHED',
+  progressPct: 42,
+  sourceLabel: 'From TMDB',
+  createdAt: '2026-05-10T12:00:00.000Z',
+  updatedAt: '2026-05-12T12:00:00.000Z',
+  ...overrides,
+})
+
+describe('HorizontalCoverScroller', () => {
+  it('renders one cell per item with title + meta', () => {
+    const items: LibraryItem[] = [
+      baseItem({ id: 'a', title: 'Alpha' }),
+      baseItem({ id: 'b', title: 'Bravo', progressLabel: 'WATCHED' }),
+      baseItem({ id: 'c', title: 'Charlie', progressLabel: null }),
+    ]
+    render(
+      <HorizontalCoverScroller
+        items={items}
+        emptyMessage='NOTHING ADDED YET'
+        ariaLabel='Recently Added'
+      />,
+    )
+    const list = screen.getByRole('list')
+    const cells = within(list).getAllByRole('listitem')
+    expect(cells).toHaveLength(3)
+    expect(within(cells[0]).getByText('Alpha')).toBeInTheDocument()
+    expect(within(cells[0]).getByText('MOVIE · 42% WATCHED')).toBeInTheDocument()
+    expect(within(cells[2]).getByText('MOVIE')).toBeInTheDocument()
+  })
+
+  it('attaches the aria-label to the <ul> so screen readers announce it', () => {
+    const items: LibraryItem[] = [baseItem({ id: 'a' })]
+    render(
+      <HorizontalCoverScroller
+        items={items}
+        emptyMessage='X'
+        ariaLabel='Recently Added'
+      />,
+    )
+    const list = screen.getByRole('list', { name: 'Recently Added' })
+    expect(list).toHaveAttribute('aria-label', 'Recently Added')
+  })
+
+  it('renders EmptyStateCard band variant when items is empty', () => {
+    render(
+      <HorizontalCoverScroller
+        items={[]}
+        emptyMessage='NOTHING ADDED YET'
+        emptySubtitle='Items you add appear here.'
+        ariaLabel='Recently Added'
+      />,
+    )
+    expect(screen.queryByRole('list')).not.toBeInTheDocument()
+    expect(screen.getByText(/NOTHING ADDED YET/)).toBeInTheDocument()
+    expect(screen.getByText('Items you add appear here.')).toBeInTheDocument()
+  })
+
+  it('only the first cell is tab-focusable initially (roving tabindex)', () => {
+    const items: LibraryItem[] = [
+      baseItem({ id: 'a' }),
+      baseItem({ id: 'b' }),
+      baseItem({ id: 'c' }),
+    ]
+    render(
+      <HorizontalCoverScroller
+        items={items}
+        emptyMessage='X'
+        ariaLabel='Recently Added'
+      />,
+    )
+    const list = screen.getByRole('list')
+    const cells = within(list).getAllByRole('listitem')
+    expect(cells[0]).toHaveAttribute('tabindex', '0')
+    expect(cells[1]).toHaveAttribute('tabindex', '-1')
+    expect(cells[2]).toHaveAttribute('tabindex', '-1')
+  })
+
+  it('ArrowRight on the first cell moves focus to the second cell', () => {
+    const items: LibraryItem[] = [
+      baseItem({ id: 'a' }),
+      baseItem({ id: 'b' }),
+      baseItem({ id: 'c' }),
+    ]
+    render(
+      <HorizontalCoverScroller
+        items={items}
+        emptyMessage='X'
+        ariaLabel='Recently Added'
+      />,
+    )
+    const list = screen.getByRole('list')
+    const cells = within(list).getAllByRole('listitem')
+    cells[0].focus()
+    expect(cells[0]).toHaveFocus()
+    fireEvent.keyDown(list, { key: 'ArrowRight' })
+    expect(cells[1]).toHaveFocus()
+  })
+
+  it('ArrowLeft on the second cell moves focus back to the first', () => {
+    const items: LibraryItem[] = [
+      baseItem({ id: 'a' }),
+      baseItem({ id: 'b' }),
+    ]
+    render(
+      <HorizontalCoverScroller
+        items={items}
+        emptyMessage='X'
+        ariaLabel='X'
+      />,
+    )
+    const list = screen.getByRole('list')
+    const cells = within(list).getAllByRole('listitem')
+    cells[1].focus()
+    fireEvent.keyDown(list, { key: 'ArrowLeft' })
+    expect(cells[0]).toHaveFocus()
+  })
+
+  it('ArrowRight at last cell does nothing (no wrap)', () => {
+    const items: LibraryItem[] = [baseItem({ id: 'a' }), baseItem({ id: 'b' })]
+    render(
+      <HorizontalCoverScroller
+        items={items}
+        emptyMessage='X'
+        ariaLabel='X'
+      />,
+    )
+    const list = screen.getByRole('list')
+    const cells = within(list).getAllByRole('listitem')
+    cells[1].focus()
+    fireEvent.keyDown(list, { key: 'ArrowRight' })
+    expect(cells[1]).toHaveFocus()
+  })
+
+  it('ArrowRight with focus outside (currentIdx === -1) lands focus on the first cell', () => {
+    const items: LibraryItem[] = [
+      baseItem({ id: 'a' }),
+      baseItem({ id: 'b' }),
+      baseItem({ id: 'c' }),
+    ]
+    render(
+      <HorizontalCoverScroller
+        items={items}
+        emptyMessage='X'
+        ariaLabel='X'
+      />,
+    )
+    const list = screen.getByRole('list')
+    const cells = within(list).getAllByRole('listitem')
+    // Note: nothing is focused yet; fire arrow event directly on the ul.
+    fireEvent.keyDown(list, { key: 'ArrowRight' })
+    expect(cells[0]).toHaveFocus()
+  })
+
+  it('boundary ArrowKey calls preventDefault so the overflow-x container does not scroll', () => {
+    const items: LibraryItem[] = [baseItem({ id: 'a' }), baseItem({ id: 'b' })]
+    render(
+      <HorizontalCoverScroller
+        items={items}
+        emptyMessage='X'
+        ariaLabel='X'
+      />,
+    )
+    const list = screen.getByRole('list')
+    const cells = within(list).getAllByRole('listitem')
+    cells[1].focus()
+    const evt = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true })
+    list.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(true)
+  })
+})

--- a/components/organisms/HorizontalCoverScroller/index.ts
+++ b/components/organisms/HorizontalCoverScroller/index.ts
@@ -1,0 +1,2 @@
+export { HorizontalCoverScroller } from './HorizontalCoverScroller'
+export type { HorizontalCoverScrollerProps } from './HorizontalCoverScroller'


### PR DESCRIPTION
Closes #109.

Story 5.4: implements the three bounded horizontal scrollers (Up Next, Recently Added, Recently Released) and the `DashboardSystemWidget` zero/active chrome on the dashboard.

## What landed

- **`GET /api/dashboard/up-next`** — wraps `withRequest`, returns `{ items: [] }` for Epic 5 (movies have no next-X semantics; TV/anime/manga/games stories grow the SQL). Auth gates via middleware, same posture as `/api/library`.
- **`GET /api/library`** — extends with `released_within_days` query param. Clamps both ends (`gte: floor, lte: now`) so future-dated TMDB releases stay out of the "Recently Released" band per AC-5's past-tense phrasing. Forces `release_date_desc` ordering when this param is set.
- **`HorizontalCoverScroller`** organism — `<ul role='list'>` of `FramedCover size='scroller'` cards with workhorse-serif italic title + small-caps meta. Roving-tabindex ArrowLeft/Right focus nav with `event.preventDefault()` at both ends (boundary + entry-from-outside cases). Inline `EmptyStateCard variant='band'` empty state. `scrollIntoView` jsdom-guarded.
- **`DashboardSystemWidget`** organism — zero state `> NO ACTIVE DOWNLOADS` + `qBT · IDLE` meta; active state `> ACTIVE DOWNLOADS · {throughput}` inline + one `PhosphorBar` row per torrent. Progress values clamped (NaN → 0, <0 → 0, >100 → 100). Epic 12 wires real qBittorrent data.
- **`app/page.tsx`** — four TanStack queries (`['library', { status: 'WATCHING' }]`, `['dashboard', 'up-next' \| 'recently-added' \| 'recently-released']`) inherit `staleTime: 60_000` from `app/providers.tsx`. Each `SectionBand` body slot wraps a `<HorizontalCoverScroller>`. `<DashboardSystemWidget />` appended as the last child of `<main>`.
- **`docs/component-inventory.md`** — `FramedCover` row lists the full size matrix (`thumb / card / hero-cover / scroller / hero`); `HorizontalCoverScroller` + `DashboardSystemWidget` rows updated to reflect the shipped shape.

## Static gates

- `pnpm typecheck` clean.
- `pnpm lint` clean.
- `pnpm vitest run components/organisms/HorizontalCoverScroller components/organisms/DashboardSystemWidget app/api/library app/api/dashboard` — 40/40 pass.
- `pnpm build` clean; `/` is 5.45 kB / 252 kB First Load JS.

## Test plan

1. Sign in, hit `/`. Confirm: rotator empty-state visible (no WATCHING items); three scroller bands all render the `EmptyStateCard variant='band'` copy from Story 5.1; Now Downloading at zero state reads `> NO ACTIVE DOWNLOADS · qBT · IDLE`.
2. Add a movie via `/search`. Confirm: `Recently Added` band populates with the new movie (no full-page reload; TanStack invalidation fires).
3. Manually flip a `UserEntry`'s `release_date` to within the last 30 days via `psql`. Refresh; confirm `Recently Released` populates.
4. Keyboard nav: Tab to a scroller card; ArrowRight moves focus between cards with a visible 2px neon-blue ring; boundary key press at last card does NOT scroll the band.
5. Screen reader (VoiceOver / NVDA) announces the band name (`Up Next` / `Recently Added` / `Recently Released`) when the list receives focus.
6. Resize to ~390px (mobile). Bands stack vertically; horizontal scroll within each band preserved; Now Downloading full-width.

## Out-of-scope (tracked)

- **AC-8: GlobalSearch `inLibrary` flip** — per OI #3 ratification, ships as its own follow-up PR off `main` after this merges. Tracked in `_bmad-output/implementation-artifacts/deferred-work.md`.
- **AC-10: Playwright e2e** — deferred per OI #7 (gated on the Story 6.x seed-data helper). Tracked in `deferred-work.md`.