### PR TITLE
feat(epic-6 part 1): TMDB adapter + /movies grid (#115, #118)

### DIFF
--- a/app/(media)/movies/page.tsx
+++ b/app/(media)/movies/page.tsx
@@ -1,0 +1,120 @@
+import { MediaType, WatchStatus } from '@prisma/client'
+import { findLibraryItems, type LibrarySortKey } from '@/lib/db/library'
+import { LibraryGrid } from '@/components/organisms/LibraryGrid'
+import type { LibraryItem } from '@/lib/types/library'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata = {
+  title: 'MOVIES · Cuatro Tracker',
+}
+
+const VALID_SORTS: ReadonlyArray<LibrarySortKey> = [
+  'recently_added',
+  'recently_created',
+  'release_date_desc',
+  'title_asc',
+  'status_asc',
+  'rating_desc',
+]
+
+type SearchParams = Promise<{
+  sort?: string
+  status?: string
+  search?: string
+}>
+
+function parseSort(raw: string | undefined): LibrarySortKey {
+  if (raw && (VALID_SORTS as readonly string[]).includes(raw)) {
+    return raw as LibrarySortKey
+  }
+  return 'recently_added'
+}
+
+function parseStatus(raw: string | undefined): WatchStatus | null {
+  if (!raw) return null
+  if ((Object.values(WatchStatus) as string[]).includes(raw)) {
+    return raw as WatchStatus
+  }
+  return null
+}
+
+function deriveYear(releaseDate: Date): number | null {
+  const year = releaseDate.getUTCFullYear()
+  return year === 1970 ? null : year
+}
+
+export default async function MoviesPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const params = await searchParams
+  const sort = parseSort(params.sort)
+  const status = parseStatus(params.status)
+  // Cap at 100 chars to match the LibraryQuerySchema upper bound, otherwise
+  // the client-side TanStack Query refetch would reject with 400 and flash
+  // the error state immediately after the SSR-rendered grid hydrates.
+  const search = (params.search?.trim() ?? '').slice(0, 100)
+
+  const entries = await findLibraryItems({
+    mediaType: MediaType.MOVIE,
+    status: status ?? undefined,
+    search: search.length > 0 ? search : undefined,
+    sort,
+    limit: 200,
+  })
+
+  const initialItems: LibraryItem[] = entries.map((entry) => ({
+    id: entry.id,
+    mediaItemId: entry.media_item_id,
+    mediaType: entry.media_item.type,
+    status: entry.status,
+    title: entry.media_item.title,
+    posterPath: entry.media_item.poster_path,
+    year: deriveYear(entry.media_item.release_date),
+    releaseDate:
+      entry.media_item.release_date.getUTCFullYear() === 1970
+        ? null
+        : entry.media_item.release_date.toISOString(),
+    progressLabel: null,
+    progressPct: null,
+    sourceLabel: null,
+    tmdbId: entry.media_item.tmdb_id,
+    anilistId: entry.media_item.anilist_id,
+    igdbId: entry.media_item.igdb_id,
+    steamId: entry.media_item.steam_id,
+    createdAt: entry.created_at.toISOString(),
+    updatedAt: entry.updated_at.toISOString(),
+  }))
+
+  return (
+    <main className='movies-page'>
+      <header className='movies-page-heading'>
+        <h1 className='movies-page-title'>
+          <span className='movies-page-blocks'>
+            <span className='movies-page-block b1'>▓</span>
+            <span className='movies-page-block b2'>▓</span>
+            <span className='movies-page-block b3'>▓</span>
+          </span>
+          <span className='movies-page-noun'>MOVIES</span>
+          <span className='movies-page-blocks'>
+            <span className='movies-page-block b4'>▓</span>
+            <span className='movies-page-block b5'>▓</span>
+            <span className='movies-page-block b6'>▓</span>
+          </span>
+        </h1>
+        <p className='movies-page-subtitle'>
+          {initialItems.length} ITEMS
+        </p>
+      </header>
+      <LibraryGrid
+        mediaType='movies'
+        initialItems={initialItems}
+        initialSort={sort}
+        initialStatus={status}
+        initialSearch={search}
+      />
+    </main>
+  )
+}

--- a/app/api/library/__tests__/route.test.ts
+++ b/app/api/library/__tests__/route.test.ts
@@ -106,9 +106,11 @@ describe('GET /api/library', () => {
     expect(res.status).toBe(400)
   })
 
-  it('caps limit at 100 (rejects beyond)', async () => {
+  it('caps limit at 200 (rejects beyond)', async () => {
+    // Story 6.3 raised the cap from 100 → 200 so the movies grid can request
+    // a user's full library in one shot. 201 still rejects.
     const { GET } = await import('@/app/api/library/route')
-    const res = await GET(makeRequest('/api/library?limit=200'))
+    const res = await GET(makeRequest('/api/library?limit=201'))
     expect(res.status).toBe(400)
   })
 

--- a/app/api/library/route.ts
+++ b/app/api/library/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { z } from 'zod'
-import { type MediaItem, MediaType, type Prisma, type UserEntry, WatchStatus } from '@prisma/client'
-import { db } from '@/lib/db'
+import { type MediaItem, MediaType, WatchStatus } from '@prisma/client'
+import { findLibraryItems, type LibrarySortKey, type UserEntryWithMedia } from '@/lib/db/library'
 import { logger } from '@/lib/logger'
 import { withRequest } from '@/lib/request-context'
 import type { LibraryItem, LibraryListResponse } from '@/lib/types/library'
@@ -19,17 +19,41 @@ export const dynamic = 'force-dynamic'
  * unscoped (one user; no userId column on UserEntry).
  */
 
+// Schema accepts the public param names callers pass on the wire.
+// `order` is the legacy 5.3/5.4 param (kept for backward compat with dashboard
+// callers); `sort` is the 6.3 param using the LibrarySortKey union. When both
+// are absent the default is `recently_added`. When both are present, `sort`
+// wins so 6.3+ callers do not need to know about the legacy enum.
 const LibraryQuerySchema = z.object({
+  type: z.nativeEnum(MediaType).optional(),
   status: z.nativeEnum(WatchStatus).optional(),
+  search: z.string().min(1).max(100).optional(),
   order: z
     .enum(['updated_at_desc', 'created_at_desc', 'release_date_desc'])
-    .optional()
-    .default('updated_at_desc'),
-  limit: z.coerce.number().int().positive().max(100).optional().default(20),
+    .optional(),
+  sort: z
+    .enum([
+      'recently_added',
+      'recently_created',
+      'release_date_desc',
+      'title_asc',
+      'status_asc',
+      'rating_desc',
+    ])
+    .optional(),
+  limit: z.coerce.number().int().positive().max(200).optional().default(20),
   released_within_days: z.coerce.number().int().positive().max(3650).optional(),
 })
 
-type UserEntryWithMedia = UserEntry & { media_item: MediaItem }
+function resolveSort(
+  sort: LibrarySortKey | undefined,
+  order: 'updated_at_desc' | 'created_at_desc' | 'release_date_desc' | undefined,
+): LibrarySortKey {
+  if (sort) return sort
+  if (order === 'created_at_desc') return 'recently_created'
+  if (order === 'release_date_desc') return 'release_date_desc'
+  return 'recently_added'
+}
 
 function deriveYear(mediaItem: MediaItem): number | null {
   // 1970 is the normaliser's sentinel for "release date unknown" per
@@ -119,39 +143,15 @@ async function handler(req: NextRequest): Promise<NextResponse> {
     )
   }
 
-  const { status, order, limit, released_within_days } = parsed.data
+  const { type, status, search, order, sort, limit, released_within_days } = parsed.data
 
-  // `released_within_days` filters by joined MediaItem.release_date and forces
-  // ordering by release_date DESC regardless of the `order` param. This matches
-  // the dashboard's "Recently Released" band semantics (Story 5.4 AC-5).
-  const effectiveOrder = released_within_days !== undefined ? 'release_date_desc' : order
-
-  const where: Prisma.UserEntryWhereInput = {}
-  if (status) where.status = status
-  if (released_within_days !== undefined) {
-    // AC-5 reads "released in the last 30 days" — past-tense. The lower bound
-    // (gte: floor) drops anything older than the window; the upper bound
-    // (lte: now) drops future-dated releases (TMDB returns unreleased movies
-    // with future release_date, and they should NOT surface as "recently
-    // released"). 1970 sentinel rows for "unknown release date" are naturally
-    // excluded by the floor (UNIX epoch < NOW - any positive N days).
-    const now = new Date()
-    const floor = new Date(now.getTime() - released_within_days * 24 * 60 * 60 * 1000)
-    where.media_item = { release_date: { gte: floor, lte: now } }
-  }
-
-  const orderBy =
-    effectiveOrder === 'release_date_desc'
-      ? { media_item: { release_date: 'desc' as const } }
-      : effectiveOrder === 'created_at_desc'
-        ? { created_at: 'desc' as const }
-        : { updated_at: 'desc' as const }
-
-  const entries = await db.userEntry.findMany({
-    where: Object.keys(where).length > 0 ? where : undefined,
-    include: { media_item: true },
-    orderBy,
-    take: limit,
+  const entries = await findLibraryItems({
+    mediaType: type,
+    status,
+    search,
+    sort: resolveSort(sort, order),
+    limit,
+    releasedWithinDays: released_within_days,
   })
 
   const items = entries.map(serializeLibraryItem)

--- a/app/global.css
+++ b/app/global.css
@@ -1829,3 +1829,549 @@ body {
   letter-spacing: 0.04em;
   font-variant-numeric: tabular-nums;
 }
+
+/* =============================================================================
+ * Story 6.3 — Library grid (/movies and per-medium counterparts in E7-E9).
+ * ============================================================================= */
+
+:root {
+  --status-color-plan_to_watch: var(--led-backlog);
+  --status-color-watching: var(--led-in-progress);
+  --status-color-completed: var(--led-completed);
+  --status-color-on_hold: var(--led-on-hold);
+  --status-color-dropped: var(--led-dropped);
+  --status-glow-plan_to_watch: var(--led-backlog-glow);
+  --status-glow-watching: var(--led-in-progress-glow);
+  --status-glow-completed: var(--led-completed-glow);
+  --status-glow-on_hold: var(--led-on-hold-glow);
+  --status-glow-dropped: var(--led-dropped-glow);
+}
+
+.movies-page {
+  display: block;
+  padding: 32px 48px 64px;
+}
+
+.movies-page-heading {
+  padding: 16px 0 24px;
+}
+
+.movies-page-title {
+  font-family: var(--font-bitmap);
+  font-size: 26px;
+  letter-spacing: 0.06em;
+  color: var(--phosphor-cream);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+}
+
+.movies-page-noun { margin: 0 8px; }
+
+.movies-page-blocks { display: inline-flex; gap: 2px; }
+
+.movies-page-block { display: inline-block; line-height: 1; }
+
+.movies-page-block.b1 { color: var(--rb-green); }
+.movies-page-block.b2 { color: var(--rb-yellow); }
+.movies-page-block.b3 { color: var(--rb-orange); }
+.movies-page-block.b4 { color: var(--rb-pink); }
+.movies-page-block.b5 { color: var(--rb-purple); }
+.movies-page-block.b6 { color: var(--rb-blue); }
+
+.movies-page-subtitle {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  color: var(--phosphor-cream-dim);
+  text-transform: uppercase;
+  margin: 8px 0 0;
+}
+
+.filter-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 14px;
+  background: transparent;
+  border: 1px solid var(--phosphor-cream-ghost);
+  color: var(--phosphor-cream-dim);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 120ms, border-color 120ms;
+}
+
+.filter-chip[data-active='true'] {
+  color: var(--phosphor-cream);
+  border-color: var(--phosphor-cream);
+}
+
+.filter-chip:hover { color: var(--phosphor-cream); }
+
+.filter-chip:focus-visible {
+  outline: 2px solid var(--neon-blue);
+  outline-offset: 2px;
+}
+
+.filter-chip-underline {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 3px;
+  background: linear-gradient(
+    to right,
+    var(--rb-green) 0 16.67%,
+    var(--rb-yellow) 16.67% 33.33%,
+    var(--rb-orange) 33.33% 50%,
+    var(--rb-pink) 50% 66.67%,
+    var(--rb-purple) 66.67% 83.33%,
+    var(--rb-blue) 83.33% 100%
+  );
+}
+
+.filter-sort-bar {
+  position: sticky;
+  top: 64px;
+  z-index: 10;
+  display: grid;
+  grid-template-columns: minmax(0, 280px) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 0;
+  background: var(--ground-base);
+  border-bottom: 1px solid var(--phosphor-cream-ghost);
+}
+
+.filter-sort-bar[data-has-scrolled='true']::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -5px;
+  height: 4px;
+  background: linear-gradient(
+    to right,
+    var(--rb-green) 0 16.67%,
+    var(--rb-yellow) 16.67% 33.33%,
+    var(--rb-orange) 33.33% 50%,
+    var(--rb-pink) 50% 66.67%,
+    var(--rb-purple) 66.67% 83.33%,
+    var(--rb-blue) 83.33% 100%
+  );
+}
+
+.filter-sort-bar-search {
+  position: relative;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--phosphor-cream-ghost);
+  padding: 8px 12px;
+  background: transparent;
+}
+
+.filter-sort-bar-search:focus-within {
+  border-color: var(--phosphor-cream);
+}
+
+.filter-sort-bar-search-caret {
+  color: var(--phosphor-cream-dim);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  user-select: none;
+  flex: 0 0 auto;
+}
+
+.filter-sort-bar-search-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--phosphor-cream);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  caret-color: var(--phosphor-cream);
+  text-transform: uppercase;
+}
+
+.filter-sort-bar-search-input::placeholder {
+  color: var(--phosphor-cream-dim);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+/* Suppress the webkit search-clear "×" button so it does not crowd the chip
+ * row to the right of the input. The Escape key in the inline handler clears
+ * the field; the filter chips provide the visual reset affordance. */
+.filter-sort-bar-search-input::-webkit-search-cancel-button {
+  display: none;
+}
+.filter-sort-bar-search-input::-webkit-search-decoration {
+  display: none;
+}
+
+.filter-sort-bar-chips { display: flex; gap: 10px; flex-wrap: wrap; }
+
+.filter-sort-bar-sort { position: relative; }
+
+.filter-sort-bar-sort-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: transparent;
+  border: 1px solid var(--phosphor-cream-ghost);
+  color: var(--phosphor-cream);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.filter-sort-bar-sort-trigger:hover,
+.filter-sort-bar-sort-trigger:focus-visible {
+  border-color: var(--phosphor-cream);
+  outline: none;
+}
+
+.filter-sort-bar-sort-label { color: var(--phosphor-cream-dim); }
+
+.filter-sort-bar-sort-chev {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid var(--phosphor-cream-dim);
+  margin-left: 4px;
+}
+
+.filter-sort-bar-sort-panel {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 200px;
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  background: var(--ground-base);
+  border: 1px solid var(--phosphor-cream-ghost);
+  z-index: 20;
+}
+
+.filter-sort-bar-sort-option {
+  padding: 8px 14px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  color: var(--phosphor-cream-dim);
+  cursor: pointer;
+  position: relative;
+}
+
+.filter-sort-bar-sort-option[data-active='true'] { color: var(--phosphor-cream); }
+
+.filter-sort-bar-sort-option[data-active='true']::after {
+  content: '';
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  bottom: 2px;
+  height: 2px;
+  background: linear-gradient(
+    to right,
+    var(--rb-green),
+    var(--rb-yellow),
+    var(--rb-orange),
+    var(--rb-pink),
+    var(--rb-purple),
+    var(--rb-blue)
+  );
+}
+
+.filter-sort-bar-sort-option:hover {
+  color: var(--phosphor-cream);
+  background: var(--ground-row-even);
+}
+
+.library-grid { display: block; }
+
+.library-grid-region { margin-top: 24px; }
+
+.library-grid-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px 16px;
+}
+
+@media (min-width: 640px) {
+  .library-grid-list { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+
+@media (min-width: 1024px) {
+  .library-grid-list { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+}
+
+@media (min-width: 1280px) {
+  .library-grid-list { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+}
+
+@media (min-width: 1536px) {
+  .library-grid-list { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+}
+
+.library-grid-cell {
+  display: block;
+  list-style: none;
+}
+
+.library-grid-cell::marker {
+  content: '';
+}
+
+.library-grid-card-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  outline: none;
+}
+
+.library-grid-card-link:focus-visible .library-grid-card {
+  outline: 2px solid var(--neon-blue);
+  outline-offset: 2px;
+  box-shadow:
+    0 0 0 2px var(--neon-blue),
+    inset 0 0 12px rgba(63, 169, 255, 0.15);
+}
+
+.library-grid-card {
+  position: relative;
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  margin-inline: auto;
+  transition: transform 150ms;
+}
+
+.library-grid-card-link:hover .library-grid-card,
+.library-grid-card-link:focus-visible .library-grid-card {
+  transform: translateY(-2px);
+}
+
+.library-grid-card-fallback {
+  width: 100%;
+  aspect-ratio: 2 / 3;
+  display: grid;
+  place-items: center;
+  background: var(--ground-card);
+  color: var(--phosphor-cream-dim);
+  font-family: var(--font-display);
+  font-size: 48px;
+  border: 1px solid var(--phosphor-cream-ghost);
+}
+
+.library-grid-card-led {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  z-index: 2;
+}
+
+.library-grid-card-led[data-status='plan_to_watch'] {
+  background: var(--status-color-plan_to_watch);
+  box-shadow: var(--status-glow-plan_to_watch);
+}
+.library-grid-card-led[data-status='watching'] {
+  background: var(--status-color-watching);
+  box-shadow: var(--status-glow-watching);
+}
+.library-grid-card-led[data-status='completed'] {
+  background: var(--status-color-completed);
+  box-shadow: var(--status-glow-completed);
+}
+.library-grid-card-led[data-status='on_hold'] {
+  background: var(--status-color-on_hold);
+  box-shadow: var(--status-glow-on_hold);
+}
+.library-grid-card-led[data-status='dropped'] {
+  background: var(--status-color-dropped);
+  box-shadow: var(--status-glow-dropped);
+}
+
+.media-card-overlay {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 40%;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 4px;
+  background: linear-gradient(
+    to top,
+    rgba(26, 20, 38, 0.95) 0%,
+    rgba(26, 20, 38, 0.85) 60%,
+    rgba(26, 20, 38, 0) 100%
+  );
+  transform: translateY(100%);
+  transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.library-grid-card-link:hover .media-card-overlay,
+.library-grid-card-link:focus-visible .media-card-overlay {
+  transform: translateY(0);
+}
+
+.media-card-overlay-title {
+  font-family: var(--font-display);
+  font-size: 18px;
+  line-height: 1.1;
+  color: var(--phosphor-cream);
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.media-card-overlay-meta {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  color: var(--phosphor-cream-dim);
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.media-card-overlay-status {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.media-card-overlay-status[data-status='plan_to_watch'] { color: var(--status-color-plan_to_watch); }
+.media-card-overlay-status[data-status='watching'] { color: var(--status-color-watching); }
+.media-card-overlay-status[data-status='completed'] { color: var(--status-color-completed); }
+.media-card-overlay-status[data-status='on_hold'] { color: var(--status-color-on_hold); }
+.media-card-overlay-status[data-status='dropped'] { color: var(--status-color-dropped); }
+
+.empty-library {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 96px 24px;
+  text-align: center;
+}
+
+.empty-library-title {
+  font-family: var(--font-bitmap);
+  font-size: 20px;
+  letter-spacing: 0.06em;
+  color: var(--phosphor-cream);
+  margin: 0;
+}
+
+.empty-library-sub {
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--phosphor-cream-dim);
+  margin: 0;
+}
+
+.empty-library-cta {
+  font-family: var(--font-bitmap);
+  font-size: 16px;
+  letter-spacing: 0.05em;
+  color: var(--phosphor-cream);
+  text-decoration: none;
+  padding: 8px 16px;
+  border: 1px solid var(--phosphor-cream);
+  background: transparent;
+  text-transform: uppercase;
+}
+
+.empty-library-cta:hover {
+  background: var(--phosphor-cream);
+  color: var(--ground-base);
+  text-shadow: 0 0 6px rgba(239, 230, 212, 0.5);
+}
+
+.library-grid-error,
+.library-grid-filtered-zero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 80px 24px;
+  text-align: center;
+}
+
+.library-grid-error-title,
+.library-grid-filtered-zero-title {
+  font-family: var(--font-bitmap);
+  font-size: 18px;
+  letter-spacing: 0.06em;
+  color: var(--phosphor-cream);
+  margin: 0;
+}
+
+.library-grid-error-title { color: var(--magenta); }
+
+.library-grid-error-sub {
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--phosphor-cream-dim);
+  margin: 0;
+}
+
+.library-grid-clear-link {
+  background: none;
+  border: none;
+  color: var(--phosphor-cream-dim);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+.library-grid-clear-link:hover,
+.library-grid-clear-link:focus-visible {
+  color: var(--phosphor-cream);
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .media-card-overlay { transition: none; }
+  .library-grid-card { transition: none; }
+  .library-grid-card-link:hover .library-grid-card,
+  .library-grid-card-link:focus-visible .library-grid-card {
+    transform: none;
+  }
+}

--- a/components/molecules/EmptyLibraryState/EmptyLibraryState.tsx
+++ b/components/molecules/EmptyLibraryState/EmptyLibraryState.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import Link from 'next/link'
+
+export type EmptyLibraryMedium = 'movies' | 'tv' | 'anime' | 'manga' | 'games'
+
+export type EmptyLibraryStateProps = {
+  medium: EmptyLibraryMedium
+}
+
+type CopyEntry = {
+  pluralNoun: string
+  ctaLabel: string
+  searchType: string
+}
+
+const COPY: Record<EmptyLibraryMedium, CopyEntry> = {
+  movies: { pluralNoun: 'MOVIES', ctaLabel: '> ADD A MOVIE', searchType: 'movie' },
+  tv: { pluralNoun: 'TV SHOWS', ctaLabel: '> ADD A TV SHOW', searchType: 'tv' },
+  anime: { pluralNoun: 'ANIME', ctaLabel: '> ADD AN ANIME', searchType: 'anime' },
+  manga: { pluralNoun: 'MANGA', ctaLabel: '> ADD A MANGA', searchType: 'manga' },
+  games: { pluralNoun: 'GAMES', ctaLabel: '> ADD A GAME', searchType: 'game' },
+}
+
+export function EmptyLibraryState({ medium }: EmptyLibraryStateProps) {
+  const copy = COPY[medium]
+  return (
+    <div className='empty-library' role='status'>
+      <p className='empty-library-title'>&gt; NO {copy.pluralNoun} IN LIBRARY</p>
+      <p className='empty-library-sub'>Search to add one and start tracking.</p>
+      <Link
+        href={`/search?type=${copy.searchType}`}
+        className='empty-library-cta crt-pixel-button'
+      >
+        {copy.ctaLabel}
+      </Link>
+    </div>
+  )
+}

--- a/components/molecules/EmptyLibraryState/__tests__/EmptyLibraryState.test.tsx
+++ b/components/molecules/EmptyLibraryState/__tests__/EmptyLibraryState.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import {
+  EmptyLibraryState,
+  type EmptyLibraryMedium,
+} from '@/components/molecules/EmptyLibraryState'
+
+describe('EmptyLibraryState', () => {
+  const cases: Array<{
+    medium: EmptyLibraryMedium
+    title: string
+    cta: string
+    href: string
+  }> = [
+    {
+      medium: 'movies',
+      title: '> NO MOVIES IN LIBRARY',
+      cta: '> ADD A MOVIE',
+      href: '/search?type=movie',
+    },
+    {
+      medium: 'tv',
+      title: '> NO TV SHOWS IN LIBRARY',
+      cta: '> ADD A TV SHOW',
+      href: '/search?type=tv',
+    },
+    {
+      medium: 'anime',
+      title: '> NO ANIME IN LIBRARY',
+      cta: '> ADD AN ANIME',
+      href: '/search?type=anime',
+    },
+    {
+      medium: 'manga',
+      title: '> NO MANGA IN LIBRARY',
+      cta: '> ADD A MANGA',
+      href: '/search?type=manga',
+    },
+    {
+      medium: 'games',
+      title: '> NO GAMES IN LIBRARY',
+      cta: '> ADD A GAME',
+      href: '/search?type=game',
+    },
+  ]
+
+  it.each(cases)(
+    'renders the per-medium copy and CTA href for $medium',
+    ({ medium, title, cta, href }) => {
+      const { unmount } = render(<EmptyLibraryState medium={medium} />)
+      expect(screen.getByText(title)).toBeInTheDocument()
+      expect(screen.getByText(cta)).toBeInTheDocument()
+      const link = screen.getByRole('link', { name: cta })
+      expect(link.getAttribute('href')).toBe(href)
+      unmount()
+    },
+  )
+
+  it('renders the subtitle inviting the user to search', () => {
+    render(<EmptyLibraryState medium='movies' />)
+    expect(
+      screen.getByText('Search to add one and start tracking.'),
+    ).toBeInTheDocument()
+  })
+
+  it('uses role="status" for the wrapper', () => {
+    const { container } = render(<EmptyLibraryState medium='movies' />)
+    expect(container.querySelector('[role="status"]')).not.toBeNull()
+  })
+})

--- a/components/molecules/EmptyLibraryState/index.ts
+++ b/components/molecules/EmptyLibraryState/index.ts
@@ -1,0 +1,5 @@
+export {
+  EmptyLibraryState,
+  type EmptyLibraryStateProps,
+  type EmptyLibraryMedium,
+} from './EmptyLibraryState'

--- a/components/molecules/FilterChip/FilterChip.tsx
+++ b/components/molecules/FilterChip/FilterChip.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { type ReactNode } from 'react'
+
+export type FilterChipProps = {
+  active: boolean
+  label: string
+  onToggle: () => void
+  ariaLabel?: string
+  children?: ReactNode
+}
+
+export function FilterChip({
+  active,
+  label,
+  onToggle,
+  ariaLabel,
+}: FilterChipProps) {
+  return (
+    <button
+      type='button'
+      className='filter-chip'
+      data-active={active ? 'true' : 'false'}
+      aria-pressed={active}
+      aria-label={ariaLabel ?? `${active ? 'Active' : 'Inactive'} filter: ${label}`}
+      onClick={onToggle}
+    >
+      <span className='filter-chip-label'>{label.toUpperCase()}</span>
+      {active ? <span className='filter-chip-underline' aria-hidden='true' /> : null}
+    </button>
+  )
+}

--- a/components/molecules/FilterChip/__tests__/FilterChip.test.tsx
+++ b/components/molecules/FilterChip/__tests__/FilterChip.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FilterChip } from '@/components/molecules/FilterChip'
+
+describe('FilterChip', () => {
+  it('renders the label in uppercase', () => {
+    render(<FilterChip active={false} label='watching' onToggle={() => {}} />)
+    expect(screen.getByText('WATCHING')).toBeInTheDocument()
+  })
+
+  it('reflects active state via data-active and aria-pressed', () => {
+    const { rerender } = render(
+      <FilterChip active={false} label='watching' onToggle={() => {}} />,
+    )
+    const button = screen.getByRole('button')
+    expect(button.getAttribute('data-active')).toBe('false')
+    expect(button.getAttribute('aria-pressed')).toBe('false')
+
+    rerender(<FilterChip active label='watching' onToggle={() => {}} />)
+    expect(button.getAttribute('data-active')).toBe('true')
+    expect(button.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('renders the rainbow underline only when active', () => {
+    const { container, rerender } = render(
+      <FilterChip active={false} label='watching' onToggle={() => {}} />,
+    )
+    expect(container.querySelector('.filter-chip-underline')).toBeNull()
+    rerender(<FilterChip active label='watching' onToggle={() => {}} />)
+    expect(container.querySelector('.filter-chip-underline')).not.toBeNull()
+  })
+
+  it('fires onToggle on click', () => {
+    const onToggle = vi.fn()
+    render(<FilterChip active={false} label='watching' onToggle={onToggle} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the custom aria-label when provided', () => {
+    render(
+      <FilterChip
+        active
+        label='watching'
+        onToggle={() => {}}
+        ariaLabel='Filter: status watching (active)'
+      />,
+    )
+    expect(
+      screen.getByLabelText('Filter: status watching (active)'),
+    ).toBeInTheDocument()
+  })
+})

--- a/components/molecules/FilterChip/index.ts
+++ b/components/molecules/FilterChip/index.ts
@@ -1,0 +1,1 @@
+export { FilterChip, type FilterChipProps } from './FilterChip'

--- a/components/molecules/FilterSortBar/FilterSortBar.tsx
+++ b/components/molecules/FilterSortBar/FilterSortBar.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type Ref,
+} from 'react'
+import { WatchStatus } from '@prisma/client'
+import { FilterChip } from '@/components/molecules/FilterChip'
+
+export type LibraryMedium = 'movies' | 'tv' | 'anime' | 'manga' | 'games'
+
+export type FilterSearchHandle = {
+  focus: () => void
+}
+
+export type SortOption = {
+  key: string
+  label: string
+}
+
+export type FilterSortBarProps = {
+  medium: LibraryMedium
+  search: string
+  onSearchChange: (next: string) => void
+  activeStatus: WatchStatus | null
+  onStatusChange: (next: WatchStatus | null) => void
+  activeSort: string
+  sortOptions: SortOption[]
+  onSortChange: (next: string) => void
+  hasScrolled?: boolean
+  searchRef?: Ref<FilterSearchHandle>
+  debounceMs?: number
+}
+
+const STATUS_CHIPS: ReadonlyArray<{ status: WatchStatus; label: string }> = [
+  { status: WatchStatus.PLAN_TO_WATCH, label: 'PLAN TO WATCH' },
+  { status: WatchStatus.WATCHING, label: 'WATCHING' },
+  { status: WatchStatus.COMPLETED, label: 'COMPLETED' },
+  { status: WatchStatus.ON_HOLD, label: 'ON HOLD' },
+  { status: WatchStatus.DROPPED, label: 'DROPPED' },
+]
+
+const PLACEHOLDER_BY_MEDIUM: Record<LibraryMedium, string> = {
+  movies: 'FILTER MOVIES…',
+  tv: 'FILTER TV SHOWS…',
+  anime: 'FILTER ANIME…',
+  manga: 'FILTER MANGA…',
+  games: 'FILTER GAMES…',
+}
+
+export function FilterSortBar({
+  medium,
+  search,
+  onSearchChange,
+  activeStatus,
+  onStatusChange,
+  activeSort,
+  sortOptions,
+  onSortChange,
+  hasScrolled = false,
+  searchRef,
+  debounceMs = 150,
+}: FilterSortBarProps) {
+  const [sortOpen, setSortOpen] = useState(false)
+  const [draft, setDraft] = useState(search)
+  const sortRef = useRef<HTMLDivElement | null>(null)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const sortPanelId = useId()
+  const activeSortLabel =
+    sortOptions.find((o) => o.key === activeSort)?.label ?? activeSort.toUpperCase()
+
+  // Expose focus() to parent so F or / keys can refocus the input.
+  useImperativeHandle(searchRef, () => ({ focus: () => inputRef.current?.focus() }), [])
+
+  // Sync draft when parent forces a value change (e.g. Escape clears externally).
+  useEffect(() => {
+    setDraft(search)
+  }, [search])
+
+  // Pin onSearchChange in a ref so the debounce timer is not re-scheduled when
+  // callers pass a non-stable function identity.
+  const onSearchChangeRef = useRef(onSearchChange)
+  useEffect(() => {
+    onSearchChangeRef.current = onSearchChange
+  })
+
+  // Debounced flush.
+  useEffect(() => {
+    if (draft === search) return
+    const timer = setTimeout(() => {
+      onSearchChangeRef.current(draft)
+    }, debounceMs)
+    return () => clearTimeout(timer)
+  }, [draft, search, debounceMs])
+
+  const closeSort = useCallback(() => setSortOpen(false), [])
+
+  useEffect(() => {
+    if (!sortOpen) return
+    function handler(e: MouseEvent | KeyboardEvent) {
+      if (e instanceof KeyboardEvent) {
+        if (e.key === 'Escape') closeSort()
+        return
+      }
+      if (!sortRef.current) return
+      if (!(e.target instanceof Node)) return
+      if (!sortRef.current.contains(e.target)) closeSort()
+    }
+    window.addEventListener('click', handler)
+    window.addEventListener('keydown', handler)
+    return () => {
+      window.removeEventListener('click', handler)
+      window.removeEventListener('keydown', handler)
+    }
+  }, [sortOpen, closeSort])
+
+  return (
+    <div
+      className='filter-sort-bar'
+      data-has-scrolled={hasScrolled ? 'true' : 'false'}
+    >
+      <div className='filter-sort-bar-search'>
+        <span className='filter-sort-bar-search-caret' aria-hidden='true'>
+          &gt;
+        </span>
+        <input
+          ref={inputRef}
+          type='search'
+          className='filter-sort-bar-search-input'
+          value={draft}
+          placeholder={PLACEHOLDER_BY_MEDIUM[medium]}
+          aria-label='Filter library'
+          autoComplete='off'
+          spellCheck={false}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape' && draft !== '') {
+              e.preventDefault()
+              setDraft('')
+              onSearchChangeRef.current('')
+            }
+          }}
+        />
+      </div>
+      <div
+        className='filter-sort-bar-chips'
+        role='group'
+        aria-label='Filter by status'
+      >
+        {STATUS_CHIPS.map((chip) => (
+          <FilterChip
+            key={chip.status}
+            active={activeStatus === chip.status}
+            label={chip.label}
+            onToggle={() =>
+              onStatusChange(activeStatus === chip.status ? null : chip.status)
+            }
+          />
+        ))}
+      </div>
+      <div className='filter-sort-bar-sort' ref={sortRef}>
+        <button
+          type='button'
+          className='filter-sort-bar-sort-trigger'
+          aria-haspopup='listbox'
+          aria-expanded={sortOpen}
+          aria-controls={sortPanelId}
+          onClick={(e) => {
+            e.stopPropagation()
+            setSortOpen((v) => !v)
+          }}
+        >
+          <span className='filter-sort-bar-sort-label'>SORT BY:</span>
+          <span className='filter-sort-bar-sort-value'>{activeSortLabel}</span>
+          <span className='filter-sort-bar-sort-chev' aria-hidden='true' />
+        </button>
+        {sortOpen ? (
+          <ul
+            id={sortPanelId}
+            className='filter-sort-bar-sort-panel'
+            role='listbox'
+            aria-label='Sort options'
+          >
+            {sortOptions.map((opt) => (
+              <li
+                key={opt.key}
+                role='option'
+                aria-selected={opt.key === activeSort}
+                className='filter-sort-bar-sort-option'
+                data-active={opt.key === activeSort ? 'true' : 'false'}
+                onClick={() => {
+                  onSortChange(opt.key)
+                  closeSort()
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    onSortChange(opt.key)
+                    closeSort()
+                  }
+                }}
+                tabIndex={0}
+              >
+                {opt.label}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/components/molecules/FilterSortBar/__tests__/FilterSortBar.test.tsx
+++ b/components/molecules/FilterSortBar/__tests__/FilterSortBar.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { WatchStatus } from '@prisma/client'
+import {
+  FilterSortBar,
+  type SortOption,
+} from '@/components/molecules/FilterSortBar'
+
+const SORT_OPTIONS: SortOption[] = [
+  { key: 'recently_added', label: 'RECENTLY ADDED' },
+  { key: 'title_asc', label: 'TITLE A-Z' },
+  { key: 'release_date_desc', label: 'RELEASE DATE' },
+]
+
+function setup(overrides: Partial<React.ComponentProps<typeof FilterSortBar>> = {}) {
+  const onSearchChange = vi.fn()
+  const onStatusChange = vi.fn()
+  const onSortChange = vi.fn()
+  const utils = render(
+    <FilterSortBar
+      medium='movies'
+      search=''
+      onSearchChange={onSearchChange}
+      activeStatus={null}
+      onStatusChange={onStatusChange}
+      activeSort='recently_added'
+      sortOptions={SORT_OPTIONS}
+      onSortChange={onSortChange}
+      {...overrides}
+    />,
+  )
+  return { ...utils, onSearchChange, onStatusChange, onSortChange }
+}
+
+describe('FilterSortBar', () => {
+  it('renders the 5 status chips', () => {
+    setup()
+    expect(screen.getByText('PLAN TO WATCH')).toBeInTheDocument()
+    expect(screen.getByText('WATCHING')).toBeInTheDocument()
+    expect(screen.getByText('COMPLETED')).toBeInTheDocument()
+    expect(screen.getByText('ON HOLD')).toBeInTheDocument()
+    expect(screen.getByText('DROPPED')).toBeInTheDocument()
+  })
+
+  it('renders the medium-specific search placeholder', () => {
+    setup({ medium: 'tv' })
+    expect(screen.getByPlaceholderText('FILTER TV SHOWS…')).toBeInTheDocument()
+  })
+
+  it('toggles status filter from null to WATCHING on chip click', () => {
+    const { onStatusChange } = setup()
+    fireEvent.click(screen.getByText('WATCHING'))
+    expect(onStatusChange).toHaveBeenCalledWith(WatchStatus.WATCHING)
+  })
+
+  it('clears status filter when clicking the currently-active chip', () => {
+    const { onStatusChange } = setup({ activeStatus: WatchStatus.WATCHING })
+    fireEvent.click(screen.getByText('WATCHING'))
+    expect(onStatusChange).toHaveBeenCalledWith(null)
+  })
+
+  it('opens the sort dropdown panel on trigger click', () => {
+    setup()
+    const trigger = screen.getByRole('button', { name: /SORT BY/ })
+    expect(screen.queryByRole('listbox')).toBeNull()
+    fireEvent.click(trigger)
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    expect(screen.getByText('TITLE A-Z')).toBeInTheDocument()
+  })
+
+  it('fires onSortChange and closes the panel when a sort option is clicked', () => {
+    const { onSortChange } = setup()
+    const trigger = screen.getByRole('button', { name: /SORT BY/ })
+    fireEvent.click(trigger)
+    fireEvent.click(screen.getByText('TITLE A-Z'))
+    expect(onSortChange).toHaveBeenCalledWith('title_asc')
+    expect(screen.queryByRole('listbox')).toBeNull()
+  })
+
+  it('displays the active sort label inline in the trigger', () => {
+    setup({ activeSort: 'title_asc' })
+    expect(screen.getByText('TITLE A-Z')).toBeInTheDocument()
+  })
+
+  it('reflects has-scrolled state via data attribute for the bottom rainbow rule', () => {
+    const { container, rerender } = setup({ hasScrolled: false })
+    const bar = container.querySelector('.filter-sort-bar')
+    expect(bar?.getAttribute('data-has-scrolled')).toBe('false')
+
+    rerender(
+      <FilterSortBar
+        medium='movies'
+        search=''
+        onSearchChange={() => {}}
+        activeStatus={null}
+        onStatusChange={() => {}}
+        activeSort='recently_added'
+        sortOptions={SORT_OPTIONS}
+        onSortChange={() => {}}
+        hasScrolled
+      />,
+    )
+    expect(bar?.getAttribute('data-has-scrolled')).toBe('true')
+  })
+
+  it('closes the sort panel on Escape key', () => {
+    setup()
+    const trigger = screen.getByRole('button', { name: /SORT BY/ })
+    fireEvent.click(trigger)
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(screen.queryByRole('listbox')).toBeNull()
+  })
+})

--- a/components/molecules/FilterSortBar/index.ts
+++ b/components/molecules/FilterSortBar/index.ts
@@ -1,0 +1,6 @@
+export {
+  FilterSortBar,
+  type FilterSortBarProps,
+  type LibraryMedium,
+  type SortOption,
+} from './FilterSortBar'

--- a/components/molecules/MediaCardOverlay/MediaCardOverlay.tsx
+++ b/components/molecules/MediaCardOverlay/MediaCardOverlay.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { MediaType, WatchStatus } from '@prisma/client'
+
+export type MediaCardOverlayProps = {
+  title: string
+  year: number | null
+  mediaType: MediaType
+  status: WatchStatus
+}
+
+const TYPE_LABEL: Record<MediaType, string> = {
+  MOVIE: 'MOVIE',
+  TV_SHOW: 'TV',
+  TV_EPISODE: 'EPISODE',
+  ANIME: 'ANIME',
+  MANGA: 'MANGA',
+  GAME: 'GAME',
+}
+
+const STATUS_LABEL: Record<WatchStatus, string> = {
+  PLAN_TO_WATCH: 'PLAN TO WATCH',
+  WATCHING: 'WATCHING',
+  COMPLETED: 'COMPLETED',
+  ON_HOLD: 'ON HOLD',
+  DROPPED: 'DROPPED',
+}
+
+export function MediaCardOverlay({
+  title,
+  year,
+  mediaType,
+  status,
+}: MediaCardOverlayProps) {
+  const typeLabel = TYPE_LABEL[mediaType]
+  const yearLabel = year === null ? typeLabel : `${typeLabel} · ${year}`
+  return (
+    <div className='media-card-overlay' aria-hidden='true'>
+      <h3 className='media-card-overlay-title'>{title}</h3>
+      <p className='media-card-overlay-meta'>{yearLabel}</p>
+      <p
+        className='media-card-overlay-status'
+        data-status={status.toLowerCase()}
+      >
+        {STATUS_LABEL[status]}
+      </p>
+    </div>
+  )
+}

--- a/components/molecules/MediaCardOverlay/__tests__/MediaCardOverlay.test.tsx
+++ b/components/molecules/MediaCardOverlay/__tests__/MediaCardOverlay.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MediaType, WatchStatus } from '@prisma/client'
+import { MediaCardOverlay } from '@/components/molecules/MediaCardOverlay'
+
+describe('MediaCardOverlay', () => {
+  it('renders title + meta + status for a fully populated movie', () => {
+    render(
+      <MediaCardOverlay
+        title='Fight Club'
+        year={1999}
+        mediaType={MediaType.MOVIE}
+        status={WatchStatus.WATCHING}
+      />,
+    )
+    expect(screen.getByText('Fight Club')).toBeInTheDocument()
+    expect(screen.getByText('MOVIE · 1999')).toBeInTheDocument()
+    expect(screen.getByText('WATCHING')).toBeInTheDocument()
+  })
+
+  it('omits the year when null (sentinel 1970 → API returns null)', () => {
+    render(
+      <MediaCardOverlay
+        title='Unknown Release'
+        year={null}
+        mediaType={MediaType.MOVIE}
+        status={WatchStatus.PLAN_TO_WATCH}
+      />,
+    )
+    expect(screen.getByText('MOVIE')).toBeInTheDocument()
+    expect(screen.queryByText(/·/)).toBeNull()
+  })
+
+  it('uses the per-medium type label', () => {
+    const cases: Array<[MediaType, string]> = [
+      [MediaType.TV_SHOW, 'TV · 2024'],
+      [MediaType.ANIME, 'ANIME · 2024'],
+      [MediaType.MANGA, 'MANGA · 2024'],
+      [MediaType.GAME, 'GAME · 2024'],
+    ]
+    for (const [mediaType, expected] of cases) {
+      const { unmount } = render(
+        <MediaCardOverlay
+          title='Sample'
+          year={2024}
+          mediaType={mediaType}
+          status={WatchStatus.COMPLETED}
+        />,
+      )
+      expect(screen.getByText(expected)).toBeInTheDocument()
+      unmount()
+    }
+  })
+
+  it('exposes the status as a data-status attribute for CSS color targeting', () => {
+    const cases: Array<[WatchStatus, string, string]> = [
+      [WatchStatus.PLAN_TO_WATCH, 'plan_to_watch', 'PLAN TO WATCH'],
+      [WatchStatus.WATCHING, 'watching', 'WATCHING'],
+      [WatchStatus.COMPLETED, 'completed', 'COMPLETED'],
+      [WatchStatus.ON_HOLD, 'on_hold', 'ON HOLD'],
+      [WatchStatus.DROPPED, 'dropped', 'DROPPED'],
+    ]
+    for (const [status, dataValue, label] of cases) {
+      const { container, unmount } = render(
+        <MediaCardOverlay
+          title='Sample'
+          year={2024}
+          mediaType={MediaType.MOVIE}
+          status={status}
+        />,
+      )
+      const statusEl = container.querySelector('.media-card-overlay-status')
+      expect(statusEl?.getAttribute('data-status')).toBe(dataValue)
+      expect(statusEl?.textContent).toBe(label)
+      unmount()
+    }
+  })
+})

--- a/components/molecules/MediaCardOverlay/index.ts
+++ b/components/molecules/MediaCardOverlay/index.ts
@@ -1,0 +1,1 @@
+export { MediaCardOverlay, type MediaCardOverlayProps } from './MediaCardOverlay'

--- a/components/organisms/LibraryGrid/LibraryGrid.tsx
+++ b/components/organisms/LibraryGrid/LibraryGrid.tsx
@@ -1,0 +1,342 @@
+'use client'
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react'
+import Link from 'next/link'
+import { useQuery } from '@tanstack/react-query'
+import { MediaType, WatchStatus } from '@prisma/client'
+import { FilterSortBar, type SortOption } from '@/components/molecules/FilterSortBar'
+import { EmptyLibraryState } from '@/components/molecules/EmptyLibraryState'
+import { MediaCardOverlay } from '@/components/molecules/MediaCardOverlay'
+import { FramedCover } from '@/components/molecules/FramedCover'
+import { getImageUrl } from '@/lib/api/tmdb-images'
+import type { LibraryItem, LibraryListResponse } from '@/lib/types/library'
+
+const MEDIUM_TO_TYPE: Record<'movies' | 'tv' | 'anime' | 'manga' | 'games', MediaType> = {
+  movies: MediaType.MOVIE,
+  tv: MediaType.TV_SHOW,
+  anime: MediaType.ANIME,
+  manga: MediaType.MANGA,
+  games: MediaType.GAME,
+}
+
+const TYPE_TO_MEDIUM: Record<MediaType, 'movies' | 'tv' | 'anime' | 'manga' | 'games'> = {
+  MOVIE: 'movies',
+  TV_SHOW: 'tv',
+  TV_EPISODE: 'tv',
+  ANIME: 'anime',
+  MANGA: 'manga',
+  GAME: 'games',
+}
+
+export const MOVIE_SORT_OPTIONS: SortOption[] = [
+  { key: 'recently_added', label: 'RECENTLY ADDED' },
+  { key: 'title_asc', label: 'TITLE A-Z' },
+  { key: 'release_date_desc', label: 'RELEASE DATE' },
+  { key: 'status_asc', label: 'STATUS' },
+  { key: 'rating_desc', label: 'RATING' },
+]
+
+export type LibraryGridProps = {
+  mediaType: 'movies' | 'tv' | 'anime' | 'manga' | 'games'
+  initialItems: LibraryItem[]
+  initialSort: string
+  initialStatus: WatchStatus | null
+  initialSearch: string
+  sortOptions?: SortOption[]
+}
+
+type FetchKey = readonly [
+  'library',
+  'movies' | 'tv' | 'anime' | 'manga' | 'games',
+  { sort: string; status: WatchStatus | null; search: string },
+]
+
+async function fetchLibrary(
+  medium: LibraryGridProps['mediaType'],
+  sort: string,
+  status: WatchStatus | null,
+  search: string,
+  signal: AbortSignal,
+): Promise<LibraryItem[]> {
+  const params = new URLSearchParams()
+  params.set('type', MEDIUM_TO_TYPE[medium])
+  params.set('sort', sort)
+  if (status) params.set('status', status)
+  if (search.trim().length > 0) params.set('search', search.trim())
+  params.set('limit', '200')
+  const res = await fetch(`/api/library?${params.toString()}`, {
+    signal,
+    cache: 'no-store',
+  })
+  if (!res.ok) throw new Error(`library fetch failed: ${res.status}`)
+  const body = (await res.json()) as LibraryListResponse
+  return body.items
+}
+
+export function LibraryGrid({
+  mediaType,
+  initialItems,
+  initialSort,
+  initialStatus,
+  initialSearch,
+  sortOptions = MOVIE_SORT_OPTIONS,
+}: LibraryGridProps) {
+  const [sort, setSortState] = useState(initialSort)
+  const [status, setStatusState] = useState<WatchStatus | null>(initialStatus)
+  const [search, setSearchState] = useState(initialSearch)
+  const [hasScrolled, setHasScrolled] = useState(false)
+  const [focusedIdx, setFocusedIdx] = useState<number | null>(null)
+  const gridRef = useRef<HTMLUListElement | null>(null)
+  const searchHandleRef = useRef<{ focus: () => void } | null>(null)
+
+  const queryKey = useMemo<FetchKey>(
+    () => ['library', mediaType, { sort, status, search }] as const,
+    [mediaType, sort, status, search],
+  )
+
+  // initialData ONLY seeds the FIRST queryKey (the one the SSR rendered with).
+  // Subsequent queryKeys (after filter/sort/search flips) get no initialData
+  // so TanStack runs a real fetch instead of reusing stale SSR data with the
+  // wrong filters applied. The flag stays true on the first render only;
+  // first state change flips it off.
+  const isFirstRenderRef = useRef(true)
+  const initialDataForQuery = isFirstRenderRef.current ? initialItems : undefined
+
+  const { data: items = initialItems, isLoading, isError } = useQuery({
+    queryKey,
+    queryFn: ({ signal }) => fetchLibrary(mediaType, sort, status, search, signal),
+    initialData: initialDataForQuery,
+    initialDataUpdatedAt: 0,
+    staleTime: 0,
+  })
+
+  // URL is written via window.history.replaceState — a true shallow URL
+  // update that does NOT trigger Next.js's Server Component refetch. Using
+  // router.replace() instead would re-run MoviesPage SSR on every chip click,
+  // racing with the client's TanStack Query state and producing the stale-
+  // data display Cuatro reported at smoke.
+  const writeUrl = useCallback(
+    (nextSort: string, nextStatus: WatchStatus | null, nextSearch: string) => {
+      if (typeof window === 'undefined') return
+      const params = new URLSearchParams()
+      params.set('sort', nextSort)
+      if (nextStatus) params.set('status', nextStatus)
+      const trimmed = nextSearch.trim()
+      if (trimmed.length > 0) params.set('search', trimmed)
+      const target = `${window.location.pathname}?${params.toString()}`
+      window.history.replaceState(null, '', target)
+    },
+    [],
+  )
+
+  // Flip the first-render flag AFTER the initial render commits. From this
+  // point on, queryKey changes get no initialData → real fetches fire.
+  useEffect(() => {
+    isFirstRenderRef.current = false
+  }, [])
+
+  const setSort = useCallback(
+    (next: string) => {
+      setSortState(next)
+      writeUrl(next, status, search)
+    },
+    [status, search, writeUrl],
+  )
+
+  const setStatus = useCallback(
+    (next: WatchStatus | null) => {
+      setStatusState(next)
+      writeUrl(sort, next, search)
+    },
+    [sort, search, writeUrl],
+  )
+
+  const setSearch = useCallback(
+    (next: string) => {
+      setSearchState(next)
+      writeUrl(sort, status, next)
+    },
+    [sort, status, writeUrl],
+  )
+
+  const clearFilters = useCallback(() => {
+    setStatusState(null)
+    setSearchState('')
+    writeUrl(sort, null, '')
+  }, [sort, writeUrl])
+
+  // Scroll affordance: rainbow rule under the toolbar once scrolled past 80px.
+  useEffect(() => {
+    function onScroll() {
+      setHasScrolled(window.scrollY > 80)
+    }
+    onScroll()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  // Page-level keyboard: F or / focuses the search input; Escape clears filters + search.
+  useEffect(() => {
+    function onKey(e: globalThis.KeyboardEvent) {
+      const target = e.target
+      const isTyping =
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        (target instanceof HTMLElement &&
+          target.getAttribute('contenteditable') === 'true')
+      if ((e.key === 'f' || e.key === '/') && !isTyping) {
+        e.preventDefault()
+        searchHandleRef.current?.focus()
+        return
+      }
+      if (e.key === 'Escape' && (status !== null || search !== '')) {
+        e.preventDefault()
+        clearFilters()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [status, search, clearFilters])
+
+  // Grid-level arrow navigation. Right at end-of-row jumps to first card of
+  // next row; Up at top-row is a no-op (no wrap to last row).
+  const handleGridKey = useCallback(
+    (e: KeyboardEvent<HTMLUListElement>) => {
+      if (!items.length) return
+      if (focusedIdx === null) return
+      const cols = currentColumnCount(gridRef.current)
+      const total = items.length
+      let next = focusedIdx
+      if (e.key === 'ArrowRight') next = Math.min(focusedIdx + 1, total - 1)
+      else if (e.key === 'ArrowLeft') next = Math.max(focusedIdx - 1, 0)
+      else if (e.key === 'ArrowDown') next = Math.min(focusedIdx + cols, total - 1)
+      else if (e.key === 'ArrowUp') {
+        const candidate = focusedIdx - cols
+        next = candidate < 0 ? focusedIdx : candidate
+      } else return
+      e.preventDefault()
+      setFocusedIdx(next)
+      const cards = gridRef.current?.querySelectorAll<HTMLAnchorElement>(
+        '.library-grid-card-link',
+      )
+      cards?.[next]?.focus()
+    },
+    [focusedIdx, items.length],
+  )
+
+  // Loading + error + filtered-zero + empty-state branching.
+  const hasActiveQuery = status !== null || search.trim().length > 0
+
+  return (
+    <div className='library-grid'>
+      <FilterSortBar
+        medium={mediaType}
+        search={search}
+        onSearchChange={setSearch}
+        activeStatus={status}
+        onStatusChange={setStatus}
+        activeSort={sort}
+        sortOptions={sortOptions}
+        onSortChange={setSort}
+        hasScrolled={hasScrolled}
+        searchRef={searchHandleRef}
+      />
+      <div className='library-grid-region'>
+        {isError ? (
+          <div className='library-grid-error' role='alert'>
+            <p className='library-grid-error-title'>&gt; COULD NOT LOAD LIBRARY</p>
+            <p className='library-grid-error-sub'>
+              Try again or check the connection.
+            </p>
+          </div>
+        ) : items.length === 0 && !isLoading ? (
+          hasActiveQuery ? (
+            <div className='library-grid-filtered-zero' role='status'>
+              <p className='library-grid-filtered-zero-title'>
+                &gt; NO RESULTS{search.trim().length > 0 ? ` FOR "${search.trim().toUpperCase()}"` : ''}
+              </p>
+              <button
+                type='button'
+                className='library-grid-clear-link'
+                onClick={clearFilters}
+              >
+                CLEAR FILTERS
+              </button>
+            </div>
+          ) : (
+            <EmptyLibraryState medium={mediaType} />
+          )
+        ) : (
+          <ul
+            ref={gridRef}
+            className='library-grid-list'
+            role='grid'
+            aria-label={`${mediaType} library`}
+            onKeyDown={handleGridKey}
+          >
+            {items.map((item, idx) => {
+              const medium = TYPE_TO_MEDIUM[item.mediaType]
+              const poster = getImageUrl(item.posterPath, 'w342')
+              return (
+                <li
+                  key={item.id}
+                  role='gridcell'
+                  className='library-grid-cell'
+                  style={{ contentVisibility: 'auto', containIntrinsicSize: '0 320px' }}
+                >
+                  <Link
+                    href={`/${medium}/${item.mediaItemId}`}
+                    className='library-grid-card-link'
+                    aria-label={`${item.title}${item.year ? `, ${item.year}` : ''}, ${item.status}`}
+                    onFocus={() => setFocusedIdx(idx)}
+                    tabIndex={idx === (focusedIdx ?? 0) ? 0 : -1}
+                  >
+                    <div className='library-grid-card' data-medium={medium}>
+                      {poster ? (
+                        <FramedCover
+                          medium={medium}
+                          size='card'
+                          src={poster}
+                          alt={item.title}
+                        />
+                      ) : (
+                        <div className='library-grid-card-fallback' aria-hidden='true'>
+                          <span>?</span>
+                        </div>
+                      )}
+                      <span
+                        className='library-grid-card-led'
+                        data-status={item.status.toLowerCase()}
+                        aria-hidden='true'
+                      />
+                      <MediaCardOverlay
+                        title={item.title}
+                        year={item.year}
+                        mediaType={item.mediaType}
+                        status={item.status}
+                      />
+                    </div>
+                  </Link>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function currentColumnCount(grid: HTMLUListElement | null): number {
+  if (!grid) return 4
+  const cs = window.getComputedStyle(grid)
+  const cols = cs.getPropertyValue('grid-template-columns').split(' ').length
+  return Math.max(1, cols)
+}

--- a/components/organisms/LibraryGrid/__tests__/LibraryGrid.test.tsx
+++ b/components/organisms/LibraryGrid/__tests__/LibraryGrid.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MediaType, WatchStatus } from '@prisma/client'
+import { LibraryGrid, MOVIE_SORT_OPTIONS } from '../LibraryGrid'
+import type { LibraryItem } from '@/lib/types/library'
+
+// Spy on window.history.replaceState because LibraryGrid uses it (NOT
+// router.replace) for URL sync — see the writeUrl helper for why.
+const replaceStateSpy = vi.fn()
+
+// Mock global fetch so useQuery never throws under jsdom. The mock returns an
+// empty library by default; specific tests can override via mockResolvedValue.
+const fetchMock = vi.fn(
+  async () =>
+    new Response(JSON.stringify({ items: [] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }),
+)
+
+vi.mock('next/navigation', () => ({
+  // useRouter still has to exist for any internal Next.js wiring even though
+  // LibraryGrid doesn't call .replace anymore.
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+// SearchInput emits onChange via its internal debounce. To keep tests fast +
+// deterministic, mock it with a plain controlled input.
+vi.mock('@/components/molecules/SearchInput', () => ({
+  SearchInput: ({ value, onChange, placeholder }: {
+    value: string
+    onChange: (v: string) => void
+    placeholder?: string
+  }) => (
+    <input
+      type='search'
+      placeholder={placeholder}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      data-testid='search-input'
+    />
+  ),
+}))
+
+// FramedCover is server-only (no `"use client"`) but the test runner renders
+// it client-side. The chrome SVGs require client config; stub to a simple img.
+vi.mock('@/components/molecules/FramedCover', () => ({
+  FramedCover: ({ src, alt }: { src: string; alt: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element -- test stub for FramedCover; next/image is not needed in jsdom and would force a Next runtime.
+    <img src={src} alt={alt} data-testid='framed-cover' />
+  ),
+}))
+
+vi.mock('@/lib/api/tmdb-images', () => ({
+  getImageUrl: (path: string | null) =>
+    path ? `https://image.tmdb.org/t/p/w342${path}` : null,
+}))
+
+const sampleItem = (overrides: Partial<LibraryItem> = {}): LibraryItem => ({
+  id: 'entry-1',
+  mediaItemId: 'movie-1',
+  mediaType: MediaType.MOVIE,
+  status: WatchStatus.WATCHING,
+  title: 'Sample Movie',
+  posterPath: '/poster.jpg',
+  year: 2024,
+  releaseDate: '2024-01-01T00:00:00.000Z',
+  progressLabel: null,
+  progressPct: null,
+  sourceLabel: null,
+  tmdbId: 550,
+  anilistId: null,
+  igdbId: null,
+  steamId: null,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  ...overrides,
+})
+
+function renderGrid(props: Partial<React.ComponentProps<typeof LibraryGrid>> = {}) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <LibraryGrid
+        mediaType='movies'
+        initialItems={[sampleItem()]}
+        initialSort='recently_added'
+        initialStatus={null}
+        initialSearch=''
+        sortOptions={MOVIE_SORT_OPTIONS}
+        {...props}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+let originalReplaceState: typeof window.history.replaceState
+
+beforeEach(() => {
+  replaceStateSpy.mockClear()
+  fetchMock.mockClear()
+  originalReplaceState = window.history.replaceState
+  window.history.replaceState = replaceStateSpy as unknown as typeof window.history.replaceState
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  window.history.replaceState = originalReplaceState
+  vi.unstubAllGlobals()
+})
+
+describe('LibraryGrid', () => {
+  it('renders the grid with initial items', () => {
+    renderGrid()
+    expect(screen.getByRole('grid')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Sample Movie/)).toBeInTheDocument()
+  })
+
+  it('renders the per-medium EmptyLibraryState when initialItems is empty and no filters', () => {
+    renderGrid({ initialItems: [] })
+    expect(screen.getByText('> NO MOVIES IN LIBRARY')).toBeInTheDocument()
+    expect(screen.getByText('> ADD A MOVIE')).toBeInTheDocument()
+  })
+
+  it('renders the filtered-zero state when initialItems is empty AND a filter is active', () => {
+    renderGrid({ initialItems: [], initialSearch: 'spielberg' })
+    expect(
+      screen.getByText('> NO RESULTS FOR "SPIELBERG"'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('CLEAR FILTERS')).toBeInTheDocument()
+  })
+
+  it('CLEAR FILTERS clears search + status when clicked', async () => {
+    renderGrid({
+      initialItems: [],
+      initialSearch: 'spielberg',
+      initialStatus: WatchStatus.WATCHING,
+    })
+    fireEvent.click(screen.getByText('CLEAR FILTERS'))
+    // After clearing, the queryKey changes; a fresh fetch fires (mocked to
+    // return { items: [] }); on resolution the empty-library state replaces
+    // the filtered-zero state because hasActiveQuery is now false.
+    await waitFor(() => {
+      expect(screen.getByText('> NO MOVIES IN LIBRARY')).toBeInTheDocument()
+    })
+  })
+
+  it('cards are anchors linking to /movies/[mediaItemId]', () => {
+    renderGrid()
+    const card = screen.getByLabelText(/Sample Movie/) as HTMLAnchorElement
+    expect(card.getAttribute('href')).toBe('/movies/movie-1')
+  })
+
+  it('clicking a status chip in the toolbar updates the URL and refilters', async () => {
+    renderGrid()
+    // The WATCHING label also renders inside the MediaCardOverlay for the
+    // sample item. Scope the click to the toolbar's status chip group.
+    const statusGroup = screen.getByRole('group', { name: /status/i })
+    const watchingChip = Array.from(
+      statusGroup.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((b) => b.textContent === 'WATCHING')
+    expect(watchingChip).toBeDefined()
+    fireEvent.click(watchingChip!)
+    await waitFor(() => {
+      const calls = replaceStateSpy.mock.calls
+      const lastUrl = calls[calls.length - 1]?.[2] as string | undefined
+      expect(lastUrl).toContain('status=WATCHING')
+    })
+  })
+
+  it('Escape clears active filters + search when one is set', async () => {
+    renderGrid({ initialStatus: WatchStatus.WATCHING })
+    fireEvent.keyDown(window, { key: 'Escape' })
+    // After clearing the status, the URL replaceState fires without status=.
+    await waitFor(() => {
+      const calls = replaceStateSpy.mock.calls
+      const lastUrl = calls[calls.length - 1]?.[2] as string | undefined
+      expect(lastUrl).not.toContain('status=')
+    })
+  })
+
+  it('renders a fallback when posterPath is null', () => {
+    renderGrid({ initialItems: [sampleItem({ posterPath: null })] })
+    expect(screen.queryByTestId('framed-cover')).toBeNull()
+    expect(screen.getByText('?')).toBeInTheDocument()
+  })
+
+  it('renders the PhosphorLED status pill with the correct data-status', () => {
+    const { container } = renderGrid()
+    const led = container.querySelector('.library-grid-card-led')
+    expect(led?.getAttribute('data-status')).toBe('watching')
+  })
+})

--- a/components/organisms/LibraryGrid/index.ts
+++ b/components/organisms/LibraryGrid/index.ts
@@ -1,0 +1,5 @@
+export {
+  LibraryGrid,
+  MOVIE_SORT_OPTIONS,
+  type LibraryGridProps,
+} from './LibraryGrid'

--- a/lib/api/__tests__/tmdb.test.ts
+++ b/lib/api/__tests__/tmdb.test.ts
@@ -118,6 +118,49 @@ const validEpisode = {
   runtime: 62,
 }
 
+const validMovieCredits = {
+  id: 550,
+  cast: [
+    {
+      id: 287,
+      name: 'Brad Pitt',
+      character: 'Tyler Durden',
+      order: 0,
+      profile_path: '/bp.jpg',
+    },
+    {
+      id: 819,
+      name: 'Edward Norton',
+      character: 'The Narrator',
+      order: 1,
+      profile_path: '/en.jpg',
+    },
+    {
+      id: 1283,
+      name: 'Helena Bonham Carter',
+      character: 'Marla Singer',
+      order: 2,
+      profile_path: null,
+    },
+  ],
+  crew: [
+    {
+      id: 7467,
+      name: 'David Fincher',
+      job: 'Director',
+      department: 'Directing',
+      profile_path: '/df.jpg',
+    },
+    {
+      id: 7468,
+      name: 'Jim Uhls',
+      job: 'Screenplay',
+      department: 'Writing',
+      profile_path: null,
+    },
+  ],
+}
+
 const validSearchMultiResponse = {
   page: 1,
   results: [
@@ -252,6 +295,107 @@ describe('lib/api/tmdb', () => {
         fieldPath: 'release_date',
       })
     })
+
+    it('does NOT append append_to_response when called without options', async () => {
+      mockFetchOk(validMovie)
+      const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+      const { getMovie } = await import('@/lib/api/tmdb')
+
+      await getMovie(550)
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string
+      expect(calledUrl).not.toContain('append_to_response')
+    })
+
+    it('with { withCredits: true } returns TmdbMovie augmented with credits.cast + credits.crew', async () => {
+      mockFetchOk({ ...validMovie, credits: validMovieCredits })
+      const { getMovie } = await import('@/lib/api/tmdb')
+
+      const result = await getMovie(550, { withCredits: true })
+
+      expect(result).toMatchObject({ id: 550, title: 'Fight Club' })
+      expect(result.credits.cast).toHaveLength(3)
+      expect(result.credits.crew).toHaveLength(2)
+      expect(result.credits.cast[0]).toMatchObject({
+        id: 287,
+        name: 'Brad Pitt',
+        character: 'Tyler Durden',
+        order: 0,
+      })
+      expect(result.credits.crew[0]).toMatchObject({
+        id: 7467,
+        name: 'David Fincher',
+        job: 'Director',
+      })
+    })
+
+    it('with { withCredits: true } adds append_to_response=credits to the request URL', async () => {
+      mockFetchOk({ ...validMovie, credits: validMovieCredits })
+      const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+      const { getMovie } = await import('@/lib/api/tmdb')
+
+      await getMovie(550, { withCredits: true })
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string
+      expect(calledUrl).toContain('/movie/550')
+      expect(calledUrl).toContain('append_to_response=credits')
+    })
+
+    it('with { withCredits: true } throws TmdbApiError with fieldPath rooted under credits when a cast entry is tampered', async () => {
+      mockFetchOk({
+        ...validMovie,
+        credits: {
+          cast: [{ id: 'not-a-number' }],
+          crew: [],
+        },
+      })
+      const { getMovie, TmdbApiError } = await import('@/lib/api/tmdb')
+
+      const promise = getMovie(550, { withCredits: true })
+      await expect(promise).rejects.toBeInstanceOf(TmdbApiError)
+      await expect(promise).rejects.toMatchObject({
+        endpoint: '/movie/550',
+        fieldPath: expect.stringMatching(/^credits\.cast\.0/),
+      })
+    })
+  })
+
+  describe('getMovieCredits', () => {
+    it('parses a valid /movie/:id/credits response', async () => {
+      mockFetchOk(validMovieCredits)
+      const { getMovieCredits } = await import('@/lib/api/tmdb')
+
+      const result = await getMovieCredits(550)
+
+      expect(result.cast).toHaveLength(3)
+      expect(result.crew).toHaveLength(2)
+      expect(result.cast[0]).toMatchObject({
+        id: 287,
+        name: 'Brad Pitt',
+        character: 'Tyler Durden',
+      })
+    })
+
+    it('returns empty arrays when TMDB reports no cast and no crew', async () => {
+      mockFetchOk({ id: 550, cast: [], crew: [] })
+      const { getMovieCredits } = await import('@/lib/api/tmdb')
+
+      const result = await getMovieCredits(550)
+
+      expect(result.cast).toEqual([])
+      expect(result.crew).toEqual([])
+    })
+
+    it('builds the expected /movie/:id/credits path', async () => {
+      mockFetchOk(validMovieCredits)
+      const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+      const { getMovieCredits } = await import('@/lib/api/tmdb')
+
+      await getMovieCredits(550)
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string
+      expect(calledUrl).toContain('/movie/550/credits')
+    })
   })
 
   describe('getTv', () => {
@@ -319,28 +463,49 @@ describe('lib/api/tmdb', () => {
   })
 
   describe('getWatchProviders', () => {
-    it('returns the slice for the requested country', async () => {
+    it('returns the requested country slice with all four arrays guaranteed present', async () => {
       mockFetchOk(validWatchProvidersResponse)
       const { getWatchProviders } = await import('@/lib/api/tmdb')
 
       const result = await getWatchProviders('movie', 550, 'CO')
 
-      expect(result).toMatchObject({
-        link: 'https://www.themoviedb.org/movie/550/watch?locale=CO',
+      expect(result.link).toBe(
+        'https://www.themoviedb.org/movie/550/watch?locale=CO',
+      )
+      expect(result.flatrate).toEqual([])
+      expect(result.rent).toEqual([])
+      expect(result.buy).toHaveLength(1)
+      expect(result.buy[0]).toMatchObject({
+        provider_id: 2,
+        provider_name: 'Apple TV',
       })
-      expect(result?.buy).toHaveLength(1)
     })
 
-    it('returns null when the country has no providers', async () => {
+    it('populates flatrate when present and leaves rent + buy as empty arrays', async () => {
+      mockFetchOk(validWatchProvidersResponse)
+      const { getWatchProviders } = await import('@/lib/api/tmdb')
+
+      const result = await getWatchProviders('movie', 550, 'US')
+
+      expect(result.flatrate).toHaveLength(1)
+      expect(result.flatrate[0]).toMatchObject({
+        provider_id: 8,
+        provider_name: 'Netflix',
+      })
+      expect(result.rent).toEqual([])
+      expect(result.buy).toEqual([])
+    })
+
+    it('returns always-shape empty payload when the country has no providers (never null)', async () => {
       mockFetchOk(validWatchProvidersResponse)
       const { getWatchProviders } = await import('@/lib/api/tmdb')
 
       const result = await getWatchProviders('movie', 550, 'ZZ')
 
-      expect(result).toBeNull()
+      expect(result).toEqual({ link: '', flatrate: [], rent: [], buy: [] })
     })
 
-    it('throws TmdbApiError when a provider entry has an invalid link', async () => {
+    it('throws TmdbApiError when the wire payload has an invalid link', async () => {
       mockFetchOk({
         id: 550,
         results: {

--- a/lib/api/tmdb.ts
+++ b/lib/api/tmdb.ts
@@ -87,6 +87,31 @@ export const TmdbEpisodeSchema = z.object({
 })
 export type TmdbEpisode = z.infer<typeof TmdbEpisodeSchema>
 
+export const TmdbCastMemberSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  character: z.string().nullable().optional(),
+  order: z.number(),
+  profile_path: z.string().nullable(),
+})
+export type TmdbCastMember = z.infer<typeof TmdbCastMemberSchema>
+
+export const TmdbCrewMemberSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  job: z.string(),
+  department: z.string(),
+  profile_path: z.string().nullable(),
+})
+export type TmdbCrewMember = z.infer<typeof TmdbCrewMemberSchema>
+
+export const TmdbCreditsSchema = z.object({
+  id: z.number().optional(),
+  cast: z.array(TmdbCastMemberSchema),
+  crew: z.array(TmdbCrewMemberSchema),
+})
+export type TmdbCredits = z.infer<typeof TmdbCreditsSchema>
+
 const TmdbSearchMovieResultSchema = z.object({
   media_type: z.literal('movie'),
   id: z.number(),
@@ -148,17 +173,30 @@ const TmdbProviderSchema = z.object({
   display_priority: z.number().optional(),
 })
 
-export const TmdbCountryProvidersSchema = z.object({
+// Wire shape — what TMDB's /watch/providers endpoint actually sends per
+// country: link is a TMDB-hosted URL, each provider category is omitted when
+// empty. Used by `tmdbFetch` at the network boundary.
+const TmdbCountryProvidersWireSchema = z.object({
   link: z.url(),
   flatrate: z.array(TmdbProviderSchema).optional(),
   buy: z.array(TmdbProviderSchema).optional(),
   rent: z.array(TmdbProviderSchema).optional(),
 })
+
+// Consumer shape — what `getWatchProviders` returns. Arrays guaranteed
+// non-undefined; link is an empty string when the country has no providers
+// (allows the detail page to render without null-guards).
+export const TmdbCountryProvidersSchema = z.object({
+  link: z.string(),
+  flatrate: z.array(TmdbProviderSchema),
+  rent: z.array(TmdbProviderSchema),
+  buy: z.array(TmdbProviderSchema),
+})
 export type TmdbCountryProviders = z.infer<typeof TmdbCountryProvidersSchema>
 
 export const TmdbWatchProvidersResponseSchema = z.object({
   id: z.number(),
-  results: z.record(z.string(), TmdbCountryProvidersSchema),
+  results: z.record(z.string(), TmdbCountryProvidersWireSchema),
 })
 export type TmdbWatchProvidersResponse = z.infer<
   typeof TmdbWatchProvidersResponseSchema
@@ -260,8 +298,28 @@ export function searchMulti(query: string): Promise<TmdbSearchMultiResponse> {
   return tmdbFetch('/search/multi', { query }, TmdbSearchMultiResponseSchema)
 }
 
-export function getMovie(id: number): Promise<TmdbMovie> {
+export function getMovie(id: number): Promise<TmdbMovie>
+export function getMovie(
+  id: number,
+  options: { withCredits: true },
+): Promise<TmdbMovie & { credits: TmdbCredits }>
+export function getMovie(
+  id: number,
+  options?: { withCredits?: boolean },
+): Promise<TmdbMovie | (TmdbMovie & { credits: TmdbCredits })> {
+  if (options?.withCredits) {
+    const schema = TmdbMovieSchema.extend({ credits: TmdbCreditsSchema })
+    return tmdbFetch(
+      `/movie/${id}`,
+      { append_to_response: 'credits' },
+      schema,
+    )
+  }
   return tmdbFetch(`/movie/${id}`, {}, TmdbMovieSchema)
+}
+
+export function getMovieCredits(id: number): Promise<TmdbCredits> {
+  return tmdbFetch(`/movie/${id}/credits`, {}, TmdbCreditsSchema)
 }
 
 export function getTv(id: number): Promise<TmdbTv> {
@@ -284,11 +342,17 @@ export async function getWatchProviders(
   type: 'movie' | 'tv',
   id: number,
   country: string,
-): Promise<TmdbCountryProviders | null> {
+): Promise<TmdbCountryProviders> {
   const response = await tmdbFetch(
     `/${type}/${id}/watch/providers`,
     {},
     TmdbWatchProvidersResponseSchema,
   )
-  return response.results[country] ?? null
+  const slice = response.results[country]
+  return {
+    link: slice?.link ?? '',
+    flatrate: slice?.flatrate ?? [],
+    rent: slice?.rent ?? [],
+    buy: slice?.buy ?? [],
+  }
 }

--- a/lib/db/library.ts
+++ b/lib/db/library.ts
@@ -1,0 +1,86 @@
+import { type MediaItem, type Prisma, type UserEntry, MediaType, WatchStatus } from '@prisma/client'
+import { db } from '@/lib/db'
+
+export type LibrarySortKey =
+  | 'recently_added'
+  | 'recently_created'
+  | 'release_date_desc'
+  | 'title_asc'
+  | 'status_asc'
+  | 'rating_desc'
+
+export type LibraryQueryOptions = {
+  mediaType?: MediaType
+  status?: WatchStatus
+  search?: string
+  sort?: LibrarySortKey
+  limit?: number
+  releasedWithinDays?: number
+}
+
+export type UserEntryWithMedia = UserEntry & { media_item: MediaItem }
+
+const DEFAULT_LIMIT = 200
+const DEFAULT_SORT: LibrarySortKey = 'recently_added'
+
+export async function findLibraryItems(
+  opts: LibraryQueryOptions = {},
+): Promise<UserEntryWithMedia[]> {
+  const {
+    mediaType,
+    status,
+    search,
+    sort = DEFAULT_SORT,
+    limit = DEFAULT_LIMIT,
+    releasedWithinDays,
+  } = opts
+
+  const mediaWhere: Prisma.MediaItemWhereInput = {}
+  if (mediaType) mediaWhere.type = mediaType
+  if (search && search.trim().length > 0) {
+    mediaWhere.title = { contains: search.trim(), mode: 'insensitive' }
+  }
+  if (releasedWithinDays !== undefined) {
+    const now = new Date()
+    const floor = new Date(now.getTime() - releasedWithinDays * 24 * 60 * 60 * 1000)
+    mediaWhere.release_date = { gte: floor, lte: now }
+  }
+
+  const where: Prisma.UserEntryWhereInput = {}
+  if (status) where.status = status
+  if (Object.keys(mediaWhere).length > 0) where.media_item = mediaWhere
+
+  // releasedWithinDays forces ordering by release_date desc to match
+  // dashboard "Recently Released" semantics, regardless of caller's sort param.
+  const effectiveSort: LibrarySortKey =
+    releasedWithinDays !== undefined ? 'release_date_desc' : sort
+
+  const orderBy = buildOrderBy(effectiveSort)
+
+  return db.userEntry.findMany({
+    where: Object.keys(where).length > 0 ? where : undefined,
+    include: { media_item: true },
+    orderBy,
+    take: limit,
+  })
+}
+
+function buildOrderBy(
+  sort: LibrarySortKey,
+): Prisma.UserEntryOrderByWithRelationInput {
+  switch (sort) {
+    case 'release_date_desc':
+      return { media_item: { release_date: 'desc' } }
+    case 'recently_created':
+      return { created_at: 'desc' }
+    case 'title_asc':
+      return { media_item: { title: 'asc' } }
+    case 'status_asc':
+      return { status: 'asc' }
+    case 'rating_desc':
+      return { media_item: { rating: 'desc' } }
+    case 'recently_added':
+    default:
+      return { updated_at: 'desc' }
+  }
+}

--- a/lib/normalise/__tests__/movie.test.ts
+++ b/lib/normalise/__tests__/movie.test.ts
@@ -269,4 +269,174 @@ describe('lib/normalise/movie', () => {
       },
     )
   })
+
+  describe('normaliseTmdbCredits', () => {
+    const validCredits = {
+      cast: [
+        {
+          id: 287,
+          name: 'Brad Pitt',
+          character: 'Tyler Durden',
+          order: 0,
+          profile_path: '/bp.jpg',
+        },
+        {
+          id: 819,
+          name: 'Edward Norton',
+          character: 'The Narrator',
+          order: 1,
+          profile_path: '/en.jpg',
+        },
+      ],
+      crew: [
+        {
+          id: 7467,
+          name: 'David Fincher',
+          job: 'Director',
+          department: 'Directing',
+          profile_path: '/df.jpg',
+        },
+        {
+          id: 7468,
+          name: 'Jim Uhls',
+          job: 'Screenplay',
+          department: 'Writing',
+          profile_path: null,
+        },
+      ],
+    }
+
+    it('maps cast members to the normalised domain shape with character → role', async () => {
+      const { normaliseTmdbCredits } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbCredits(validCredits)
+
+      expect(result.cast).toEqual([
+        {
+          id: 287,
+          name: 'Brad Pitt',
+          role: 'Tyler Durden',
+          order: 0,
+          profile_path: '/bp.jpg',
+        },
+        {
+          id: 819,
+          name: 'Edward Norton',
+          role: 'The Narrator',
+          order: 1,
+          profile_path: '/en.jpg',
+        },
+      ])
+    })
+
+    it('maps crew members to the normalised domain shape with job → role and array-index order', async () => {
+      const { normaliseTmdbCredits } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbCredits(validCredits)
+
+      expect(result.crew).toEqual([
+        {
+          id: 7467,
+          name: 'David Fincher',
+          role: 'Director',
+          order: 0,
+          profile_path: '/df.jpg',
+        },
+        {
+          id: 7468,
+          name: 'Jim Uhls',
+          role: 'Screenplay',
+          order: 1,
+          profile_path: null,
+        },
+      ])
+    })
+
+    it('falls back to empty string when a cast member has null character (uncredited)', async () => {
+      const { normaliseTmdbCredits } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbCredits({
+        cast: [
+          {
+            id: 1,
+            name: 'Archival Footage',
+            character: null,
+            order: 0,
+            profile_path: null,
+          },
+        ],
+        crew: [],
+      })
+
+      expect(result.cast[0].role).toBe('')
+    })
+
+    it('returns empty arrays when input has empty cast and crew', async () => {
+      const { normaliseTmdbCredits } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbCredits({ cast: [], crew: [] })
+
+      expect(result).toEqual({ cast: [], crew: [] })
+    })
+
+    it('preserves input order (no implicit sort by order field)', async () => {
+      const { normaliseTmdbCredits } = await import('@/lib/normalise/movie')
+
+      const result = normaliseTmdbCredits({
+        cast: [
+          {
+            id: 1,
+            name: 'A',
+            character: 'X',
+            order: 5,
+            profile_path: null,
+          },
+          {
+            id: 2,
+            name: 'B',
+            character: 'Y',
+            order: 1,
+            profile_path: null,
+          },
+          {
+            id: 3,
+            name: 'C',
+            character: 'Z',
+            order: 3,
+            profile_path: null,
+          },
+        ],
+        crew: [],
+      })
+
+      expect(result.cast.map((c) => c.id)).toEqual([1, 2, 3])
+      expect(result.cast.map((c) => c.order)).toEqual([5, 1, 3])
+    })
+
+    it('throws ZodError when a cast id is the wrong type', async () => {
+      const { normaliseTmdbCredits } = await import('@/lib/normalise/movie')
+
+      expect(() =>
+        normaliseTmdbCredits({
+          cast: [
+            {
+              id: 'not-a-number',
+              name: 'X',
+              character: 'Y',
+              order: 0,
+              profile_path: null,
+            },
+          ],
+          crew: [],
+        }),
+      ).toThrow(ZodError)
+    })
+
+    it('throws ZodError when input is null or undefined', async () => {
+      const { normaliseTmdbCredits } = await import('@/lib/normalise/movie')
+
+      expect(() => normaliseTmdbCredits(null)).toThrow(ZodError)
+      expect(() => normaliseTmdbCredits(undefined)).toThrow(ZodError)
+    })
+  })
 })

--- a/lib/normalise/movie.ts
+++ b/lib/normalise/movie.ts
@@ -1,5 +1,21 @@
 import { Prisma, MediaType } from '@prisma/client'
-import { TmdbMovieSchema } from '@/lib/api/tmdb'
+import { TmdbMovieSchema, TmdbCreditsSchema } from '@/lib/api/tmdb'
+
+export type NormalisedCastMember = {
+  id: number
+  name: string
+  role: string
+  order: number
+  profile_path: string | null
+}
+
+export type NormalisedCrewMember = {
+  id: number
+  name: string
+  role: string
+  order: number
+  profile_path: string | null
+}
 
 const RELEASE_DATE_SENTINEL = new Date('1970-01-01T00:00:00Z')
 
@@ -41,5 +57,28 @@ export function normaliseTmdbMovie(raw: unknown): Prisma.MediaItemCreateInput {
     popularity: source.popularity,
     genres: source.genres.map((g) => g.name),
     tmdb_id: source.id,
+  }
+}
+
+export function normaliseTmdbCredits(raw: unknown): {
+  cast: NormalisedCastMember[]
+  crew: NormalisedCrewMember[]
+} {
+  const source = TmdbCreditsSchema.parse(raw)
+  return {
+    cast: source.cast.map((c) => ({
+      id: c.id,
+      name: c.name,
+      role: c.character ?? '',
+      order: c.order,
+      profile_path: c.profile_path,
+    })),
+    crew: source.crew.map((c, idx) => ({
+      id: c.id,
+      name: c.name,
+      role: c.job,
+      order: idx,
+      profile_path: c.profile_path,
+    })),
   }
 }


### PR DESCRIPTION
Epic 6 sub-bundle PR A of 2. Carries Stories 6.1 (TMDB adapter extension) and 6.3 (/movies grid). PR B (`epic-6-detail-page`) carries Story 6.5 and ships separately to keep each PR reviewable.

**Scope ceiling escalation:** ~2350 LOC. Above the workspace's 1.5K guideline; explicitly accepted to avoid sub-splitting an already-shipped commit (per the kickoff handoff rationale).

## What's in this PR

- **Story 6.1** (`0692985f`) — `lib/api/tmdb.ts`: added `getMovieCredits`, reshaped `getWatchProviders` to return per-country slice with guaranteed-array shape, added `TmdbExternalIds` and `TmdbCountryProviders` types.
- **Story 6.3** (`20e9844d`) — `/movies` library grid: Server Component page at `app/(media)/movies/page.tsx`, new `LibraryGrid` organism with TanStack Query + URL sync + roving-tabindex keyboard nav, new `FilterChip` / `FilterSortBar` / `MediaCardOverlay` / `EmptyLibraryState` molecules, extended `/api/library` schema with `type` / `search` / `sort` params, introduced `lib/db/library.ts` repo function.

Closes #115
Closes #118

## Test plan

- [ ] CI green on the build + lint + typecheck + vitest passes.
- [ ] `/movies` route loads with the user's library.
- [ ] Filter chips toggle status (PLAN_TO_WATCH / WATCHING / COMPLETED / ON_HOLD / DROPPED); URL syncs.
- [ ] Sort options reorder grid in place.
- [ ] Search field debounces at 150ms; Escape clears.
- [ ] Keyboard navigation: arrow keys move card focus; Enter navigates to /movies/[id].
- [ ] Empty-library state renders when user has zero movies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)