### PR TITLE
feat(dashboard): wire first-load boot sequence with localStorage gate (#113)

### DIFF
--- a/app/__tests__/page.test.tsx
+++ b/app/__tests__/page.test.tsx
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { dashClassFor } from '@/app/page-boot-gate'
+
+// `next/navigation` is consumed by useChannelFlipNavigate inside the page.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => '/',
+}))
+
+const reducedMotionRef = { value: false }
+vi.mock('@/lib/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => reducedMotionRef.value,
+  readInitialReducedMotion: () => reducedMotionRef.value,
+}))
+
+const localStorageBacking: Record<string, string> = {}
+const localStorageMock = {
+  getItem: vi.fn((key: string) => localStorageBacking[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    localStorageBacking[key] = value
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete localStorageBacking[key]
+  }),
+  clear: vi.fn(() => {
+    for (const k of Object.keys(localStorageBacking)) delete localStorageBacking[k]
+  }),
+}
+
+function setupLocalStorage(): void {
+  Object.defineProperty(window, 'localStorage', {
+    value: localStorageMock,
+    writable: true,
+    configurable: true,
+  })
+}
+
+function fetchEmpty() {
+  return new Response(JSON.stringify({ items: [] }), { status: 200 })
+}
+
+beforeEach(() => {
+  localStorageMock.getItem.mockClear()
+  localStorageMock.setItem.mockClear()
+  localStorageMock.removeItem.mockClear()
+  for (const k of Object.keys(localStorageBacking)) delete localStorageBacking[k]
+  setupLocalStorage()
+  reducedMotionRef.value = false
+  vi.stubGlobal('fetch', vi.fn(async () => fetchEmpty()))
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+async function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  })
+  const { default: DashboardPage } = await import('@/app/page')
+  return render(
+    <QueryClientProvider client={client}>
+      <DashboardPage />
+    </QueryClientProvider>,
+  )
+}
+
+describe('app/page.tsx — first-load boot gate (Story 5.5)', () => {
+  // AC-7 bullet 1: 'unknown' state renders `dash-invisible`. RTL flushes
+  // useEffect synchronously so the pre-effect render is not directly
+  // observable from a render() result. The pure `dashClassFor` helper covers
+  // the className mapping for all three phases including 'unknown'.
+  it('dashClassFor returns dash + dash-invisible for unknown phase', () => {
+    expect(dashClassFor('unknown')).toBe('dash dash-invisible')
+  })
+
+  it('dashClassFor returns dash + dash-ghost for playing phase', () => {
+    expect(dashClassFor('playing')).toBe('dash dash-ghost')
+  })
+
+  it('dashClassFor returns bare dash for skipped phase', () => {
+    expect(dashClassFor('skipped')).toBe('dash')
+  })
+
+  it('post-mount: page resolves to a valid post-effect boot phase', async () => {
+    const { container } = await renderPage()
+    const main = container.querySelector('main')
+    expect(main).not.toBeNull()
+    await waitFor(() => {
+      expect(main!.getAttribute('data-boot-phase')).not.toBe('unknown')
+    })
+  })
+
+  it('plays the boot overlay when localStorage is missing and motion is normal', async () => {
+    const { container } = await renderPage()
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('System boot sequence'),
+      ).toBeInTheDocument()
+    })
+    const main = container.querySelector('main')
+    expect(main).toHaveAttribute('data-boot-phase', 'playing')
+    expect(main!.className).toContain('dash-ghost')
+  })
+
+  it('skips the boot when localStorage.boot.played is fresh (<24h)', async () => {
+    localStorageBacking['boot.played'] = String(Date.now() - 60_000)
+    const { container } = await renderPage()
+    await waitFor(() => {
+      expect(container.querySelector('main')).toHaveAttribute(
+        'data-boot-phase',
+        'skipped',
+      )
+    })
+    expect(screen.queryByLabelText('System boot sequence')).not.toBeInTheDocument()
+    const main = container.querySelector('main')
+    expect(main!.className).not.toContain('dash-ghost')
+    expect(main!.className).not.toContain('dash-invisible')
+  })
+
+  it('treats stale localStorage (>24h) as missing and plays the boot', async () => {
+    localStorageBacking['boot.played'] = String(Date.now() - 25 * 60 * 60 * 1000)
+    await renderPage()
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('System boot sequence'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('treats unparseable localStorage value as missing and plays the boot', async () => {
+    localStorageBacking['boot.played'] = 'not-a-number'
+    await renderPage()
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('System boot sequence'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('rejects trailing-garbage stamps like "1234abc" and plays the boot', async () => {
+    localStorageBacking['boot.played'] = `${Date.now()}abc`
+    await renderPage()
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('System boot sequence'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('rejects negative-numeric stamps like "-100" and plays the boot', async () => {
+    localStorageBacking['boot.played'] = '-100'
+    await renderPage()
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('System boot sequence'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('rejects future-dated stamps (ts > now) and plays the boot', async () => {
+    localStorageBacking['boot.played'] = String(Date.now() + 60 * 60 * 1000)
+    await renderPage()
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('System boot sequence'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('bypasses the boot under reduced-motion and still commits boot.played', async () => {
+    reducedMotionRef.value = true
+    const { container } = await renderPage()
+    await waitFor(() => {
+      expect(container.querySelector('main')).toHaveAttribute(
+        'data-boot-phase',
+        'skipped',
+      )
+    })
+    expect(screen.queryByLabelText('System boot sequence')).not.toBeInTheDocument()
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'boot.played',
+      expect.any(String),
+    )
+  })
+
+  it('commits boot.played + transitions to skipped on BootSequence onComplete', async () => {
+    const { container } = await renderPage()
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('System boot sequence'),
+      ).toBeInTheDocument()
+    })
+
+    // Simulate the boot finishing by pressing a key (BootSequence's keypress-
+    // to-skip handler fires onComplete). Wrap in act so React flushes the
+    // state transition before the assertion.
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('main')).toHaveAttribute(
+        'data-boot-phase',
+        'skipped',
+      )
+    })
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'boot.played',
+      expect.any(String),
+    )
+  })
+
+  it('survives a throwing localStorage (Safari Private Browsing posture)', async () => {
+    localStorageMock.getItem.mockImplementation(() => {
+      throw new Error('storage disabled')
+    })
+    localStorageMock.setItem.mockImplementation(() => {
+      throw new Error('storage disabled')
+    })
+    await renderPage()
+    // Should still resolve to a valid phase ('playing' because getItem throws → null branch).
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('System boot sequence'),
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/app/global.css
+++ b/app/global.css
@@ -1382,6 +1382,34 @@ body {
   color: var(--phosphor-cream);
 }
 
+/* Story 5.5 first-load gate. `.dash-invisible` covers the SSR / pre-useEffect
+   window so the dashboard mounts (queries fire) but doesn't paint before the
+   boot phase resolves. `.dash-ghost` mirrors the bundle's "10% ghost beneath"
+   reveal during boot. Reduced-motion users skip both states entirely. */
+.dash-invisible {
+  visibility: hidden;
+}
+
+.dash-ghost {
+  opacity: 0.10;
+  filter: blur(1px);
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dash-ghost { filter: none; }
+}
+
+/* Fixed-position overlay wrapper for the BootSequence on first-load. z-index 40
+   covers MainNav + dashboard chrome per the bundle's `.boot-overlay-full`. The
+   BootSequence molecule (Story 2.7) renders inside. */
+.dash-boot-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: var(--ground-base);
+}
+
 .dash-hero {
   display: flex;
   align-items: center;

--- a/app/page-boot-gate.ts
+++ b/app/page-boot-gate.ts
@@ -1,0 +1,68 @@
+/* Story 5.5 first-load boot gate helpers, extracted from `app/page.tsx`
+ * because Next.js app routes only allow specific named exports
+ * (`default`, `metadata`, `dynamic`, etc.) and arbitrary helpers trigger a
+ * `.next/types/app/page.ts` typecheck error.
+ *
+ * The dashboard page imports these directly. Tests target them in isolation.
+ */
+
+export type BootPhase = 'unknown' | 'playing' | 'skipped'
+
+export const BOOT_LOCAL_STORAGE_KEY = 'boot.played'
+export const BOOT_GATE_TTL_MS = 24 * 60 * 60 * 1000
+export const BOOT_TOTAL_DURATION_MS = 1000
+
+// Strict integer pattern: parseInt would happily accept '1234abc' or '-100'
+// (the EH/AA review caught these). Anchor to digits-only so tampered or
+// corrupted stamps replay the boot instead of skipping it forever.
+const STAMP_PATTERN = /^\d+$/
+
+export function safeRead(): string | null {
+  try {
+    return window.localStorage.getItem(BOOT_LOCAL_STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+export function safeCommit(): void {
+  try {
+    window.localStorage.setItem(BOOT_LOCAL_STORAGE_KEY, Date.now().toString())
+  } catch {
+    // Safari Private Browsing / disabled storage: silently skip. The user
+    // still got their reveal; they'll re-play the boot on next visit.
+  }
+}
+
+export function resolveBootPhase(reduced: boolean): BootPhase {
+  if (typeof window === 'undefined') return 'unknown'
+
+  // Reduced-motion: commit + skip regardless of stored state. The commit
+  // avoids an unwanted boot if the user toggles reduced-motion off later.
+  if (reduced) {
+    safeCommit()
+    return 'skipped'
+  }
+
+  const stamp = safeRead()
+  if (stamp !== null && STAMP_PATTERN.test(stamp)) {
+    const ts = Number(stamp)
+    const now = Date.now()
+    // Clamp upper bound at `now` so a future-dated stamp (clock skew or
+    // tampered write) can't keep the boot skipped indefinitely. Without this
+    // a stamp set to `now + 1 year` would satisfy `now - ts < TTL` for a year.
+    if (Number.isFinite(ts) && ts <= now && now - ts < BOOT_GATE_TTL_MS) {
+      return 'skipped'
+    }
+  }
+  return 'playing'
+}
+
+// Pure className mapping for the dashboard `<main>`. Tested in isolation to
+// cover AC-7 bullet 1 ('unknown' renders dash-invisible) without trying to
+// observe the pre-useEffect React render through RTL.
+export function dashClassFor(phase: BootPhase): string {
+  if (phase === 'unknown') return 'dash dash-invisible'
+  if (phase === 'playing') return 'dash dash-ghost'
+  return 'dash'
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,22 @@
 'use client'
 
+import { useCallback, useEffect, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { BootSequence } from '@/components/molecules/BootSequence'
 import { useChannelFlipNavigate } from '@/components/molecules/ChannelFlipTransition'
 import { CurrentlyActiveCarousel } from '@/components/organisms/CurrentlyActiveCarousel'
 import { DashboardSystemWidget } from '@/components/organisms/DashboardSystemWidget'
 import { HorizontalCoverScroller } from '@/components/organisms/HorizontalCoverScroller'
 import { SectionBand } from '@/components/organisms/SectionBand'
+import { useReducedMotion } from '@/lib/hooks/useReducedMotion'
 import type { LibraryListResponse } from '@/lib/types/library'
+import {
+  BOOT_TOTAL_DURATION_MS,
+  type BootPhase,
+  dashClassFor,
+  resolveBootPhase,
+  safeCommit,
+} from './page-boot-gate'
 
 async function fetchJson(url: string): Promise<LibraryListResponse> {
   const res = await fetch(url, { cache: 'no-store' })
@@ -24,7 +34,21 @@ const fetchRecentlyReleased = () =>
 
 export default function DashboardPage() {
   const { overlay } = useChannelFlipNavigate()
+  const reduced = useReducedMotion()
+  const [bootPhase, setBootPhase] = useState<BootPhase>('unknown')
 
+  useEffect(() => {
+    setBootPhase(resolveBootPhase(reduced))
+  }, [reduced])
+
+  const onBootComplete = useCallback(() => {
+    safeCommit()
+    setBootPhase('skipped')
+  }, [])
+
+  // Dashboard subscriptions: fire on mount regardless of bootPhase so data
+  // resolves in parallel with the ~1s boot animation per AC-4. The default
+  // staleTime: 60_000 in app/providers.tsx prevents re-fetches on tab focus.
   const watchingQuery = useQuery({
     queryKey: ['library', { status: 'WATCHING' }],
     queryFn: fetchActiveLibrary,
@@ -47,40 +71,61 @@ export default function DashboardPage() {
   const recentlyAddedItems = recentlyAddedQuery.data?.items ?? []
   const recentlyReleasedItems = recentlyReleasedQuery.data?.items ?? []
 
+  // SSR returns 'unknown'; the dashboard is mounted (queries fire) but invisible
+  // until useEffect resolves. 'playing' adds the dash-ghost dim+blur per the
+  // bundle. 'skipped' reveals full opacity.
+  const dashClassName = dashClassFor(bootPhase)
+
   return (
-    <main className='dash'>
-      <CurrentlyActiveCarousel items={watchingItems} />
+    <>
+      <main
+        className={dashClassName}
+        data-boot-phase={bootPhase}
+        aria-hidden={bootPhase === 'playing' || bootPhase === 'unknown'}
+      >
+        <CurrentlyActiveCarousel items={watchingItems} />
 
-      <SectionBand title='Up Next'>
-        <HorizontalCoverScroller
-          items={upNextItems}
-          emptyMessage='NOTHING IN PROGRESS'
-          emptySubtitle='Start watching, reading, or playing to populate this band.'
-          ariaLabel='Up Next'
-        />
-      </SectionBand>
+        <SectionBand title='Up Next'>
+          <HorizontalCoverScroller
+            items={upNextItems}
+            emptyMessage='NOTHING IN PROGRESS'
+            emptySubtitle='Start watching, reading, or playing to populate this band.'
+            ariaLabel='Up Next'
+          />
+        </SectionBand>
 
-      <SectionBand title='Recently Added'>
-        <HorizontalCoverScroller
-          items={recentlyAddedItems}
-          emptyMessage='NOTHING ADDED YET'
-          emptySubtitle='Items you add to your library appear here.'
-          ariaLabel='Recently Added'
-        />
-      </SectionBand>
+        <SectionBand title='Recently Added'>
+          <HorizontalCoverScroller
+            items={recentlyAddedItems}
+            emptyMessage='NOTHING ADDED YET'
+            emptySubtitle='Items you add to your library appear here.'
+            ariaLabel='Recently Added'
+          />
+        </SectionBand>
 
-      <SectionBand title='Recently Released'>
-        <HorizontalCoverScroller
-          items={recentlyReleasedItems}
-          emptyMessage='NO RECENT RELEASES'
-          emptySubtitle='Items in your library released in the last 30 days appear here.'
-          ariaLabel='Recently Released'
-        />
-      </SectionBand>
+        <SectionBand title='Recently Released'>
+          <HorizontalCoverScroller
+            items={recentlyReleasedItems}
+            emptyMessage='NO RECENT RELEASES'
+            emptySubtitle='Items in your library released in the last 30 days appear here.'
+            ariaLabel='Recently Released'
+          />
+        </SectionBand>
 
-      <DashboardSystemWidget />
+        <DashboardSystemWidget />
 
-      {overlay}
-    </main>
+        {overlay}
+      </main>
+
+      {bootPhase === 'playing' ? (
+        <div className='dash-boot-overlay' role='presentation'>
+          <BootSequence
+            onComplete={onBootComplete}
+            totalDuration={BOOT_TOTAL_DURATION_MS}
+            showWelcome
+          />
+        </div>
+      ) : null}
+    </>
   )
 }

--- a/e2e/dashboard-boot.spec.ts
+++ b/e2e/dashboard-boot.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test'
+
+const ADMIN_EMAIL = 'admin@tracker.local'
+const ADMIN_PASS = process.env.ADMIN_PASS
+
+test.beforeAll(async ({ browser }) => {
+  if (!ADMIN_PASS) {
+    throw new Error(
+      'ADMIN_PASS env is required for e2e tests. Set it in .env (local) or the CI env block.',
+    )
+  }
+  // Mirror login.spec.ts: warm up `/login` + `/` so dev-mode turbopack compile
+  // latency doesn't poison the timing-sensitive assertions below.
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+  await page.goto('/login', { waitUntil: 'domcontentloaded' })
+  await page.goto('/', { waitUntil: 'domcontentloaded' }).catch(() => undefined)
+  await ctx.close()
+})
+
+async function signIn(page: import('@playwright/test').Page): Promise<void> {
+  await page.goto('/login')
+  const email = page.getByLabel('EMAIL')
+  const password = page.getByLabel('PASSWORD')
+  await expect(email).toHaveValue(ADMIN_EMAIL)
+  await password.fill(ADMIN_PASS!)
+  await page.getByRole('button', { name: '> LOG IN' }).click()
+  await page.waitForURL('/', { timeout: 10_000 })
+}
+
+test.describe('Dashboard first-load boot gate (Story 5.5)', () => {
+  test('AC-1+AC-2: first load plays boot; reload skips it', async ({ page, context }) => {
+    await context.clearCookies()
+    await signIn(page)
+    // Belt-and-braces: clear localStorage AFTER landing on / so the page-side
+    // gate sees a missing flag on first paint. (signIn already navigates to /
+    // and may have committed the flag in that first paint; clearing now resets.)
+    await page.evaluate(() => window.localStorage.removeItem('boot.played'))
+    await page.reload()
+
+    // First-load: overlay must appear and then dismiss within the boot duration.
+    const overlay = page.locator('[aria-label="System boot sequence"]')
+    await expect(overlay).toBeVisible({ timeout: 3_000 })
+    await expect(overlay).toBeHidden({ timeout: 5_000 })
+
+    // After the boot dismisses, localStorage carries a recent timestamp.
+    const stamp = await page.evaluate(() => window.localStorage.getItem('boot.played'))
+    expect(stamp).not.toBeNull()
+    expect(Number.isFinite(Number(stamp))).toBe(true)
+
+    // Reload: overlay must NOT appear within the same 1s window.
+    await page.reload()
+    await expect(overlay).toHaveCount(0, { timeout: 1_000 })
+  })
+
+  test('AC-3: reduced-motion bypasses the boot and still commits boot.played', async ({
+    page,
+    context,
+  }) => {
+    await context.clearCookies()
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await signIn(page)
+    await page.evaluate(() => window.localStorage.removeItem('boot.played'))
+    await page.reload()
+
+    const overlay = page.locator('[aria-label="System boot sequence"]')
+    await expect(overlay).toHaveCount(0, { timeout: 1_000 })
+
+    const stamp = await page.evaluate(() => window.localStorage.getItem('boot.played'))
+    expect(stamp).not.toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #113.

Last story in Epic 5: gates the BootSequence (Story 2.7) overlay on a `localStorage.getItem('boot.played')` timestamp. First dashboard visit per 24h plays the bitmap boot animation over a 10%-opacity-ghost dashboard; subsequent reloads skip straight to the dashboard; reduced-motion bypasses the overlay but still commits the flag so a later non-reduced session doesn't get an unwanted boot.

## What landed

- **`app/page-boot-gate.ts`** (NEW): pure helpers — `safeRead` / `safeCommit` (Safari Private Browsing posture), `resolveBootPhase(reduced)` with strict `/^\d+$/` stamp parsing + `ts <= now` clamp (rejects future-dated tampering) + 24h TTL, `dashClassFor(phase)` for the `<main>` className. Extracted from `app/page.tsx` because Next.js App Router page modules can't carry arbitrary named exports.
- **`app/page.tsx`**: 3-state machine `'unknown' | 'playing' | 'skipped'`. SSR initial state is `'unknown'` with `<main className='dash dash-invisible'>` (mounted but invisible — queries fire on mount per AC-4 parallel I/O). `useEffect` resolves the phase from localStorage + `useReducedMotion()`. `onBootComplete` commits + transitions to `'skipped'`.
- **`app/global.css`**: appends `.dash-invisible` (visibility: hidden), `.dash-ghost` (opacity 0.10 + 1px blur per the bundle's `.dash-ghost` rule), `.dash-boot-overlay` (position fixed; inset 0; z-index 40 — covers MainNav too), and `@media (prefers-reduced-motion: reduce) { .dash-ghost { filter: none } }`.
- **`app/__tests__/page.test.tsx`** (NEW, 11 tests): `dashClassFor` branches, gate state-machine cases (missing/fresh/stale/unparseable/trailing-garbage/negative/future stamps), reduced-motion bypass + commit, onComplete commit + transition, throwing-localStorage Safari Private Browsing posture.
- **`e2e/dashboard-boot.spec.ts`** (NEW, 2 tests): first-load plays + reload skips with stamp verification; reduced-motion bypass + commit.

## Code-review patches (Edge Case Hunter + Acceptance Auditor)

- Stamp parser tightened: `/^\d+$/` + `ts <= now` clamp. Rejects future-dated, negative, and trailing-garbage stamps (`'1234abc'` → boot replays as if missing).
- Extracted `dashClassFor` to `app/page-boot-gate.ts` so AC-7 bullet 1 ('unknown' state renders dash-invisible) can be asserted directly (Next.js page modules block arbitrary named exports — see `reference_nextjs_page_named_exports_blocked` memory).
- Skipped Blind Hunter per Epic 2/3/4/5 precedent.

## Static gates

- `pnpm typecheck` clean.
- `pnpm lint` clean.
- `pnpm vitest run app components/molecules/BootSequence` — 124/124 pass.
- `pnpm build` clean; `/` route at 3.94 kB / 254 kB First Load JS.

## Test plan

Verified manually (LGTM from Cuatro 2026-05-14):

1. First-load: clear `boot.played`, reload `/` — boot overlay paints over dashboard ghost (10% opacity + 1px blur), dismisses after ~1s.
2. Localstorage commit: `boot.played` holds a Date.now() ms string after dismiss.
3. Cached gate: reload — no overlay; dashboard reveals immediately.
4. Stale gate (>24h): rewrite stamp to `Date.now() - 25h`, reload — overlay plays again.
5. Future-stamp rejection: rewrite stamp to `Date.now() + 1h`, reload — overlay plays (future stamp treated as missing).
6. Reduced-motion bypass: DevTools → Rendering → `prefers-reduced-motion: reduce`, clear localStorage, reload — no overlay; `boot.played` is committed anyway.
7. Keypress skip: mid-boot, press any key — overlay dismisses, stamp committed.

Playwright `e2e/dashboard-boot.spec.ts` codifies AC-1+AC-2 (first-load → reload) and AC-3 (reduced-motion bypass) for CI.

## Closes Epic 5

This is the final story. Epic 5 retrospective ships as a separate doc-only deliverable.