### PR TITLE
feat(epic-7): TV shows & episodes (#122-#128)

### DIFF
--- a/app/(media)/tv/[id]/TvDetailControls.tsx
+++ b/app/(media)/tv/[id]/TvDetailControls.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+import { WatchStatus } from '@prisma/client'
+import {
+  SeasonAccordion,
+  type SeasonGroup,
+} from '@/components/molecules/SeasonAccordion'
+
+export type TvDetailControlsProps = {
+  showId: string
+  seasons: SeasonGroup[]
+  defaultExpandedSeason: number | null
+}
+
+async function putEpisodeStatus(body: {
+  mediaItemId: string
+  status: WatchStatus
+}): Promise<void> {
+  const res = await fetch('/api/progress', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    throw new Error(`episode_status_failed:${res.status}`)
+  }
+}
+
+async function postBulkSeason(body: {
+  parentId: string
+  scope: 'season'
+  seasonNumber: number
+  status: WatchStatus
+}): Promise<{ updated: number }> {
+  const res = await fetch('/api/progress/bulk', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    throw new Error(`bulk_progress_failed:${res.status}`)
+  }
+  return res.json() as Promise<{ updated: number }>
+}
+
+export function TvDetailControls({
+  showId,
+  seasons,
+  defaultExpandedSeason,
+}: TvDetailControlsProps) {
+  const router = useRouter()
+  const queryClient = useQueryClient()
+
+  function invalidateAndRefresh() {
+    void queryClient.invalidateQueries({ queryKey: ['library', 'tv'] })
+    void queryClient.invalidateQueries({ queryKey: ['tvDetail', showId] })
+    router.refresh()
+  }
+
+  const episodeMutation = useMutation<
+    void,
+    Error,
+    { mediaItemId: string; status: WatchStatus }
+  >({
+    mutationFn: putEpisodeStatus,
+    onSuccess: () => {
+      invalidateAndRefresh()
+    },
+    onError: () => {
+      toast.error('COULD NOT UPDATE EPISODE')
+    },
+  })
+
+  const bulkMutation = useMutation<
+    { updated: number },
+    Error,
+    { parentId: string; scope: 'season'; seasonNumber: number; status: WatchStatus }
+  >({
+    mutationFn: postBulkSeason,
+    onSuccess: (data, variables) => {
+      invalidateAndRefresh()
+      toast.success(
+        `SEASON ${variables.seasonNumber} MARKED WATCHED · ${data.updated} EPS`,
+      )
+    },
+    onError: () => {
+      toast.error('COULD NOT MARK SEASON')
+    },
+  })
+
+  function handleToggle(mediaItemId: string, next: WatchStatus) {
+    episodeMutation.mutate({ mediaItemId, status: next })
+  }
+
+  function handleMarkSeasonWatched(seasonNumber: number) {
+    bulkMutation.mutate({
+      parentId: showId,
+      scope: 'season',
+      seasonNumber,
+      status: WatchStatus.COMPLETED,
+    })
+  }
+
+  return (
+    <SeasonAccordion
+      seasons={seasons}
+      defaultExpandedSeason={defaultExpandedSeason}
+      onToggleEpisode={handleToggle}
+      onMarkSeasonWatched={handleMarkSeasonWatched}
+    />
+  )
+}

--- a/app/(media)/tv/[id]/not-found.tsx
+++ b/app/(media)/tv/[id]/not-found.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function TvNotFound() {
+  return (
+    <main className='tv-not-found'>
+      <h1>&gt; SHOW NOT IN LIBRARY</h1>
+      <p>Try adding it from the search.</p>
+      <Link href='/tv' className='crt-pixel-button'>
+        &gt; BACK TO TV LIBRARY
+      </Link>
+    </main>
+  )
+}

--- a/app/(media)/tv/[id]/page.tsx
+++ b/app/(media)/tv/[id]/page.tsx
@@ -1,0 +1,212 @@
+import { notFound } from 'next/navigation'
+import { MediaType, WatchStatus } from '@prisma/client'
+import { db } from '@/lib/db'
+import { findUserEntryByMediaItemId } from '@/lib/db/library'
+import { getTv, getWatchProviders, getImageUrl } from '@/lib/api/tmdb'
+import { env } from '@/lib/env'
+import { logger } from '@/lib/logger'
+import { BackToLibraryLink } from '@/components/molecules/BackToLibraryLink'
+import { DetailHero } from '@/components/organisms/DetailHero'
+import { CastList } from '@/components/organisms/CastList'
+import { StreamingBadges } from '@/components/organisms/StreamingBadges'
+import { SectionBand } from '@/components/organisms/SectionBand/SectionBand'
+import { PhosphorBar } from '@/components/atoms/PhosphorBar'
+import type { MetadataItem } from '@/components/molecules/MetadataRow'
+import type { SeasonEpisode, SeasonGroup } from '@/components/molecules/SeasonAccordion'
+import { TvDetailControls } from './TvDetailControls'
+
+export const dynamic = 'force-dynamic'
+
+type PageParams = Promise<{ id: string }>
+
+function deriveYear(d: Date): number | null {
+  const y = d.getUTCFullYear()
+  return y === 1970 ? null : y
+}
+
+function computeDefaultExpandedSeason(
+  seasons: SeasonGroup[],
+): number | null {
+  if (seasons.length === 0) return null
+  // Find the highest season where the user has at least one watched episode;
+  // expand the NEXT season after that (the user's "currently watching"
+  // position). Fall back to the lowest season number if nothing watched yet.
+  let highestWatchedSeason = -1
+  for (const season of seasons) {
+    const hasWatched = season.episodes.some(
+      (e) => e.status === WatchStatus.COMPLETED,
+    )
+    if (hasWatched && season.number > highestWatchedSeason) {
+      highestWatchedSeason = season.number
+    }
+  }
+  if (highestWatchedSeason === -1) return seasons[0].number
+  const seasonNumbers = seasons.map((s) => s.number).sort((a, b) => a - b)
+  const idx = seasonNumbers.indexOf(highestWatchedSeason)
+  // Next season exists → expand it. Otherwise stay on the last watched one.
+  if (idx >= 0 && idx + 1 < seasonNumbers.length) return seasonNumbers[idx + 1]
+  return highestWatchedSeason
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: PageParams
+}): Promise<{ title: string }> {
+  const { id } = await params
+  const entry = await findUserEntryByMediaItemId(id)
+  if (!entry) return { title: 'NOT IN LIBRARY · Cuatro Tracker' }
+  return {
+    title: `${entry.media_item.title.toUpperCase()} · Cuatro Tracker`,
+  }
+}
+
+export default async function TvDetailPage({
+  params,
+}: {
+  params: PageParams
+}) {
+  const { id } = await params
+  if (!id) notFound()
+
+  const entry = await findUserEntryByMediaItemId(id)
+  if (!entry || entry.media_item.type !== MediaType.TV_SHOW) notFound()
+  if (entry.media_item.tmdb_id === null) {
+    logger.warn(
+      { event: 'tv_detail.missing_tmdb_id', mediaItemId: id },
+      'TV_SHOW row has no tmdb_id; rendering 404',
+    )
+    notFound()
+  }
+
+  const tmdbId = entry.media_item.tmdb_id
+
+  // Parallel-fetch the show's episodes (with UserEntry join) + TMDB detail +
+  // watch providers. The show MediaItem + its UserEntry came from
+  // findUserEntryByMediaItemId above.
+  const [episodes, tvDetail, providers] = await Promise.all([
+    db.mediaItem.findMany({
+      where: { parent_id: id, type: MediaType.TV_EPISODE },
+      orderBy: [{ season_number: 'asc' }, { episode_number: 'asc' }],
+      include: { user_entry: true },
+    }),
+    getTv(tmdbId),
+    getWatchProviders('tv', tmdbId, env.TMDB_WATCH_PROVIDER_COUNTRY),
+  ])
+
+  // Group episodes by season_number.
+  const seasonsMap = new Map<number, SeasonEpisode[]>()
+  for (const ep of episodes) {
+    const sNum = ep.season_number ?? 0
+    const list = seasonsMap.get(sNum) ?? []
+    list.push({
+      mediaItemId: ep.id,
+      seasonNumber: sNum,
+      episodeNumber: ep.episode_number ?? 0,
+      title: ep.title,
+      airDate: ep.release_date
+        ? ep.release_date.getUTCFullYear() === 1970
+          ? null
+          : ep.release_date.toISOString()
+        : null,
+      runtime: ep.runtime,
+      unaired: ep.unaired,
+      status: ep.user_entry?.status ?? null,
+    })
+    seasonsMap.set(sNum, list)
+  }
+  const seasons: SeasonGroup[] = Array.from(seasonsMap.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([number, eps]) => ({ number, episodes: eps }))
+
+  // Show-level PhosphorBar metrics.
+  const totalAired = episodes.filter((e) => !e.unaired).length
+  const watched = episodes.filter(
+    (e) => e.user_entry?.status === WatchStatus.COMPLETED && !e.unaired,
+  ).length
+
+  const defaultExpandedSeason = computeDefaultExpandedSeason(seasons)
+
+  // Hero metadata.
+  const year = deriveYear(entry.media_item.release_date)
+  const cast = tvDetail.credits.cast.slice(0, 12).map((c) => ({
+    name: c.name,
+    role: c.character ?? '',
+    profilePath: c.profile_path,
+  }))
+
+  const metadata: MetadataItem[] = []
+  if (totalAired > 0) {
+    metadata.push({ value: `${totalAired} EPISODES` })
+  }
+  if (year !== null) metadata.push({ value: String(year) })
+  if (entry.media_item.lifecycle_status) {
+    metadata.push({
+      value: entry.media_item.lifecycle_status.replaceAll('_', ' ').toUpperCase(),
+      dim: true,
+    })
+  }
+  if (entry.media_item.genres.length > 0) {
+    metadata.push({
+      value: entry.media_item.genres.map((g) => g.toUpperCase()).join(' · '),
+      dim: true,
+    })
+  }
+
+  const posterUrl = getImageUrl(entry.media_item.poster_path, 'w780')
+
+  const synopsisParagraphs = (entry.media_item.overview ?? '')
+    .split(/\n+/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+
+  return (
+    <main className='tv-detail-page'>
+      <BackToLibraryLink medium='tv' />
+      <DetailHero
+        mediaItemId={entry.media_item_id}
+        medium='tv'
+        mediumLabel={`TV${year !== null ? ` · ${year}` : ''}`}
+        title={entry.media_item.title}
+        originalTitle={entry.media_item.original_title}
+        posterUrl={posterUrl}
+        metadata={metadata}
+        currentStatus={entry.status}
+        imdbId={tvDetail.external_ids?.imdb_id ?? null}
+        showQbtButton={false}
+      />
+      <div className='tv-detail-rule' aria-hidden='true' />
+      {synopsisParagraphs.length > 0 ? (
+        <article className='tv-detail-synopsis'>
+          {synopsisParagraphs.map((para, idx) => (
+            <p key={idx}>{para}</p>
+          ))}
+        </article>
+      ) : null}
+      <div className='tv-detail-rule tv-detail-rule-thick' aria-hidden='true' />
+      <section className='tv-detail-progress' aria-label='Show progress'>
+        <p className='tv-detail-progress-label'>
+          {watched} / {totalAired} EPISODES WATCHED
+        </p>
+        <PhosphorBar
+          value={watched}
+          max={totalAired > 0 ? totalAired : 1}
+          label='Show progress'
+        />
+      </section>
+      <SectionBand title='Seasons' count={seasons.length}>
+        <TvDetailControls
+          showId={entry.media_item_id}
+          seasons={seasons}
+          defaultExpandedSeason={defaultExpandedSeason}
+        />
+      </SectionBand>
+      <SectionBand title='Cast' count={cast.length}>
+        <CastList people={cast} />
+      </SectionBand>
+      <SectionBand title='Streaming'>
+        <StreamingBadges providers={providers} />
+      </SectionBand>
+    </main>
+  )
+}

--- a/app/(media)/tv/[id]/season/[n]/episode/[e]/EpisodeDetailToggle.tsx
+++ b/app/(media)/tv/[id]/season/[n]/episode/[e]/EpisodeDetailToggle.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+import { WatchStatus } from '@prisma/client'
+import { EpisodeWatchToggle } from '@/components/molecules/EpisodeWatchToggle'
+
+export type EpisodeDetailToggleProps = {
+  mediaItemId: string
+  showId: string
+  initialStatus: WatchStatus | null
+  unaired: boolean
+  label: string
+}
+
+async function putEpisodeStatus(body: {
+  mediaItemId: string
+  status: WatchStatus
+}): Promise<void> {
+  const res = await fetch('/api/progress', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    throw new Error(`episode_status_failed:${res.status}`)
+  }
+}
+
+export function EpisodeDetailToggle({
+  mediaItemId,
+  showId,
+  initialStatus,
+  unaired,
+  label,
+}: EpisodeDetailToggleProps) {
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  // Optimistic state so the checkbox flips immediately, then either confirms
+  // (onSuccess) or rolls back (onError).
+  const [status, setStatus] = useState<WatchStatus | null>(initialStatus)
+
+  const mutation = useMutation<
+    void,
+    Error,
+    { mediaItemId: string; status: WatchStatus }
+  >({
+    mutationFn: putEpisodeStatus,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['library', 'tv'] })
+      void queryClient.invalidateQueries({ queryKey: ['tvDetail', showId] })
+      router.refresh()
+    },
+    onError: () => {
+      setStatus(initialStatus)
+      toast.error('COULD NOT UPDATE EPISODE')
+    },
+  })
+
+  const checked = status === WatchStatus.COMPLETED
+
+  function handleToggle() {
+    const next = checked
+      ? WatchStatus.PLAN_TO_WATCH
+      : WatchStatus.COMPLETED
+    setStatus(next)
+    mutation.mutate({ mediaItemId, status: next })
+  }
+
+  return (
+    <EpisodeWatchToggle
+      checked={checked}
+      disabled={unaired}
+      label={label}
+      onToggle={handleToggle}
+    />
+  )
+}

--- a/app/(media)/tv/[id]/season/[n]/episode/[e]/__tests__/EpisodeDetailToggle.test.tsx
+++ b/app/(media)/tv/[id]/season/[n]/episode/[e]/__tests__/EpisodeDetailToggle.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { WatchStatus } from '@prisma/client'
+
+const routerMock = vi.hoisted(() => ({ refresh: vi.fn() }))
+vi.mock('next/navigation', () => ({
+  useRouter: () => routerMock,
+}))
+
+const toastMock = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+}))
+vi.mock('sonner', () => ({ toast: toastMock }))
+
+const fetchMock = vi.fn()
+
+import { EpisodeDetailToggle } from '@/app/(media)/tv/[id]/season/[n]/episode/[e]/EpisodeDetailToggle'
+
+function wrap(ui: React.ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+describe('EpisodeDetailToggle', () => {
+  it('fires PUT /api/progress with the inverse status on click + refreshes the router on success', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) })
+    wrap(
+      <EpisodeDetailToggle
+        mediaItemId='ep-1'
+        showId='show-1'
+        initialStatus={WatchStatus.PLAN_TO_WATCH}
+        unaired={false}
+        label='Mark episode watched'
+      />,
+    )
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Mark episode watched' }))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/progress')
+    expect(init.method).toBe('PUT')
+    const body = JSON.parse(init.body)
+    expect(body).toEqual({
+      mediaItemId: 'ep-1',
+      status: WatchStatus.COMPLETED,
+    })
+    await waitFor(() => expect(routerMock.refresh).toHaveBeenCalled())
+  })
+
+  it('toggles back to PLAN_TO_WATCH when currently COMPLETED', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) })
+    wrap(
+      <EpisodeDetailToggle
+        mediaItemId='ep-1'
+        showId='show-1'
+        initialStatus={WatchStatus.COMPLETED}
+        unaired={false}
+        label='Mark episode watched'
+      />,
+    )
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Mark episode watched' }))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.status).toBe(WatchStatus.PLAN_TO_WATCH)
+  })
+
+  it('shows a Sonner error toast and rolls back optimistic state on a failed PUT', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) })
+    wrap(
+      <EpisodeDetailToggle
+        mediaItemId='ep-1'
+        showId='show-1'
+        initialStatus={WatchStatus.PLAN_TO_WATCH}
+        unaired={false}
+        label='Mark episode watched'
+      />,
+    )
+    const box = screen.getByRole('checkbox', { name: 'Mark episode watched' })
+    fireEvent.click(box)
+    await waitFor(() => expect(toastMock.error).toHaveBeenCalledWith('COULD NOT UPDATE EPISODE'))
+    // Optimistic flip rolled back: aria-checked returned to false.
+    await waitFor(() => expect(box.getAttribute('aria-checked')).toBe('false'))
+  })
+
+  it('invalidates both [library, tv] AND [tvDetail, showId] queryKeys on success (F10 guard)', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) })
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries')
+    render(
+      <QueryClientProvider client={client}>
+        <EpisodeDetailToggle
+          mediaItemId='ep-1'
+          showId='show-42'
+          initialStatus={WatchStatus.PLAN_TO_WATCH}
+          unaired={false}
+          label='Mark episode watched'
+        />
+      </QueryClientProvider>,
+    )
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Mark episode watched' }))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    await waitFor(() => expect(routerMock.refresh).toHaveBeenCalled())
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['library', 'tv'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tvDetail', 'show-42'] })
+  })
+
+  it('disabled state when unaired prevents PUT call', () => {
+    wrap(
+      <EpisodeDetailToggle
+        mediaItemId='ep-1'
+        showId='show-1'
+        initialStatus={null}
+        unaired={true}
+        label='Mark future episode watched'
+      />,
+    )
+    const box = screen.getByRole('checkbox', {
+      name: 'Mark future episode watched',
+      hidden: true,
+    })
+    fireEvent.click(box)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/app/(media)/tv/[id]/season/[n]/episode/[e]/not-found.tsx
+++ b/app/(media)/tv/[id]/season/[n]/episode/[e]/not-found.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function EpisodeNotFound() {
+  return (
+    <main className='episode-not-found'>
+      <h1>&gt; EPISODE NOT FOUND</h1>
+      <p>The episode isn&apos;t in your library, or doesn&apos;t exist.</p>
+      <Link href='/tv' className='crt-pixel-button'>
+        &gt; BACK TO TV LIBRARY
+      </Link>
+    </main>
+  )
+}

--- a/app/(media)/tv/[id]/season/[n]/episode/[e]/page.tsx
+++ b/app/(media)/tv/[id]/season/[n]/episode/[e]/page.tsx
@@ -1,0 +1,232 @@
+import Link from 'next/link'
+import Image from 'next/image'
+import { notFound } from 'next/navigation'
+import { MediaType, WatchStatus } from '@prisma/client'
+import { db } from '@/lib/db'
+import { getTvEpisode, getImageUrl } from '@/lib/api/tmdb'
+import { logger } from '@/lib/logger'
+import { EpisodeDetailToggle } from './EpisodeDetailToggle'
+
+export const dynamic = 'force-dynamic'
+
+type PageParams = Promise<{ id: string; n: string; e: string }>
+
+function parseSeasonOrEpisodeInt(raw: string): number | null {
+  // Strict integer match — rejects '1.5', '3xss', '01' (canonicalisation) so
+  // multiple URL spellings can't render the same content. Season 0 is valid
+  // (Specials); negatives rejected.
+  if (!/^(0|[1-9]\d*)$/.test(raw)) return null
+  const n = Number.parseInt(raw, 10)
+  return Number.isFinite(n) && n >= 0 ? n : null
+}
+
+function formatAirDate(d: Date | null, unaired: boolean): {
+  label: string
+  prefix: string | null
+} {
+  if (!d || d.getUTCFullYear() === 1970) {
+    return { label: 'TBA', prefix: unaired ? 'AIRS' : null }
+  }
+  return {
+    label: d.toISOString().slice(0, 10),
+    // Aired episodes show the date alone (no verb prefix) per Story 7.6 AC-3;
+    // only the future-tense `AIRS {date}` carries a prefix.
+    prefix: unaired ? 'AIRS' : null,
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: PageParams
+}): Promise<{ title: string }> {
+  const { id, n, e } = await params
+  const seasonN = parseSeasonOrEpisodeInt(n)
+  const episodeE = parseSeasonOrEpisodeInt(e)
+  if (seasonN === null || episodeE === null) {
+    return { title: 'EPISODE NOT FOUND · Cuatro Tracker' }
+  }
+  const episode = await db.mediaItem.findFirst({
+    where: {
+      parent_id: id,
+      season_number: seasonN,
+      episode_number: episodeE,
+      type: MediaType.TV_EPISODE,
+    },
+    select: {
+      title: true,
+      parent: { select: { title: true } },
+    },
+  })
+  if (!episode) return { title: 'EPISODE NOT FOUND · Cuatro Tracker' }
+  return {
+    title: `S${seasonN}E${episodeE} · ${episode.parent?.title ?? 'TV'} · Cuatro Tracker`,
+  }
+}
+
+export default async function EpisodeDetailPage({
+  params,
+}: {
+  params: PageParams
+}) {
+  const { id, n, e } = await params
+  const seasonN = parseSeasonOrEpisodeInt(n)
+  const episodeE = parseSeasonOrEpisodeInt(e)
+  if (seasonN === null || episodeE === null) notFound()
+
+  const episode = await db.mediaItem.findFirst({
+    where: {
+      parent_id: id,
+      season_number: seasonN,
+      episode_number: episodeE,
+      type: MediaType.TV_EPISODE,
+    },
+    include: {
+      user_entry: true,
+      parent: {
+        include: { user_entry: true },
+      },
+    },
+  })
+  // Episode missing OR the parent show is not in the user's library OR the
+  // parent row is not actually a TV_SHOW (corrupted-data defence per F2).
+  if (
+    !episode ||
+    !episode.parent ||
+    !episode.parent.user_entry ||
+    episode.parent.type !== MediaType.TV_SHOW
+  ) {
+    notFound()
+  }
+
+  // Aired-episode count for the "EP / TOTAL" header.
+  const totalAired = await db.mediaItem.count({
+    where: {
+      parent_id: id,
+      type: MediaType.TV_EPISODE,
+      unaired: false,
+    },
+  })
+
+  // TMDB episode payload (guest cast, fuller overview, optional still
+  // backfill). Best-effort: a fetch failure shouldn't 500 the page since the
+  // local episode data is enough to render the core surface.
+  let tmdbEpisode: Awaited<ReturnType<typeof getTvEpisode>> | null = null
+  if (episode.parent.tmdb_id != null) {
+    try {
+      tmdbEpisode = await getTvEpisode(
+        episode.parent.tmdb_id,
+        seasonN,
+        episodeE,
+      )
+    } catch (err) {
+      // Best-effort: an upstream failure shouldn't 500 the page (the local
+      // episode data is enough). Surface the failure to the operator so the
+      // missing guest cast isn't silent (F4).
+      logger.warn(
+        {
+          event: 'episode_detail.tmdb_fetch_failed',
+          showId: id,
+          seasonN,
+          episodeE,
+          err,
+        },
+        'getTvEpisode rejected; rendering without TMDB guest cast',
+      )
+      tmdbEpisode = null
+    }
+  }
+
+  const stillPath = episode.still_path ?? tmdbEpisode?.still_path ?? null
+  const stillUrl = getImageUrl(stillPath, 'w780')
+
+  const airDate = formatAirDate(episode.release_date, episode.unaired)
+
+  const guestStars = (tmdbEpisode?.guest_stars ?? []).slice(0, 8)
+
+  const overviewParagraphs = (episode.overview ?? '')
+    .split(/\n+/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+
+  const status: WatchStatus | null = episode.user_entry?.status ?? null
+
+  return (
+    <main className='episode-detail-page'>
+      <Link
+        href={`/tv/${id}#season-${seasonN}`}
+        className='episode-detail-back'
+      >
+        &lt; S{seasonN} OF {episode.parent.title.toUpperCase()}
+      </Link>
+
+      <header className='episode-detail-header'>
+        <p className='episode-detail-code'>
+          S{seasonN} EP{episodeE} / {totalAired}
+        </p>
+        <h1 className='episode-detail-title'>{episode.title}</h1>
+      </header>
+
+      {stillUrl ? (
+        <div className='episode-detail-still'>
+          <Image
+            src={stillUrl}
+            alt={episode.title}
+            width={780}
+            height={439}
+            unoptimized
+          />
+        </div>
+      ) : null}
+
+      {overviewParagraphs.length > 0 ? (
+        <article className='episode-detail-overview'>
+          {overviewParagraphs.map((para, idx) => (
+            <p key={idx}>{para}</p>
+          ))}
+        </article>
+      ) : null}
+
+      <section className='episode-detail-meta' aria-label='Episode metadata'>
+        <p className='episode-detail-air-date'>
+          {airDate.prefix !== null ? (
+            <>
+              <span className='episode-detail-air-date-prefix'>
+                {airDate.prefix}
+              </span>{' '}
+            </>
+          ) : null}
+          <span className='episode-detail-air-date-value'>{airDate.label}</span>
+        </p>
+        {episode.runtime ? (
+          <p className='episode-detail-runtime'>{episode.runtime} MIN</p>
+        ) : null}
+        <EpisodeDetailToggle
+          mediaItemId={episode.id}
+          showId={id}
+          initialStatus={status}
+          unaired={episode.unaired}
+          label={`Mark ${episode.title} watched`}
+        />
+      </section>
+
+      {guestStars.length > 0 ? (
+        <section className='episode-detail-guests' aria-label='Guest cast'>
+          <h2 className='episode-detail-guests-title'>GUEST CAST</h2>
+          <ul className='episode-detail-guests-list'>
+            {guestStars.map((guest) => (
+              <li key={`${guest.id}-${guest.name}`}>
+                <span className='episode-detail-guest-name'>{guest.name}</span>
+                {guest.character ? (
+                  <span className='episode-detail-guest-role'>
+                    {guest.character}
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </main>
+  )
+}

--- a/app/(media)/tv/page.tsx
+++ b/app/(media)/tv/page.tsx
@@ -1,0 +1,147 @@
+import { MediaType, WatchStatus } from '@prisma/client'
+import {
+  findLibraryItems,
+  formatTvProgressLabel,
+  formatTvProgressPct,
+  type LibrarySortKey,
+  type LifecycleStatus,
+} from '@/lib/db/library'
+import { LibraryGrid } from '@/components/organisms/LibraryGrid'
+import type { LifecycleFilter } from '@/components/molecules/FilterSortBar'
+import type { LibraryItem } from '@/lib/types/library'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata = {
+  title: 'TV · Cuatro Tracker',
+}
+
+const VALID_SORTS: ReadonlyArray<LibrarySortKey> = [
+  'recently_added',
+  'recently_created',
+  'release_date_desc',
+  'title_asc',
+  'status_asc',
+  'rating_desc',
+]
+
+const VALID_LIFECYCLES: ReadonlyArray<LifecycleFilter> = [
+  'in_progress',
+  'continuing',
+  'ended',
+]
+
+type SearchParams = Promise<{
+  sort?: string
+  status?: string
+  search?: string
+  lifecycle?: string
+}>
+
+function parseSort(raw: string | undefined): LibrarySortKey {
+  if (raw && (VALID_SORTS as readonly string[]).includes(raw)) {
+    return raw as LibrarySortKey
+  }
+  return 'recently_added'
+}
+
+function parseStatus(raw: string | undefined): WatchStatus | null {
+  if (!raw) return null
+  if ((Object.values(WatchStatus) as string[]).includes(raw)) {
+    return raw as WatchStatus
+  }
+  return null
+}
+
+function parseLifecycle(raw: string | undefined): LifecycleFilter | null {
+  if (!raw) return null
+  if ((VALID_LIFECYCLES as readonly string[]).includes(raw)) {
+    return raw as LifecycleFilter
+  }
+  return null
+}
+
+function deriveYear(releaseDate: Date): number | null {
+  const year = releaseDate.getUTCFullYear()
+  return year === 1970 ? null : year
+}
+
+export default async function TvPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const params = await searchParams
+  const sort = parseSort(params.sort)
+  const status = parseStatus(params.status)
+  const lifecycle = parseLifecycle(params.lifecycle)
+  const search = (params.search?.trim() ?? '').slice(0, 100)
+
+  const lifecycleStatus: LifecycleStatus | undefined =
+    lifecycle === 'continuing' || lifecycle === 'ended' ? lifecycle : undefined
+  const lifecycleInProgress = lifecycle === 'in_progress'
+
+  const entries = await findLibraryItems({
+    mediaType: MediaType.TV_SHOW,
+    status: status ?? undefined,
+    search: search.length > 0 ? search : undefined,
+    sort,
+    limit: 200,
+    lifecycleStatus,
+    lifecycleInProgress,
+  })
+
+  const initialItems: LibraryItem[] = entries.map((entry) => ({
+    id: entry.id,
+    mediaItemId: entry.media_item_id,
+    mediaType: entry.media_item.type,
+    status: entry.status,
+    title: entry.media_item.title,
+    posterPath: entry.media_item.poster_path,
+    year: deriveYear(entry.media_item.release_date),
+    releaseDate:
+      entry.media_item.release_date.getUTCFullYear() === 1970
+        ? null
+        : entry.media_item.release_date.toISOString(),
+    progressLabel: formatTvProgressLabel(entry.status, entry.episodeStats),
+    progressPct: formatTvProgressPct(entry.episodeStats),
+    sourceLabel: null,
+    tmdbId: entry.media_item.tmdb_id,
+    anilistId: entry.media_item.anilist_id,
+    igdbId: entry.media_item.igdb_id,
+    steamId: entry.media_item.steam_id,
+    createdAt: entry.created_at.toISOString(),
+    updatedAt: entry.updated_at.toISOString(),
+  }))
+
+  return (
+    <main className='movies-page'>
+      <header className='movies-page-heading'>
+        <h1 className='movies-page-title'>
+          <span className='movies-page-blocks'>
+            <span className='movies-page-block b1'>▓</span>
+            <span className='movies-page-block b2'>▓</span>
+            <span className='movies-page-block b3'>▓</span>
+          </span>
+          <span className='movies-page-noun'>TV</span>
+          <span className='movies-page-blocks'>
+            <span className='movies-page-block b4'>▓</span>
+            <span className='movies-page-block b5'>▓</span>
+            <span className='movies-page-block b6'>▓</span>
+          </span>
+        </h1>
+        <p className='movies-page-subtitle'>
+          {initialItems.length} ITEMS
+        </p>
+      </header>
+      <LibraryGrid
+        mediaType='tv'
+        initialItems={initialItems}
+        initialSort={sort}
+        initialStatus={status}
+        initialSearch={search}
+        initialLifecycle={lifecycle}
+      />
+    </main>
+  )
+}

--- a/app/api/library/__tests__/route.test.ts
+++ b/app/api/library/__tests__/route.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/lib/logger', () => ({
 
 const dbMock = vi.hoisted(() => ({
   userEntry: { findMany: vi.fn() },
+  mediaItem: { groupBy: vi.fn() },
 }))
 
 vi.mock('@/lib/db', () => ({ db: dbMock }))
@@ -263,5 +264,123 @@ describe('GET /api/library', () => {
     const body = await res.json()
     expect(body.items[0].year).toBeNull()
     expect(body.items[0].releaseDate).toBeNull()
+  })
+
+  describe('TV branch (Story 7.4)', () => {
+    const tvEntry = (
+      overrides: Record<string, unknown> = {},
+      mediaOverrides: Record<string, unknown> = {},
+    ) => ({
+      id: 'tv-entry-1',
+      media_item_id: 'tv-show-1',
+      status: WatchStatus.WATCHING,
+      user_rating: null,
+      progress: 0,
+      notes: null,
+      started_at: null,
+      completed_at: null,
+      created_at: new Date('2026-05-10T12:00:00Z'),
+      updated_at: new Date('2026-05-12T12:00:00Z'),
+      media_item: {
+        id: 'tv-show-1',
+        type: MediaType.TV_SHOW,
+        title: 'Breaking Bad',
+        original_title: null,
+        release_date: new Date('2008-01-20T00:00:00Z'),
+        end_date: new Date('2013-09-29T00:00:00Z'),
+        poster_path: '/poster.jpg',
+        backdrop_path: null,
+        overview: null,
+        genres: [],
+        rating: null,
+        popularity: null,
+        status: 'Ended',
+        lifecycle_status: 'ended',
+        tmdb_id: 1396,
+        anilist_id: null,
+        igdb_id: null,
+        steam_id: null,
+        parent_id: null,
+        franchise_id: null,
+        season_number: null,
+        episode_number: null,
+        runtime: null,
+        still_path: null,
+        unaired: false,
+        created_at: new Date('2026-05-10T12:00:00Z'),
+        updated_at: new Date('2026-05-12T12:00:00Z'),
+        ...mediaOverrides,
+      },
+      ...overrides,
+    })
+
+    it('formats progressLabel as "S{n}E{m} / {total}" when watched episodes exist', async () => {
+      const entry = tvEntry()
+      dbMock.userEntry.findMany.mockImplementation((args: { where?: { media_item?: { parent_id?: unknown } } }) => {
+        if (args?.where?.media_item?.parent_id) {
+          // Second call: watched episodes lookup.
+          return Promise.resolve([
+            {
+              media_item: { parent_id: 'tv-show-1', season_number: 2, episode_number: 4 },
+            },
+            {
+              media_item: { parent_id: 'tv-show-1', season_number: 2, episode_number: 3 },
+            },
+            {
+              media_item: { parent_id: 'tv-show-1', season_number: 1, episode_number: 1 },
+            },
+          ])
+        }
+        return Promise.resolve([entry])
+      })
+      dbMock.mediaItem.groupBy.mockResolvedValue([
+        { parent_id: 'tv-show-1', _count: { id: 10 } },
+      ])
+      const { GET } = await import('@/app/api/library/route')
+      const res = await GET(makeRequest('/api/library?type=TV_SHOW'))
+      const body = await res.json()
+      expect(body.items).toHaveLength(1)
+      expect(body.items[0].progressLabel).toBe('S2E4 / 10')
+      expect(body.items[0].progressPct).toBe(30)
+    })
+
+    it('returns null progressLabel for PLAN_TO_WATCH TV show with no aired episodes', async () => {
+      const entry = tvEntry({ status: WatchStatus.PLAN_TO_WATCH })
+      dbMock.userEntry.findMany.mockImplementation((args: { where?: { media_item?: { parent_id?: unknown } } }) => {
+        if (args?.where?.media_item?.parent_id) return Promise.resolve([])
+        return Promise.resolve([entry])
+      })
+      dbMock.mediaItem.groupBy.mockResolvedValue([])
+      const { GET } = await import('@/app/api/library/route')
+      const res = await GET(makeRequest('/api/library?type=TV_SHOW'))
+      const body = await res.json()
+      expect(body.items[0].progressLabel).toBeNull()
+      expect(body.items[0].progressPct).toBeNull()
+    })
+
+    it('applies lifecycle=continuing filter to media_item.lifecycle_status', async () => {
+      dbMock.userEntry.findMany.mockResolvedValue([])
+      dbMock.mediaItem.groupBy.mockResolvedValue([])
+      const { GET } = await import('@/app/api/library/route')
+      await GET(makeRequest('/api/library?type=TV_SHOW&lifecycle=continuing'))
+      const call = dbMock.userEntry.findMany.mock.calls[0][0]
+      expect(call.where.media_item.lifecycle_status).toBe('continuing')
+    })
+
+    it('applies lifecycle=in_progress composite (WATCHING + lifecycle_status=continuing)', async () => {
+      dbMock.userEntry.findMany.mockResolvedValue([])
+      dbMock.mediaItem.groupBy.mockResolvedValue([])
+      const { GET } = await import('@/app/api/library/route')
+      await GET(makeRequest('/api/library?type=TV_SHOW&lifecycle=in_progress'))
+      const call = dbMock.userEntry.findMany.mock.calls[0][0]
+      expect(call.where.status).toBe(WatchStatus.WATCHING)
+      expect(call.where.media_item.lifecycle_status).toBe('continuing')
+    })
+
+    it('rejects invalid lifecycle values with 400', async () => {
+      const { GET } = await import('@/app/api/library/route')
+      const res = await GET(makeRequest('/api/library?lifecycle=cancelled'))
+      expect(res.status).toBe(400)
+    })
   })
 })

--- a/app/api/library/route.ts
+++ b/app/api/library/route.ts
@@ -1,7 +1,14 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { z } from 'zod'
 import { type MediaItem, MediaType, WatchStatus } from '@prisma/client'
-import { findLibraryItems, type LibrarySortKey, type UserEntryWithMedia } from '@/lib/db/library'
+import {
+  findLibraryItems,
+  formatTvProgressLabel,
+  formatTvProgressPct,
+  type LibrarySortKey,
+  type LifecycleStatus,
+  type UserEntryWithMedia,
+} from '@/lib/db/library'
 import { logger } from '@/lib/logger'
 import { withRequest } from '@/lib/request-context'
 import type { LibraryItem, LibraryListResponse } from '@/lib/types/library'
@@ -24,26 +31,39 @@ export const dynamic = 'force-dynamic'
 // callers); `sort` is the 6.3 param using the LibrarySortKey union. When both
 // are absent the default is `recently_added`. When both are present, `sort`
 // wins so 6.3+ callers do not need to know about the legacy enum.
-const LibraryQuerySchema = z.object({
-  type: z.nativeEnum(MediaType).optional(),
-  status: z.nativeEnum(WatchStatus).optional(),
-  search: z.string().min(1).max(100).optional(),
-  order: z
-    .enum(['updated_at_desc', 'created_at_desc', 'release_date_desc'])
-    .optional(),
-  sort: z
-    .enum([
-      'recently_added',
-      'recently_created',
-      'release_date_desc',
-      'title_asc',
-      'status_asc',
-      'rating_desc',
-    ])
-    .optional(),
-  limit: z.coerce.number().int().positive().max(200).optional().default(20),
-  released_within_days: z.coerce.number().int().positive().max(3650).optional(),
-})
+const LibraryQuerySchema = z
+  .object({
+    type: z.nativeEnum(MediaType).optional(),
+    status: z.nativeEnum(WatchStatus).optional(),
+    search: z.string().min(1).max(100).optional(),
+    order: z
+      .enum(['updated_at_desc', 'created_at_desc', 'release_date_desc'])
+      .optional(),
+    sort: z
+      .enum([
+        'recently_added',
+        'recently_created',
+        'release_date_desc',
+        'title_asc',
+        'status_asc',
+        'rating_desc',
+      ])
+      .optional(),
+    limit: z.coerce.number().int().positive().max(200).optional().default(20),
+    released_within_days: z.coerce.number().int().positive().max(3650).optional(),
+    lifecycle: z.enum(['in_progress', 'continuing', 'ended']).optional(),
+  })
+  // The `in_progress` lifecycle filter is a single-click composite for
+  // WATCHING + lifecycle_status='continuing'. Allowing an explicit `status`
+  // alongside it would silently override the composite, which is surprising.
+  // Reject the combination so the API surface honours the override.
+  .refine(
+    (v) => !(v.status !== undefined && v.lifecycle === 'in_progress'),
+    {
+      message: '`status` cannot be combined with `lifecycle=in_progress` (the composite already pins status to WATCHING)',
+      path: ['lifecycle'],
+    },
+  )
 
 function resolveSort(
   sort: LibrarySortKey | undefined,
@@ -68,32 +88,36 @@ function deriveReleaseDate(mediaItem: MediaItem): string | null {
 }
 
 function formatProgressLabel(
-  mediaType: MediaType,
-  status: WatchStatus,
-  progress: number,
+  entry: UserEntryWithMedia,
 ): string | null {
-  if (mediaType === MediaType.MOVIE) {
+  const { type } = entry.media_item
+  const { status, progress } = entry
+  if (type === MediaType.MOVIE) {
     if (status === WatchStatus.COMPLETED) return 'WATCHED'
     if (status === WatchStatus.WATCHING && progress > 0 && progress < 100) {
       return `${progress}% WATCHED`
     }
     return status.replaceAll('_', ' ')
   }
-  // TV / anime / manga / games progress formatting lands in Stories 7-9 when
-  // those media types become addable. For now return null and let the client
-  // hide the line.
+  if (type === MediaType.TV_SHOW) {
+    return formatTvProgressLabel(status, entry.episodeStats)
+  }
+  // anime / manga / games progress formatting lands in Stories 8-9.
   return null
 }
 
 function formatProgressPct(
-  mediaType: MediaType,
-  status: WatchStatus,
-  progress: number,
+  entry: UserEntryWithMedia,
 ): number | null {
-  if (mediaType === MediaType.MOVIE) {
+  const { type } = entry.media_item
+  const { status, progress } = entry
+  if (type === MediaType.MOVIE) {
     if (status === WatchStatus.COMPLETED) return 100
     if (status === WatchStatus.WATCHING) return Math.min(100, Math.max(0, progress))
     return null
+  }
+  if (type === MediaType.TV_SHOW) {
+    return formatTvProgressPct(entry.episodeStats)
   }
   return null
 }
@@ -117,8 +141,8 @@ function serializeLibraryItem(entry: UserEntryWithMedia): LibraryItem {
     posterPath: mediaItem.poster_path,
     year: deriveYear(mediaItem),
     releaseDate: deriveReleaseDate(mediaItem),
-    progressLabel: formatProgressLabel(mediaItem.type, entry.status, entry.progress),
-    progressPct: formatProgressPct(mediaItem.type, entry.status, entry.progress),
+    progressLabel: formatProgressLabel(entry),
+    progressPct: formatProgressPct(entry),
     sourceLabel: deriveSourceLabel(mediaItem),
     tmdbId: mediaItem.tmdb_id,
     anilistId: mediaItem.anilist_id,
@@ -143,7 +167,11 @@ async function handler(req: NextRequest): Promise<NextResponse> {
     )
   }
 
-  const { type, status, search, order, sort, limit, released_within_days } = parsed.data
+  const { type, status, search, order, sort, limit, released_within_days, lifecycle } = parsed.data
+
+  const lifecycleStatus: LifecycleStatus | undefined =
+    lifecycle === 'continuing' || lifecycle === 'ended' ? lifecycle : undefined
+  const lifecycleInProgress = lifecycle === 'in_progress'
 
   const entries = await findLibraryItems({
     mediaType: type,
@@ -152,6 +180,8 @@ async function handler(req: NextRequest): Promise<NextResponse> {
     sort: resolveSort(sort, order),
     limit,
     releasedWithinDays: released_within_days,
+    lifecycleStatus,
+    lifecycleInProgress,
   })
 
   const items = entries.map(serializeLibraryItem)

--- a/app/api/media/__tests__/route.test.ts
+++ b/app/api/media/__tests__/route.test.ts
@@ -18,6 +18,8 @@ vi.mock('@/lib/logger', () => ({
 
 const tmdbMock = vi.hoisted(() => ({
   getMovie: vi.fn(),
+  getTv: vi.fn(),
+  getTvSeason: vi.fn(),
 }))
 
 vi.mock('@/lib/api/tmdb', async () => {
@@ -26,8 +28,17 @@ vi.mock('@/lib/api/tmdb', async () => {
   return {
     ...actual,
     getMovie: tmdbMock.getMovie,
+    getTv: tmdbMock.getTv,
+    getTvSeason: tmdbMock.getTvSeason,
   }
 })
+
+const txMock = vi.hoisted(() => ({
+  mediaItem: {
+    create: vi.fn(),
+    createMany: vi.fn(),
+  },
+}))
 
 const dbMock = vi.hoisted(() => ({
   mediaItem: {
@@ -39,6 +50,7 @@ const dbMock = vi.hoisted(() => ({
   userEntry: {
     create: vi.fn(),
   },
+  $transaction: vi.fn(),
 }))
 
 vi.mock('@/lib/db', () => ({ db: dbMock }))
@@ -66,6 +78,12 @@ beforeEach(() => {
   vi.resetModules()
   vi.resetAllMocks()
   for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+  // Default: $transaction runs its callback against the chain-mocked tx so
+  // each test only needs to wire `txMock.mediaItem.create` / `createMany`
+  // behaviour, not the transaction shell.
+  dbMock.$transaction.mockImplementation(
+    async (fn: (tx: typeof txMock) => unknown) => fn(txMock),
+  )
 })
 
 afterEach(() => {
@@ -221,14 +239,14 @@ describe('POST /api/media', () => {
       )
     })
 
-    it('returns 501 for unwired type (tmdb + TV_SHOW)', async () => {
+    it('returns 501 for unwired type (tmdb + ANIME)', async () => {
       const { POST } = await import('@/app/api/media/route')
 
       const res = await POST(
         postRequest({
           source: 'tmdb',
           sourceId: 1399,
-          type: MediaType.TV_SHOW,
+          type: MediaType.ANIME,
         }),
       )
 
@@ -537,6 +555,383 @@ describe('POST /api/media', () => {
         expect.objectContaining({
           event: 'media.constraint_violation',
           code: 'P2004',
+        }),
+        expect.any(String),
+      )
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TV branch (Story 7.2a)
+// ---------------------------------------------------------------------------
+
+const validTmdbTv = {
+  id: 1396,
+  name: 'Breaking Bad',
+  original_name: 'Breaking Bad',
+  overview: 'A high school chemistry teacher diagnosed with...',
+  first_air_date: '2008-01-20',
+  last_air_date: '2013-09-29',
+  poster_path: '/poster.jpg',
+  backdrop_path: '/backdrop.jpg',
+  vote_average: 8.9,
+  popularity: 240.5,
+  genres: [{ id: 18, name: 'Drama' }],
+  status: 'Ended',
+  seasons: [
+    { id: 9001, season_number: 1, name: 'Season 1', episode_count: 2 },
+    { id: 9002, season_number: 2, name: 'Season 2', episode_count: 2 },
+  ],
+}
+
+function seasonPayload(seasonNumber: number, episodeCount: number) {
+  return {
+    id: 9000 + seasonNumber,
+    season_number: seasonNumber,
+    name: `Season ${seasonNumber}`,
+    episodes: Array.from({ length: episodeCount }, (_, idx) => ({
+      id: seasonNumber * 1000 + idx + 1,
+      name: `S${seasonNumber}E${idx + 1}`,
+      overview: 'episode overview',
+      air_date: '2008-01-20',
+      episode_number: idx + 1,
+      season_number: seasonNumber,
+      still_path: '/still.jpg',
+      vote_average: 8.0,
+      runtime: 47,
+    })),
+  }
+}
+
+function newShowRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'cm_show_1',
+    type: MediaType.TV_SHOW,
+    title: 'Breaking Bad',
+    original_title: 'Breaking Bad',
+    release_date: new Date('2008-01-20T00:00:00Z'),
+    end_date: new Date('2013-09-29T00:00:00Z'),
+    poster_path: '/poster.jpg',
+    backdrop_path: '/backdrop.jpg',
+    overview: 'A high school chemistry teacher diagnosed with...',
+    genres: ['Drama'],
+    rating: 8.9,
+    popularity: 240.5,
+    status: 'Ended',
+    lifecycle_status: 'ended',
+    tmdb_id: 1396,
+    anilist_id: null,
+    igdb_id: null,
+    steam_id: null,
+    parent_id: null,
+    franchise_id: null,
+    season_number: null,
+    episode_number: null,
+    runtime: null,
+    still_path: null,
+    unaired: false,
+    created_at: new Date('2026-05-15T00:00:00Z'),
+    updated_at: new Date('2026-05-15T00:00:00Z'),
+    user_entry: null,
+    ...overrides,
+  }
+}
+
+describe('POST /api/media (TV branch — Story 7.2a)', () => {
+  describe('happy path', () => {
+    it('returns 201 with show + UserEntry, runs transaction with createMany for episodes', async () => {
+      tmdbMock.getTv.mockResolvedValue(validTmdbTv)
+      tmdbMock.getTvSeason
+        .mockResolvedValueOnce(seasonPayload(1, 2))
+        .mockResolvedValueOnce(seasonPayload(2, 2))
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      dbMock.mediaItem.findMany.mockResolvedValue([])
+      txMock.mediaItem.create.mockResolvedValue(
+        newShowRow({ user_entry: newUserEntry({ media_item_id: 'cm_show_1' }) }),
+      )
+      txMock.mediaItem.createMany.mockResolvedValue({ count: 4 })
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 1396, type: MediaType.TV_SHOW }),
+      )
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.mediaItem.tmdb_id).toBe(1396)
+      expect(body.mediaItem.type).toBe(MediaType.TV_SHOW)
+      expect(body.mediaItem.user_entry.status).toBe(WatchStatus.PLAN_TO_WATCH)
+      expect(body.merged).toBe(false)
+      expect(tmdbMock.getTv).toHaveBeenCalledWith(1396)
+      expect(tmdbMock.getTvSeason).toHaveBeenCalledTimes(2)
+      expect(dbMock.$transaction).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({ timeout: 30_000 }),
+      )
+      expect(txMock.mediaItem.createMany).toHaveBeenCalledTimes(1)
+      const createManyArg = txMock.mediaItem.createMany.mock.calls[0][0]
+      expect(createManyArg.data).toHaveLength(4)
+      expect(createManyArg.data[0]).toEqual(
+        expect.objectContaining({
+          type: MediaType.TV_EPISODE,
+          parent_id: 'cm_show_1',
+        }),
+      )
+    })
+
+    it('passes nested user_entry create on the show insert (single UserEntry per show)', async () => {
+      tmdbMock.getTv.mockResolvedValue(validTmdbTv)
+      tmdbMock.getTvSeason
+        .mockResolvedValueOnce(seasonPayload(1, 2))
+        .mockResolvedValueOnce(seasonPayload(2, 2))
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      dbMock.mediaItem.findMany.mockResolvedValue([])
+      txMock.mediaItem.create.mockResolvedValue(
+        newShowRow({ user_entry: newUserEntry({ media_item_id: 'cm_show_1' }) }),
+      )
+      txMock.mediaItem.createMany.mockResolvedValue({ count: 4 })
+      const { POST } = await import('@/app/api/media/route')
+
+      await POST(
+        postRequest({ source: 'tmdb', sourceId: 1396, type: MediaType.TV_SHOW }),
+      )
+
+      const showCreateArg = txMock.mediaItem.create.mock.calls[0][0]
+      expect(showCreateArg.data.user_entry).toEqual({
+        create: { status: WatchStatus.PLAN_TO_WATCH, progress: 0 },
+      })
+      // Episodes do NOT carry nested user_entry creates.
+      const createManyArg = txMock.mediaItem.createMany.mock.calls[0][0]
+      for (const episode of createManyArg.data) {
+        expect(episode).not.toHaveProperty('user_entry')
+      }
+    })
+  })
+
+  describe('idempotent fast-path', () => {
+    it('returns 200 + zero TMDB calls when the show already exists with UserEntry', async () => {
+      const existing = newShowRow({
+        user_entry: newUserEntry({ media_item_id: 'cm_show_1' }),
+      })
+      dbMock.mediaItem.findUnique.mockResolvedValue(existing)
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 1396, type: MediaType.TV_SHOW }),
+      )
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.merged).toBe(false)
+      expect(tmdbMock.getTv).not.toHaveBeenCalled()
+      expect(tmdbMock.getTvSeason).not.toHaveBeenCalled()
+      expect(dbMock.$transaction).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('cross-source merge (show-only, episodes discarded)', () => {
+    it('patches source ID on existing TV_SHOW row matching title + year, returns merged: true', async () => {
+      tmdbMock.getTv.mockResolvedValue(validTmdbTv)
+      tmdbMock.getTvSeason
+        .mockResolvedValueOnce(seasonPayload(1, 2))
+        .mockResolvedValueOnce(seasonPayload(2, 2))
+      // No existing by tmdb_id.
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      // But a cross-source TV row with matching title+year, tmdb_id null.
+      const anilistShow = newShowRow({
+        id: 'cm_anilist_show',
+        tmdb_id: null,
+        anilist_id: 5678,
+        user_entry: newUserEntry({ media_item_id: 'cm_anilist_show' }),
+      })
+      dbMock.mediaItem.findMany.mockResolvedValue([anilistShow])
+      dbMock.mediaItem.update.mockResolvedValue({
+        ...anilistShow,
+        tmdb_id: 1396,
+      })
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 1396, type: MediaType.TV_SHOW }),
+      )
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.merged).toBe(true)
+      expect(body.mediaItem.tmdb_id).toBe(1396)
+      expect(body.mediaItem.anilist_id).toBe(5678)
+      // Episodes from inbound TMDB payload are DISCARDED on cross-source merge.
+      expect(dbMock.$transaction).not.toHaveBeenCalled()
+      expect(txMock.mediaItem.createMany).not.toHaveBeenCalled()
+    })
+
+    it('does NOT cross-merge against a MOVIE row with the same title + year', async () => {
+      tmdbMock.getTv.mockResolvedValue(validTmdbTv)
+      tmdbMock.getTvSeason
+        .mockResolvedValueOnce(seasonPayload(1, 2))
+        .mockResolvedValueOnce(seasonPayload(2, 2))
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      // A MOVIE row with the same title + year — must NOT merge with an
+      // inbound TV_SHOW.
+      dbMock.mediaItem.findMany.mockResolvedValue([
+        newMediaItem({
+          id: 'cm_movie_collision',
+          type: MediaType.MOVIE,
+          title: 'Breaking Bad',
+          release_date: new Date('2008-01-20T00:00:00Z'),
+          tmdb_id: null,
+        }),
+      ])
+      txMock.mediaItem.create.mockResolvedValue(
+        newShowRow({ user_entry: newUserEntry({ media_item_id: 'cm_show_1' }) }),
+      )
+      txMock.mediaItem.createMany.mockResolvedValue({ count: 4 })
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 1396, type: MediaType.TV_SHOW }),
+      )
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.merged).toBe(false)
+      expect(dbMock.mediaItem.update).not.toHaveBeenCalled()
+      expect(dbMock.$transaction).toHaveBeenCalled()
+    })
+  })
+
+  describe('empty seasons', () => {
+    it('inserts the show with zero episodes when every season has episode_count === 0', async () => {
+      tmdbMock.getTv.mockResolvedValue({
+        ...validTmdbTv,
+        seasons: [
+          { id: 9001, season_number: 1, name: 'Season 1', episode_count: 0 },
+          { id: 9002, season_number: 2, name: 'Season 2', episode_count: 0 },
+        ],
+      })
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      dbMock.mediaItem.findMany.mockResolvedValue([])
+      txMock.mediaItem.create.mockResolvedValue(
+        newShowRow({ user_entry: newUserEntry({ media_item_id: 'cm_show_1' }) }),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 1396, type: MediaType.TV_SHOW }),
+      )
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.merged).toBe(false)
+      // No season fetches because every season filtered out.
+      expect(tmdbMock.getTvSeason).not.toHaveBeenCalled()
+      // Transaction ran but createMany was never called (episodes: []).
+      expect(dbMock.$transaction).toHaveBeenCalled()
+      expect(txMock.mediaItem.createMany).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('error paths', () => {
+    it('returns 422 when the TV normaliser throws ZodError (tampered TMDB payload)', async () => {
+      tmdbMock.getTv.mockResolvedValue({ ...validTmdbTv, id: 'not-a-number' })
+      // No season fetches because the normaliser fails before persistence.
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 1396, type: MediaType.TV_SHOW }),
+      )
+
+      expect(res.status).toBe(422)
+      const body = await res.json()
+      expect(body.error).toBe('normalise_failed')
+      expect(body.issues).toBeDefined()
+      expect(dbMock.$transaction).not.toHaveBeenCalled()
+    })
+
+    it('returns 502 when getTv throws TmdbApiError', async () => {
+      const { TmdbApiError } = await import('@/lib/api/tmdb')
+      tmdbMock.getTv.mockRejectedValue(
+        new TmdbApiError('TMDB HTTP 500: /tv/1396', {
+          endpoint: '/tv/1396',
+          httpStatus: 500,
+        }),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 1396, type: MediaType.TV_SHOW }),
+      )
+
+      expect(res.status).toBe(502)
+      const body = await res.json()
+      expect(body.error).toBe('upstream_failed')
+      expect(dbMock.$transaction).not.toHaveBeenCalled()
+    })
+
+    it('returns 200 idempotent when transaction P2002 + findExistingBySourceId finds the racing show', async () => {
+      tmdbMock.getTv.mockResolvedValue(validTmdbTv)
+      tmdbMock.getTvSeason
+        .mockResolvedValueOnce(seasonPayload(1, 2))
+        .mockResolvedValueOnce(seasonPayload(2, 2))
+      dbMock.mediaItem.findUnique
+        .mockResolvedValueOnce(null) // fast-path miss
+        .mockResolvedValueOnce(
+          newShowRow({ user_entry: newUserEntry({ media_item_id: 'cm_show_1' }) }),
+        ) // post-P2002 race recovery
+      dbMock.mediaItem.findMany.mockResolvedValue([])
+      dbMock.$transaction.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError(
+          'Unique constraint failed on the fields: (`tmdb_id`)',
+          { code: 'P2002', clientVersion: '6.0.0' },
+        ),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 1396, type: MediaType.TV_SHOW }),
+      )
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.merged).toBe(false)
+      expect(body.mediaItem.tmdb_id).toBe(1396)
+    })
+
+    it('returns 500 cross_type_tmdb_id_collision when transaction P2002 + no racing show found', async () => {
+      tmdbMock.getTv.mockResolvedValue(validTmdbTv)
+      tmdbMock.getTvSeason
+        .mockResolvedValueOnce(seasonPayload(1, 2))
+        .mockResolvedValueOnce(seasonPayload(2, 2))
+      // Fast-path miss AND post-P2002 lookup miss → no racing show, so the
+      // P2002 must have come from an episode tmdb_id colliding with a
+      // foreign MediaItem row.
+      dbMock.mediaItem.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+      dbMock.mediaItem.findMany.mockResolvedValue([])
+      dbMock.$transaction.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError(
+          'Unique constraint failed on the fields: (`tmdb_id`)',
+          { code: 'P2002', clientVersion: '6.0.0' },
+        ),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({ source: 'tmdb', sourceId: 1396, type: MediaType.TV_SHOW }),
+      )
+
+      expect(res.status).toBe(500)
+      const body = await res.json()
+      expect(body.error).toBe('cross_type_tmdb_id_collision')
+      expect(body.code).toBe('P2002')
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'media.tmdb_id_collision',
+          source: 'tmdb',
+          sourceId: 1396,
+          type: MediaType.TV_SHOW,
         }),
         expect.any(String),
       )

--- a/app/api/media/route.ts
+++ b/app/api/media/route.ts
@@ -8,6 +8,7 @@ import { TmdbApiError } from '@/lib/api/tmdb'
 import {
   getDispatcher,
   type AddMediaSource,
+  type NormalisedShowWithEpisodes,
 } from '@/lib/search/media-dispatcher'
 import { normaliseTitle } from '@/lib/search/federation'
 
@@ -218,7 +219,9 @@ async function handler(req: NextRequest): Promise<NextResponse> {
     throw err
   }
 
-  let normalised: Prisma.MediaItemCreateInput
+  let normalised:
+    | Prisma.MediaItemCreateInput
+    | NormalisedShowWithEpisodes
   try {
     normalised = dispatcher.normalise(raw)
   } catch (err) {
@@ -240,6 +243,19 @@ async function handler(req: NextRequest): Promise<NextResponse> {
     throw err
   }
 
+  if ('episodes' in normalised) {
+    return persistShowWithEpisodes(normalised, source, sourceId, type)
+  }
+
+  return persistSingleMediaItem(normalised, source, sourceId, type)
+}
+
+async function persistSingleMediaItem(
+  normalised: Prisma.MediaItemCreateInput,
+  source: AddMediaSource,
+  sourceId: number,
+  type: MediaType,
+): Promise<NextResponse> {
   try {
     const releaseYear = normalised.release_date instanceof Date
       ? normalised.release_date.getUTCFullYear()
@@ -284,25 +300,132 @@ async function handler(req: NextRequest): Promise<NextResponse> {
           )
         }
       }
-      logger.warn(
-        {
-          event: 'media.constraint_violation',
-          source,
-          sourceId,
-          type,
-          code: err.code,
-          err,
-        },
-        'database constraint violation',
-      )
-      // Omit err.message in the response to avoid leaking schema column names.
-      return jsonResponse(
-        { error: 'constraint_violation', code: err.code },
-        400,
-      )
+      return logAndReturnConstraintViolation(err, source, sourceId, type)
     }
     throw err
   }
+}
+
+async function persistShowWithEpisodes(
+  normalised: NormalisedShowWithEpisodes,
+  source: AddMediaSource,
+  sourceId: number,
+  type: MediaType,
+): Promise<NextResponse> {
+  try {
+    const releaseYear = normalised.show.release_date instanceof Date
+      ? normalised.show.release_date.getUTCFullYear()
+      : new Date(normalised.show.release_date as string).getUTCFullYear()
+    const normalisedKey = normaliseTitle(normalised.show.title)
+    // Skip cross-merge when the normaliser fell back to the 1970 sentinel —
+    // every undated item shares that year bucket and would falsely collide.
+    const candidates =
+      releaseYear === 1970
+        ? []
+        : await findCrossSourceCandidates(source, releaseYear)
+    // Filter to TV_SHOW only: a 1984 movie and a 1984 TV show with the same
+    // normalised title (e.g. "Dune") must not collapse.
+    const crossMatch = candidates.find(
+      (c) =>
+        c.type === MediaType.TV_SHOW &&
+        normaliseTitle(c.title) === normalisedKey,
+    )
+
+    if (crossMatch) {
+      // Patch the source ID onto the existing show row; the inbound episodes
+      // are DISCARDED — the cross-source sibling's episodes from the original
+      // adapter remain authoritative (per OI #6 in the impl-artifact).
+      const patched = await patchSourceId(crossMatch.id, source, sourceId)
+      const ensured = await ensureUserEntry(patched)
+      return jsonResponse(
+        { mediaItem: ensured.mediaItem, merged: true },
+        ensured.created ? 201 : 200,
+      )
+    }
+
+    const created: MediaItemWithUserEntry = await db.$transaction(
+      async (tx) => {
+        const showRow = await tx.mediaItem.create({
+          data: {
+            ...normalised.show,
+            user_entry: { create: NEW_USER_ENTRY },
+          },
+          include: { user_entry: true },
+        })
+        if (normalised.episodes.length > 0) {
+          await tx.mediaItem.createMany({
+            data: normalised.episodes.map((e) => ({
+              ...(e as Prisma.MediaItemCreateManyInput),
+              parent_id: showRow.id,
+            })),
+          })
+        }
+        return showRow
+      },
+      { timeout: 30_000 },
+    )
+    return jsonResponse({ mediaItem: created, merged: false }, 201)
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError) {
+      if (err.code === 'P2002') {
+        // Show-level race: a concurrent POST inserted the same `sourceId`
+        // between the fast-path check and the transaction's show create.
+        const racedExisting = await findExistingBySourceId(source, sourceId)
+        if (racedExisting) {
+          const ensured = await ensureUserEntry(racedExisting)
+          return jsonResponse(
+            { mediaItem: ensured.mediaItem, merged: false },
+            200,
+          )
+        }
+        // Episode tmdb_id collided with a foreign MediaItem row. Atomic
+        // transactions can't leave orphan episodes, so the "same-parent
+        // re-import" case is unreachable here — this is a real cross-context
+        // collision worth surfacing for operator investigation. The schema
+        // fix is the @@unique([type, tmdb_id]) follow-up migration (ECH-4).
+        logger.error(
+          {
+            event: 'media.tmdb_id_collision',
+            source,
+            sourceId,
+            type,
+            err,
+          },
+          'episode tmdb_id collided with existing MediaItem of a different context',
+        )
+        return jsonResponse(
+          { error: 'cross_type_tmdb_id_collision', code: 'P2002' },
+          500,
+        )
+      }
+      return logAndReturnConstraintViolation(err, source, sourceId, type)
+    }
+    throw err
+  }
+}
+
+function logAndReturnConstraintViolation(
+  err: Prisma.PrismaClientKnownRequestError,
+  source: AddMediaSource,
+  sourceId: number,
+  type: MediaType,
+): NextResponse {
+  logger.warn(
+    {
+      event: 'media.constraint_violation',
+      source,
+      sourceId,
+      type,
+      code: err.code,
+      err,
+    },
+    'database constraint violation',
+  )
+  // Omit err.message in the response to avoid leaking schema column names.
+  return jsonResponse(
+    { error: 'constraint_violation', code: err.code },
+    400,
+  )
 }
 
 export const POST = withRequest<NextRequest, NextResponse>(handler)

--- a/app/api/progress/__tests__/route.test.ts
+++ b/app/api/progress/__tests__/route.test.ts
@@ -20,6 +20,11 @@ const dbMock = vi.hoisted(() => ({
   userEntry: {
     findUnique: vi.fn(),
     update: vi.fn(),
+    create: vi.fn(),
+    upsert: vi.fn(),
+  },
+  mediaItem: {
+    findUnique: vi.fn(),
   },
 }))
 
@@ -128,8 +133,12 @@ describe('PUT /api/progress', () => {
     expect(dbMock.userEntry.findUnique).not.toHaveBeenCalled()
   })
 
-  it('returns 404 when UserEntry does not exist', async () => {
+  it('returns 404 when UserEntry does not exist AND MediaItem is a MOVIE', async () => {
     dbMock.userEntry.findUnique.mockResolvedValue(null)
+    dbMock.mediaItem.findUnique.mockResolvedValue({
+      id: 'missing',
+      type: MediaType.MOVIE,
+    })
     const { PUT } = await import('@/app/api/progress/route')
     const res = await PUT(
       putRequest({ mediaItemId: 'missing', status: WatchStatus.WATCHING }),
@@ -138,6 +147,87 @@ describe('PUT /api/progress', () => {
     const body = await res.json()
     expect(body.error).toBe('not_in_library')
     expect(dbMock.userEntry.update).not.toHaveBeenCalled()
+    expect(dbMock.userEntry.upsert).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when UserEntry does not exist AND MediaItem is missing entirely', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(null)
+    dbMock.mediaItem.findUnique.mockResolvedValue(null)
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(
+      putRequest({ mediaItemId: 'missing', status: WatchStatus.WATCHING }),
+    )
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.error).toBe('not_in_library')
+  })
+
+  it('lazy-creates UserEntry via upsert when MediaItem is a TV_EPISODE (Story 7.5 AC-5)', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(null)
+    dbMock.mediaItem.findUnique.mockResolvedValue({
+      id: 'ep-1',
+      type: MediaType.TV_EPISODE,
+    })
+    dbMock.userEntry.upsert.mockResolvedValue({
+      id: 'new-entry-1',
+      media_item_id: 'ep-1',
+      status: WatchStatus.COMPLETED,
+      user_rating: null,
+      progress: 0,
+      notes: null,
+      started_at: null,
+      completed_at: null,
+      created_at: new Date('2026-05-15T12:00:00Z'),
+      updated_at: new Date('2026-05-15T12:00:00Z'),
+    })
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(
+      putRequest({ mediaItemId: 'ep-1', status: WatchStatus.COMPLETED }),
+    )
+    expect(res.status).toBe(201)
+    expect(dbMock.userEntry.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { media_item_id: 'ep-1' },
+        create: expect.objectContaining({
+          media_item_id: 'ep-1',
+          status: WatchStatus.COMPLETED,
+          progress: 0,
+        }),
+        update: expect.objectContaining({
+          status: WatchStatus.COMPLETED,
+          progress: 0,
+        }),
+      }),
+    )
+    expect(dbMock.userEntry.update).not.toHaveBeenCalled()
+    const body = await res.json()
+    expect(body.status).toBe(WatchStatus.COMPLETED)
+  })
+
+  it('lazy-create defaults to PLAN_TO_WATCH when no status is supplied (TV_EPISODE)', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(null)
+    dbMock.mediaItem.findUnique.mockResolvedValue({
+      id: 'ep-1',
+      type: MediaType.TV_EPISODE,
+    })
+    dbMock.userEntry.upsert.mockResolvedValue({
+      id: 'new-entry-1',
+      media_item_id: 'ep-1',
+      status: WatchStatus.PLAN_TO_WATCH,
+      user_rating: null,
+      progress: 5,
+      notes: null,
+      started_at: null,
+      completed_at: null,
+      created_at: new Date('2026-05-15T12:00:00Z'),
+      updated_at: new Date('2026-05-15T12:00:00Z'),
+    })
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(putRequest({ mediaItemId: 'ep-1', progress: 5 }))
+    expect(res.status).toBe(201)
+    const call = dbMock.userEntry.upsert.mock.calls[0][0]
+    expect(call.create.status).toBe(WatchStatus.PLAN_TO_WATCH)
+    expect(call.create.progress).toBe(5)
   })
 
   it('updates status and returns the serialized entry', async () => {

--- a/app/api/progress/bulk/__tests__/route.test.ts
+++ b/app/api/progress/bulk/__tests__/route.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { MediaType, WatchStatus } from '@prisma/client'
+
+const loggerMock = vi.hoisted(() => ({
+  fatal: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: loggerMock,
+  createLogger: () => loggerMock,
+}))
+
+const txMock = vi.hoisted(() => ({
+  userEntry: { upsert: vi.fn() },
+}))
+
+const dbMock = vi.hoisted(() => ({
+  mediaItem: { findMany: vi.fn() },
+  $transaction: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({ db: dbMock }))
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.resetAllMocks()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+  dbMock.$transaction.mockImplementation(
+    async (fn: (tx: typeof txMock) => Promise<unknown>) => fn(txMock),
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+function postRequest(body: unknown): NextRequest {
+  return new NextRequest(new URL('http://localhost/api/progress/bulk'), {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('POST /api/progress/bulk', () => {
+  it('rejects scope=season without seasonNumber with 400', async () => {
+    const { POST } = await import('@/app/api/progress/bulk/route')
+    const res = await POST(
+      postRequest({
+        parentId: 'show-1',
+        scope: 'season',
+        status: WatchStatus.COMPLETED,
+      }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects invalid JSON with 400', async () => {
+    const { POST } = await import('@/app/api/progress/bulk/route')
+    const req = new NextRequest(new URL('http://localhost/api/progress/bulk'), {
+      method: 'POST',
+      body: 'not-json',
+      headers: { 'content-type': 'application/json' },
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 405 on GET', async () => {
+    const { POST } = await import('@/app/api/progress/bulk/route')
+    const req = new NextRequest(new URL('http://localhost/api/progress/bulk'), {
+      method: 'GET',
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(405)
+  })
+
+  it('upserts a UserEntry for each aired episode in a season, returns the count', async () => {
+    dbMock.mediaItem.findMany.mockResolvedValue([
+      { id: 'ep-s2e1' },
+      { id: 'ep-s2e2' },
+      { id: 'ep-s2e3' },
+    ])
+    txMock.userEntry.upsert.mockResolvedValue({})
+    const { POST } = await import('@/app/api/progress/bulk/route')
+
+    const res = await POST(
+      postRequest({
+        parentId: 'show-1',
+        scope: 'season',
+        seasonNumber: 2,
+        status: WatchStatus.COMPLETED,
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ updated: 3 })
+    expect(dbMock.mediaItem.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          parent_id: 'show-1',
+          type: MediaType.TV_EPISODE,
+          unaired: false,
+          season_number: 2,
+        },
+        select: { id: true },
+      }),
+    )
+    expect(txMock.userEntry.upsert).toHaveBeenCalledTimes(3)
+    const firstCall = txMock.userEntry.upsert.mock.calls[0][0]
+    expect(firstCall).toEqual({
+      where: { media_item_id: 'ep-s2e1' },
+      create: { media_item_id: 'ep-s2e1', status: WatchStatus.COMPLETED, progress: 0 },
+      update: { status: WatchStatus.COMPLETED },
+    })
+  })
+
+  it('upserts all aired episodes for scope=show (no season_number filter)', async () => {
+    dbMock.mediaItem.findMany.mockResolvedValue([
+      { id: 'ep-1' },
+      { id: 'ep-2' },
+    ])
+    txMock.userEntry.upsert.mockResolvedValue({})
+    const { POST } = await import('@/app/api/progress/bulk/route')
+
+    const res = await POST(
+      postRequest({
+        parentId: 'show-1',
+        scope: 'show',
+        status: WatchStatus.COMPLETED,
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    const where = dbMock.mediaItem.findMany.mock.calls[0][0].where
+    expect(where).toEqual({
+      parent_id: 'show-1',
+      type: MediaType.TV_EPISODE,
+      unaired: false,
+    })
+    expect(where.season_number).toBeUndefined()
+  })
+
+  it('returns updated: 0 + no transaction when no aired episodes match', async () => {
+    dbMock.mediaItem.findMany.mockResolvedValue([])
+    const { POST } = await import('@/app/api/progress/bulk/route')
+
+    const res = await POST(
+      postRequest({
+        parentId: 'show-1',
+        scope: 'season',
+        seasonNumber: 99,
+        status: WatchStatus.COMPLETED,
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.updated).toBe(0)
+    expect(dbMock.$transaction).not.toHaveBeenCalled()
+  })
+
+  it('propagates a transaction rollback when an upsert rejects mid-flight', async () => {
+    dbMock.mediaItem.findMany.mockResolvedValue([
+      { id: 'ep-1' },
+      { id: 'ep-2' },
+    ])
+    // First upsert succeeds; second rejects. Real Prisma rolls back the whole
+    // transaction on any throw inside the callback. The mock's `$transaction`
+    // re-throws what the callback throws; the route's outer error handler
+    // surfaces a non-2xx response (here the rejection bubbles to withRequest).
+    txMock.userEntry.upsert
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('row lock timeout'))
+    const { POST } = await import('@/app/api/progress/bulk/route')
+
+    await expect(
+      POST(
+        postRequest({
+          parentId: 'show-1',
+          scope: 'show',
+          status: WatchStatus.COMPLETED,
+        }),
+      ),
+    ).rejects.toThrow('row lock timeout')
+    // No `updated` response was emitted; the route handler didn't reach the
+    // success path.
+    expect(txMock.userEntry.upsert).toHaveBeenCalledTimes(2)
+  })
+
+  it('passes the 30s timeout to db.$transaction', async () => {
+    dbMock.mediaItem.findMany.mockResolvedValue([{ id: 'ep-1' }])
+    txMock.userEntry.upsert.mockResolvedValue({})
+    const { POST } = await import('@/app/api/progress/bulk/route')
+
+    await POST(
+      postRequest({
+        parentId: 'show-1',
+        scope: 'show',
+        status: WatchStatus.COMPLETED,
+      }),
+    )
+
+    expect(dbMock.$transaction).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ timeout: 30_000 }),
+    )
+  })
+})

--- a/app/api/progress/bulk/route.ts
+++ b/app/api/progress/bulk/route.ts
@@ -1,0 +1,117 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { MediaType, WatchStatus, type Prisma } from '@prisma/client'
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import { withRequest } from '@/lib/request-context'
+
+export const dynamic = 'force-dynamic'
+
+/* `POST /api/progress/bulk`: transactional UserEntry upserts for a season or
+ * a whole TV show. Powers the SeasonAccordion's "Mark Season Watched" and
+ * "Mark Show Watched" actions from Story 7.5. Single-transaction shape so
+ * partial failures don't leave a half-marked season.
+ */
+
+const BulkProgressBodySchema = z
+  .object({
+    parentId: z.string().min(1),
+    scope: z.enum(['season', 'show']),
+    seasonNumber: z.number().int().min(0).optional(),
+    status: z.nativeEnum(WatchStatus),
+  })
+  .refine(
+    (v) => !(v.scope === 'season' && v.seasonNumber === undefined),
+    {
+      message: '`seasonNumber` is required when scope === "season"',
+      path: ['seasonNumber'],
+    },
+  )
+
+function jsonResponse(body: unknown, status: number): NextResponse {
+  return NextResponse.json(body, {
+    status,
+    headers: { 'Cache-Control': 'no-store' },
+  })
+}
+
+async function handler(req: NextRequest): Promise<NextResponse> {
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'method_not_allowed' }, 405)
+  }
+
+  let rawBody: unknown
+  try {
+    rawBody = await req.json()
+  } catch {
+    logger.warn(
+      { event: 'progress.bulk.bad_request', reason: 'invalid_json' },
+      'bulk progress body was not valid JSON',
+    )
+    return jsonResponse({ error: 'invalid_body', reason: 'invalid_json' }, 400)
+  }
+
+  const parsed = BulkProgressBodySchema.safeParse(rawBody)
+  if (!parsed.success) {
+    logger.warn(
+      { event: 'progress.bulk.bad_request', issues: parsed.error.issues },
+      'bulk progress body validation failed',
+    )
+    return jsonResponse(
+      { error: 'invalid_body', issues: parsed.error.issues },
+      400,
+    )
+  }
+
+  const { parentId, scope, seasonNumber, status } = parsed.data
+
+  const where: Prisma.MediaItemWhereInput = {
+    parent_id: parentId,
+    type: MediaType.TV_EPISODE,
+    unaired: false,
+  }
+  if (scope === 'season') {
+    where.season_number = seasonNumber
+  }
+
+  const episodes = await db.mediaItem.findMany({
+    where,
+    select: { id: true },
+  })
+
+  if (episodes.length === 0) {
+    return jsonResponse({ updated: 0 }, 200)
+  }
+
+  // 30s timeout mirrors Story 7.2a's transaction discipline. The callback form
+  // is required to pass options; the array form rejects `timeout`. Sequential
+  // upserts inside the callback are acceptable for the realistic worst case
+  // (Game of Thrones at 73 episodes) and stay simpler than a Promise.all.
+  await db.$transaction(
+    async (tx) => {
+      for (const episode of episodes) {
+        await tx.userEntry.upsert({
+          where: { media_item_id: episode.id },
+          create: { media_item_id: episode.id, status, progress: 0 },
+          update: { status },
+        })
+      }
+    },
+    { timeout: 30_000 },
+  )
+
+  logger.info(
+    {
+      event: 'progress.bulk.ok',
+      parentId,
+      scope,
+      seasonNumber: scope === 'season' ? seasonNumber : null,
+      updated: episodes.length,
+    },
+    'bulk progress upserted',
+  )
+
+  return jsonResponse({ updated: episodes.length }, 200)
+}
+
+export const POST = withRequest<NextRequest, NextResponse>(handler)

--- a/app/api/progress/route.ts
+++ b/app/api/progress/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server'
-import { Prisma, WatchStatus } from '@prisma/client'
+import { MediaType, Prisma, WatchStatus } from '@prisma/client'
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { findUserEntryByMediaItemId } from '@/lib/db/library'
@@ -91,11 +91,59 @@ async function handler(req: NextRequest): Promise<NextResponse> {
 
   const entry = await findUserEntryByMediaItemId(mediaItemId)
   if (!entry) {
-    logger.warn(
-      { event: 'progress.update.not_found', mediaItemId },
-      'no UserEntry for mediaItemId',
+    // TV_EPISODE rows get lazy-created UserEntries on first toggle per
+    // Story 7.5 AC-5: episodes don't ship with UserEntries from the add
+    // flow (Story 7.2a's transaction creates UserEntry only for the show
+    // row). All other types preserve the existing not_in_library path.
+    //
+    // Lazy-create is implemented as `upsert` (not `create`) so concurrent
+    // PUTs for the same episode tmdb_id don't trip P2002 on the
+    // `media_item_id @unique` constraint — both racers converge to the same
+    // row idempotently. See ECH-T19 (Story 7.5 review).
+    const mediaItem = await db.mediaItem.findUnique({
+      where: { id: mediaItemId },
+      select: { id: true, type: true },
+    })
+    if (!mediaItem || mediaItem.type !== MediaType.TV_EPISODE) {
+      logger.warn(
+        { event: 'progress.update.not_found', mediaItemId },
+        'no UserEntry for mediaItemId',
+      )
+      return jsonResponse({ error: 'not_in_library' }, 404)
+    }
+    const lazyStatus =
+      (data.status as WatchStatus | undefined) ?? WatchStatus.PLAN_TO_WATCH
+    const lazyProgress = (data.progress as number | undefined) ?? 0
+    const lazyCompletedAt =
+      completed_at === undefined
+        ? undefined
+        : completed_at === null
+          ? null
+          : new Date(completed_at)
+    const created = await db.userEntry.upsert({
+      where: { media_item_id: mediaItemId },
+      create: {
+        media_item_id: mediaItemId,
+        status: lazyStatus,
+        progress: lazyProgress,
+        ...(lazyCompletedAt !== undefined
+          ? { completed_at: lazyCompletedAt }
+          : {}),
+      },
+      update: {
+        status: lazyStatus,
+        progress: lazyProgress,
+        ...(lazyCompletedAt !== undefined
+          ? { completed_at: lazyCompletedAt }
+          : {}),
+      },
+    })
+    logger.info(
+      { event: 'progress.update.lazy_created', mediaItemId, fieldsApplied },
+      'UserEntry lazy-created for TV episode',
     )
-    return jsonResponse({ error: 'not_in_library' }, 404)
+    const body: ProgressResponse = serializeProgressEntry(created)
+    return jsonResponse(body, 201)
   }
 
   const updated = await db.userEntry.update({

--- a/app/api/search/__tests__/route.test.ts
+++ b/app/api/search/__tests__/route.test.ts
@@ -173,6 +173,50 @@ describe('GET /api/search', () => {
       })
     })
 
+    it('returns movie + TV with same title and year as separate results (AC-3 + AC-4)', async () => {
+      tmdbMock.searchMulti.mockResolvedValue({
+        page: 1,
+        results: [
+          {
+            media_type: 'movie',
+            id: 9999,
+            title: 'The Office',
+            release_date: '2001-08-24',
+            poster_path: '/movie.jpg',
+            vote_average: 6.0,
+            popularity: 5.0,
+          },
+          {
+            media_type: 'tv',
+            id: 2606,
+            name: 'The Office',
+            first_air_date: '2001-08-24',
+            poster_path: '/tv.jpg',
+            vote_average: 8.5,
+          },
+        ],
+        total_pages: 1,
+        total_results: 2,
+      })
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search?q=the%20office'))
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.results).toHaveLength(2)
+      const types = body.results.map((r: { type: string }) => r.type).sort()
+      expect(types).toEqual(['movie', 'tv'])
+      const movieRow = body.results.find(
+        (r: { type: string }) => r.type === 'movie',
+      )
+      const tvRow = body.results.find(
+        (r: { type: string }) => r.type === 'tv',
+      )
+      expect(movieRow.tmdb_id).toBe(9999)
+      expect(tvRow.tmdb_id).toBe(2606)
+    })
+
     it('sets Cache-Control: no-store on success', async () => {
       tmdbMock.searchMulti.mockResolvedValue({
         page: 1,

--- a/components/molecules/EpisodeWatchToggle/EpisodeWatchToggle.tsx
+++ b/components/molecules/EpisodeWatchToggle/EpisodeWatchToggle.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+export type EpisodeWatchToggleProps = {
+  checked: boolean
+  disabled?: boolean
+  label: string
+  onToggle: () => void
+}
+
+export function EpisodeWatchToggle({
+  checked,
+  disabled = false,
+  label,
+  onToggle,
+}: EpisodeWatchToggleProps) {
+  return (
+    <button
+      type='button'
+      role='checkbox'
+      aria-checked={checked}
+      aria-disabled={disabled || undefined}
+      aria-label={label}
+      title={disabled ? 'UNAIRED — CANNOT MARK WATCHED' : label}
+      disabled={disabled}
+      className='episode-watch-toggle crt-pixel-checkbox'
+      data-checked={checked ? 'true' : 'false'}
+      onClick={() => {
+        if (!disabled) onToggle()
+      }}
+    >
+      <span className='episode-watch-toggle-mark' aria-hidden='true'>
+        {checked ? '×' : ' '}
+      </span>
+    </button>
+  )
+}

--- a/components/molecules/EpisodeWatchToggle/__tests__/EpisodeWatchToggle.test.tsx
+++ b/components/molecules/EpisodeWatchToggle/__tests__/EpisodeWatchToggle.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { EpisodeWatchToggle } from '@/components/molecules/EpisodeWatchToggle'
+
+describe('EpisodeWatchToggle', () => {
+  it('renders an accessible role=checkbox with aria-checked matching the prop', () => {
+    render(
+      <EpisodeWatchToggle
+        checked={true}
+        label='Mark S1E1 watched'
+        onToggle={vi.fn()}
+      />,
+    )
+    const box = screen.getByRole('checkbox', { name: 'Mark S1E1 watched' })
+    expect(box.getAttribute('aria-checked')).toBe('true')
+    expect(box.getAttribute('data-checked')).toBe('true')
+  })
+
+  it('fires onToggle when clicked', () => {
+    const onToggle = vi.fn()
+    render(
+      <EpisodeWatchToggle
+        checked={false}
+        label='Mark S1E1 watched'
+        onToggle={onToggle}
+      />,
+    )
+    fireEvent.click(screen.getByRole('checkbox'))
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT fire onToggle when disabled, shows the UNAIRED tooltip', () => {
+    const onToggle = vi.fn()
+    render(
+      <EpisodeWatchToggle
+        checked={false}
+        disabled
+        label='Mark unaired episode'
+        onToggle={onToggle}
+      />,
+    )
+    const box = screen.getByRole('checkbox', { hidden: true })
+    expect(box.getAttribute('aria-disabled')).toBe('true')
+    expect(box.getAttribute('title')).toBe('UNAIRED — CANNOT MARK WATCHED')
+    fireEvent.click(box)
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+})

--- a/components/molecules/EpisodeWatchToggle/index.ts
+++ b/components/molecules/EpisodeWatchToggle/index.ts
@@ -1,0 +1,4 @@
+export {
+  EpisodeWatchToggle,
+  type EpisodeWatchToggleProps,
+} from './EpisodeWatchToggle'

--- a/components/molecules/FilterSortBar/FilterSortBar.tsx
+++ b/components/molecules/FilterSortBar/FilterSortBar.tsx
@@ -14,6 +14,8 @@ import { FilterChip } from '@/components/molecules/FilterChip'
 
 export type LibraryMedium = 'movies' | 'tv' | 'anime' | 'manga' | 'games'
 
+export type LifecycleFilter = 'in_progress' | 'continuing' | 'ended'
+
 export type FilterSearchHandle = {
   focus: () => void
 }
@@ -35,6 +37,9 @@ export type FilterSortBarProps = {
   hasScrolled?: boolean
   searchRef?: Ref<FilterSearchHandle>
   debounceMs?: number
+  // TV-only lifecycle filter chip group. Ignored for non-TV mediums.
+  activeLifecycle?: LifecycleFilter | null
+  onLifecycleChange?: (next: LifecycleFilter | null) => void
 }
 
 const STATUS_CHIPS: ReadonlyArray<{ status: WatchStatus; label: string }> = [
@@ -43,6 +48,12 @@ const STATUS_CHIPS: ReadonlyArray<{ status: WatchStatus; label: string }> = [
   { status: WatchStatus.COMPLETED, label: 'COMPLETED' },
   { status: WatchStatus.ON_HOLD, label: 'ON HOLD' },
   { status: WatchStatus.DROPPED, label: 'DROPPED' },
+]
+
+const LIFECYCLE_CHIPS: ReadonlyArray<{ key: LifecycleFilter; label: string }> = [
+  { key: 'in_progress', label: 'IN PROGRESS' },
+  { key: 'continuing', label: 'CONTINUING' },
+  { key: 'ended', label: 'ENDED' },
 ]
 
 const PLACEHOLDER_BY_MEDIUM: Record<LibraryMedium, string> = {
@@ -65,6 +76,8 @@ export function FilterSortBar({
   hasScrolled = false,
   searchRef,
   debounceMs = 150,
+  activeLifecycle = null,
+  onLifecycleChange,
 }: FilterSortBarProps) {
   const [sortOpen, setSortOpen] = useState(false)
   const [draft, setDraft] = useState(search)
@@ -163,6 +176,26 @@ export function FilterSortBar({
           />
         ))}
       </div>
+      {medium === 'tv' && onLifecycleChange ? (
+        <div
+          className='filter-sort-bar-chips filter-sort-bar-chips-lifecycle'
+          role='group'
+          aria-label='Filter by lifecycle'
+        >
+          {LIFECYCLE_CHIPS.map((chip) => (
+            <FilterChip
+              key={chip.key}
+              active={activeLifecycle === chip.key}
+              label={chip.label}
+              onToggle={() =>
+                onLifecycleChange(
+                  activeLifecycle === chip.key ? null : chip.key,
+                )
+              }
+            />
+          ))}
+        </div>
+      ) : null}
       <div className='filter-sort-bar-sort' ref={sortRef}>
         <button
           type='button'

--- a/components/molecules/FilterSortBar/__tests__/FilterSortBar.test.tsx
+++ b/components/molecules/FilterSortBar/__tests__/FilterSortBar.test.tsx
@@ -111,4 +111,43 @@ describe('FilterSortBar', () => {
     fireEvent.keyDown(window, { key: 'Escape' })
     expect(screen.queryByRole('listbox')).toBeNull()
   })
+
+  describe('lifecycle chips (TV-only, Story 7.4)', () => {
+    it('does NOT render lifecycle chips for non-TV mediums', () => {
+      setup({ medium: 'movies', onLifecycleChange: vi.fn() })
+      expect(screen.queryByText('IN PROGRESS')).toBeNull()
+      expect(screen.queryByText('CONTINUING')).toBeNull()
+      expect(screen.queryByText('ENDED')).toBeNull()
+    })
+
+    it('renders 3 lifecycle chips when medium=tv and onLifecycleChange is wired', () => {
+      setup({ medium: 'tv', onLifecycleChange: vi.fn() })
+      expect(screen.getByText('IN PROGRESS')).toBeInTheDocument()
+      expect(screen.getByText('CONTINUING')).toBeInTheDocument()
+      expect(screen.getByText('ENDED')).toBeInTheDocument()
+    })
+
+    it('hides lifecycle chips when medium=tv but onLifecycleChange is undefined', () => {
+      setup({ medium: 'tv' })
+      expect(screen.queryByText('IN PROGRESS')).toBeNull()
+    })
+
+    it('fires onLifecycleChange("continuing") when the continuing chip is clicked', () => {
+      const onLifecycleChange = vi.fn()
+      setup({ medium: 'tv', onLifecycleChange })
+      fireEvent.click(screen.getByText('CONTINUING'))
+      expect(onLifecycleChange).toHaveBeenCalledWith('continuing')
+    })
+
+    it('toggles off the lifecycle filter when clicking the currently-active chip', () => {
+      const onLifecycleChange = vi.fn()
+      setup({
+        medium: 'tv',
+        onLifecycleChange,
+        activeLifecycle: 'continuing',
+      })
+      fireEvent.click(screen.getByText('CONTINUING'))
+      expect(onLifecycleChange).toHaveBeenCalledWith(null)
+    })
+  })
 })

--- a/components/molecules/FilterSortBar/index.ts
+++ b/components/molecules/FilterSortBar/index.ts
@@ -2,5 +2,6 @@ export {
   FilterSortBar,
   type FilterSortBarProps,
   type LibraryMedium,
+  type LifecycleFilter,
   type SortOption,
 } from './FilterSortBar'

--- a/components/molecules/MediaCardOverlay/MediaCardOverlay.tsx
+++ b/components/molecules/MediaCardOverlay/MediaCardOverlay.tsx
@@ -1,12 +1,15 @@
 'use client'
 
 import { MediaType, WatchStatus } from '@prisma/client'
+import { PhosphorBar } from '@/components/atoms/PhosphorBar'
 
 export type MediaCardOverlayProps = {
   title: string
   year: number | null
   mediaType: MediaType
   status: WatchStatus
+  progressLabel?: string | null
+  progressPct?: number | null
 }
 
 const TYPE_LABEL: Record<MediaType, string> = {
@@ -31,9 +34,16 @@ export function MediaCardOverlay({
   year,
   mediaType,
   status,
+  progressLabel = null,
+  progressPct = null,
 }: MediaCardOverlayProps) {
   const typeLabel = TYPE_LABEL[mediaType]
   const yearLabel = year === null ? typeLabel : `${typeLabel} · ${year}`
+  const showProgress =
+    progressLabel !== null &&
+    progressLabel.length > 0 &&
+    progressPct !== null &&
+    Number.isFinite(progressPct)
   return (
     <div className='media-card-overlay' aria-hidden='true'>
       <h3 className='media-card-overlay-title'>{title}</h3>
@@ -44,6 +54,16 @@ export function MediaCardOverlay({
       >
         {STATUS_LABEL[status]}
       </p>
+      {showProgress ? (
+        <div className='media-card-overlay-progress'>
+          <p className='media-card-overlay-progress-label'>{progressLabel}</p>
+          <PhosphorBar
+            value={progressPct as number}
+            max={100}
+            label={progressLabel as string}
+          />
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/components/molecules/MediaCardOverlay/__tests__/MediaCardOverlay.test.tsx
+++ b/components/molecules/MediaCardOverlay/__tests__/MediaCardOverlay.test.tsx
@@ -52,6 +52,54 @@ describe('MediaCardOverlay', () => {
     }
   })
 
+  it('renders inline PhosphorBar + progress label when progressLabel + progressPct are both set (Story 7.4)', () => {
+    render(
+      <MediaCardOverlay
+        title='Breaking Bad'
+        year={2008}
+        mediaType={MediaType.TV_SHOW}
+        status={WatchStatus.WATCHING}
+        progressLabel='S2E4 / 10'
+        progressPct={30}
+      />,
+    )
+    expect(screen.getByText('S2E4 / 10')).toBeInTheDocument()
+    // The overlay is aria-hidden (decorative); accessible name query needs
+    // the hidden flag to reach the progressbar inside.
+    const bar = screen.getByRole('progressbar', { hidden: true })
+    expect(bar.getAttribute('aria-valuenow')).toBe('30')
+    expect(bar.getAttribute('aria-valuemax')).toBe('100')
+  })
+
+  it('does NOT render the progress block when progressLabel is null', () => {
+    const { container } = render(
+      <MediaCardOverlay
+        title='Breaking Bad'
+        year={2008}
+        mediaType={MediaType.TV_SHOW}
+        status={WatchStatus.PLAN_TO_WATCH}
+        progressLabel={null}
+        progressPct={null}
+      />,
+    )
+    expect(container.querySelector('.media-card-overlay-progress')).toBeNull()
+    expect(screen.queryByRole('progressbar', { hidden: true })).toBeNull()
+  })
+
+  it('does NOT render progress when progressPct is non-finite (defensive)', () => {
+    const { container } = render(
+      <MediaCardOverlay
+        title='Sample'
+        year={2024}
+        mediaType={MediaType.TV_SHOW}
+        status={WatchStatus.WATCHING}
+        progressLabel='S1E1 / 10'
+        progressPct={Number.NaN}
+      />,
+    )
+    expect(container.querySelector('.media-card-overlay-progress')).toBeNull()
+  })
+
   it('exposes the status as a data-status attribute for CSS color targeting', () => {
     const cases: Array<[WatchStatus, string, string]> = [
       [WatchStatus.PLAN_TO_WATCH, 'plan_to_watch', 'PLAN TO WATCH'],

--- a/components/molecules/SeasonAccordion/SeasonAccordion.tsx
+++ b/components/molecules/SeasonAccordion/SeasonAccordion.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { WatchStatus } from '@prisma/client'
+import { PhosphorBar } from '@/components/atoms/PhosphorBar'
+import { EpisodeWatchToggle } from '@/components/molecules/EpisodeWatchToggle'
+
+export type SeasonEpisode = {
+  mediaItemId: string
+  seasonNumber: number
+  episodeNumber: number
+  title: string
+  airDate: string | null
+  runtime: number | null
+  unaired: boolean
+  status: WatchStatus | null
+}
+
+export type SeasonGroup = {
+  number: number
+  episodes: SeasonEpisode[]
+}
+
+export type SeasonAccordionProps = {
+  seasons: SeasonGroup[]
+  defaultExpandedSeason: number | null
+  onToggleEpisode: (mediaItemId: string, next: WatchStatus) => void
+  onMarkSeasonWatched: (seasonNumber: number) => void
+}
+
+function seasonLabel(number: number): string {
+  return number === 0 ? 'SPECIALS' : `SEASON ${number}`
+}
+
+function watchedCount(episodes: SeasonEpisode[]): number {
+  return episodes.filter((e) => e.status === WatchStatus.COMPLETED).length
+}
+
+function airedCount(episodes: SeasonEpisode[]): number {
+  return episodes.filter((e) => !e.unaired).length
+}
+
+function formatAirDate(raw: string | null, unaired: boolean): string {
+  if (unaired) return 'UNAIRED'
+  if (!raw) return '—'
+  // Server passes ISO; format as YYYY-MM-DD.
+  return raw.slice(0, 10)
+}
+
+export function SeasonAccordion({
+  seasons,
+  defaultExpandedSeason,
+  onToggleEpisode,
+  onMarkSeasonWatched,
+}: SeasonAccordionProps) {
+  const [expanded, setExpanded] = useState<Set<number>>(
+    () => new Set(defaultExpandedSeason === null ? [] : [defaultExpandedSeason]),
+  )
+
+  // When the server re-renders after a mutation (router.refresh()), the
+  // `defaultExpandedSeason` prop can change (e.g. user just watched the last
+  // S1 episode → new default is S2). Additively expand the new default so the
+  // user's manual expansions are preserved.
+  useEffect(() => {
+    if (defaultExpandedSeason === null) return
+    setExpanded((prev) => {
+      if (prev.has(defaultExpandedSeason)) return prev
+      const next = new Set(prev)
+      next.add(defaultExpandedSeason)
+      return next
+    })
+  }, [defaultExpandedSeason])
+
+  return (
+    <div className='season-accordion'>
+      {seasons.map((season) => {
+        const isOpen = expanded.has(season.number)
+        const total = airedCount(season.episodes)
+        const watched = watchedCount(season.episodes)
+        return (
+          <section
+            key={season.number}
+            id={`season-${season.number}`}
+            className='season-accordion-section'
+            data-expanded={isOpen ? 'true' : 'false'}
+          >
+            <button
+              type='button'
+              className='season-accordion-header'
+              aria-expanded={isOpen}
+              aria-controls={`season-${season.number}-panel`}
+              onClick={() => {
+                setExpanded((prev) => {
+                  const next = new Set(prev)
+                  if (next.has(season.number)) next.delete(season.number)
+                  else next.add(season.number)
+                  return next
+                })
+              }}
+            >
+              <span className='season-accordion-header-title'>
+                {seasonLabel(season.number)}
+              </span>
+              <span className='season-accordion-header-count'>
+                {season.episodes.length} EPISODES
+              </span>
+              <span className='season-accordion-header-progress'>
+                <PhosphorBar
+                  value={watched}
+                  max={total > 0 ? total : 1}
+                  label={`${seasonLabel(season.number)} progress`}
+                />
+              </span>
+              <span
+                className='season-accordion-header-chev'
+                aria-hidden='true'
+                data-rot={isOpen ? '90' : '0'}
+              >
+                ›
+              </span>
+            </button>
+            {isOpen ? (
+              <div
+                id={`season-${season.number}-panel`}
+                className='season-accordion-panel'
+              >
+                <div className='season-accordion-actions'>
+                  <button
+                    type='button'
+                    className='season-accordion-mark-watched crt-pixel-button'
+                    disabled={total === 0}
+                    onClick={() => onMarkSeasonWatched(season.number)}
+                  >
+                    &gt; MARK SEASON WATCHED
+                  </button>
+                </div>
+                <ul className='season-accordion-episodes'>
+                  {season.episodes.map((episode) => {
+                    const isWatched = episode.status === WatchStatus.COMPLETED
+                    return (
+                      <li
+                        key={episode.mediaItemId}
+                        className='season-accordion-episode'
+                        data-unaired={episode.unaired ? 'true' : 'false'}
+                      >
+                        <span className='season-accordion-episode-code'>
+                          S{episode.seasonNumber}E{episode.episodeNumber}
+                        </span>
+                        <span className='season-accordion-episode-title'>
+                          {episode.title}
+                        </span>
+                        <span className='season-accordion-episode-air'>
+                          {formatAirDate(episode.airDate, episode.unaired)}
+                        </span>
+                        <span className='season-accordion-episode-runtime'>
+                          {episode.runtime ? `${episode.runtime} MIN` : ''}
+                        </span>
+                        <EpisodeWatchToggle
+                          checked={isWatched}
+                          disabled={episode.unaired}
+                          label={`Mark ${episode.title} watched`}
+                          onToggle={() =>
+                            onToggleEpisode(
+                              episode.mediaItemId,
+                              isWatched
+                                ? WatchStatus.PLAN_TO_WATCH
+                                : WatchStatus.COMPLETED,
+                            )
+                          }
+                        />
+                      </li>
+                    )
+                  })}
+                </ul>
+              </div>
+            ) : null}
+          </section>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/molecules/SeasonAccordion/__tests__/SeasonAccordion.test.tsx
+++ b/components/molecules/SeasonAccordion/__tests__/SeasonAccordion.test.tsx
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { WatchStatus } from '@prisma/client'
+import {
+  SeasonAccordion,
+  type SeasonGroup,
+} from '@/components/molecules/SeasonAccordion'
+
+function seasons(): SeasonGroup[] {
+  return [
+    {
+      number: 1,
+      episodes: [
+        {
+          mediaItemId: 's1e1',
+          seasonNumber: 1,
+          episodeNumber: 1,
+          title: 'Pilot',
+          airDate: '2008-01-20T00:00:00Z',
+          runtime: 47,
+          unaired: false,
+          status: WatchStatus.COMPLETED,
+        },
+        {
+          mediaItemId: 's1e2',
+          seasonNumber: 1,
+          episodeNumber: 2,
+          title: "Cat's in the Bag...",
+          airDate: '2008-01-27T00:00:00Z',
+          runtime: 48,
+          unaired: false,
+          status: WatchStatus.PLAN_TO_WATCH,
+        },
+      ],
+    },
+    {
+      number: 2,
+      episodes: [
+        {
+          mediaItemId: 's2e1',
+          seasonNumber: 2,
+          episodeNumber: 1,
+          title: 'Seven Thirty-Seven',
+          airDate: '2009-03-08T00:00:00Z',
+          runtime: 47,
+          unaired: false,
+          status: WatchStatus.PLAN_TO_WATCH,
+        },
+      ],
+    },
+  ]
+}
+
+describe('SeasonAccordion', () => {
+  it('renders all season headers (collapsed by default when defaultExpandedSeason is null)', () => {
+    render(
+      <SeasonAccordion
+        seasons={seasons()}
+        defaultExpandedSeason={null}
+        onToggleEpisode={vi.fn()}
+        onMarkSeasonWatched={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('SEASON 1')).toBeInTheDocument()
+    expect(screen.getByText('SEASON 2')).toBeInTheDocument()
+    // Episode titles only render in the expanded panel.
+    expect(screen.queryByText('Pilot')).toBeNull()
+  })
+
+  it('expands the defaultExpandedSeason on initial render', () => {
+    render(
+      <SeasonAccordion
+        seasons={seasons()}
+        defaultExpandedSeason={1}
+        onToggleEpisode={vi.fn()}
+        onMarkSeasonWatched={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('Pilot')).toBeInTheDocument()
+    expect(screen.getByText("Cat's in the Bag...")).toBeInTheDocument()
+    // Season 2 panel is still collapsed.
+    expect(screen.queryByText('Seven Thirty-Seven')).toBeNull()
+  })
+
+  it('toggles a season open/closed on header click', () => {
+    render(
+      <SeasonAccordion
+        seasons={seasons()}
+        defaultExpandedSeason={null}
+        onToggleEpisode={vi.fn()}
+        onMarkSeasonWatched={vi.fn()}
+      />,
+    )
+    const s1Header = screen.getByText('SEASON 1').closest('button')!
+    fireEvent.click(s1Header)
+    expect(screen.getByText('Pilot')).toBeInTheDocument()
+    fireEvent.click(s1Header)
+    expect(screen.queryByText('Pilot')).toBeNull()
+  })
+
+  it('fires onToggleEpisode with the next status when an episode checkbox is clicked', () => {
+    const onToggle = vi.fn()
+    render(
+      <SeasonAccordion
+        seasons={seasons()}
+        defaultExpandedSeason={1}
+        onToggleEpisode={onToggle}
+        onMarkSeasonWatched={vi.fn()}
+      />,
+    )
+    // S1E1 is COMPLETED → toggling sends PLAN_TO_WATCH
+    const s1e1Box = screen.getByRole('checkbox', {
+      name: 'Mark Pilot watched',
+    })
+    fireEvent.click(s1e1Box)
+    expect(onToggle).toHaveBeenCalledWith('s1e1', WatchStatus.PLAN_TO_WATCH)
+  })
+
+  it('fires onMarkSeasonWatched when the per-season button is clicked', () => {
+    const onMark = vi.fn()
+    render(
+      <SeasonAccordion
+        seasons={seasons()}
+        defaultExpandedSeason={1}
+        onToggleEpisode={vi.fn()}
+        onMarkSeasonWatched={onMark}
+      />,
+    )
+    const mark = screen.getByRole('button', { name: /MARK SEASON WATCHED/ })
+    fireEvent.click(mark)
+    expect(onMark).toHaveBeenCalledWith(1)
+  })
+
+  it('renders SPECIALS label for season 0', () => {
+    render(
+      <SeasonAccordion
+        seasons={[
+          {
+            number: 0,
+            episodes: [
+              {
+                mediaItemId: 'special-1',
+                seasonNumber: 0,
+                episodeNumber: 1,
+                title: 'Behind the scenes',
+                airDate: '2008-01-20T00:00:00Z',
+                runtime: 30,
+                unaired: false,
+                status: WatchStatus.PLAN_TO_WATCH,
+              },
+            ],
+          },
+        ]}
+        defaultExpandedSeason={null}
+        onToggleEpisode={vi.fn()}
+        onMarkSeasonWatched={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('SPECIALS')).toBeInTheDocument()
+  })
+
+  it('renders UNAIRED chip + disabled checkbox for unaired episodes', () => {
+    render(
+      <SeasonAccordion
+        seasons={[
+          {
+            number: 1,
+            episodes: [
+              {
+                mediaItemId: 'unaired-1',
+                seasonNumber: 1,
+                episodeNumber: 99,
+                title: 'Future Episode',
+                airDate: null,
+                runtime: null,
+                unaired: true,
+                status: null,
+              },
+            ],
+          },
+        ]}
+        defaultExpandedSeason={1}
+        onToggleEpisode={vi.fn()}
+        onMarkSeasonWatched={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('UNAIRED')).toBeInTheDocument()
+    const box = screen.getByRole('checkbox', {
+      name: 'Mark Future Episode watched',
+      hidden: true,
+    })
+    expect(box.getAttribute('aria-disabled')).toBe('true')
+  })
+})

--- a/components/molecules/SeasonAccordion/index.ts
+++ b/components/molecules/SeasonAccordion/index.ts
@@ -1,0 +1,6 @@
+export {
+  SeasonAccordion,
+  type SeasonAccordionProps,
+  type SeasonEpisode,
+  type SeasonGroup,
+} from './SeasonAccordion'

--- a/components/organisms/LibraryGrid/LibraryGrid.tsx
+++ b/components/organisms/LibraryGrid/LibraryGrid.tsx
@@ -11,7 +11,11 @@ import {
 import Link from 'next/link'
 import { useQuery } from '@tanstack/react-query'
 import { MediaType, WatchStatus } from '@prisma/client'
-import { FilterSortBar, type SortOption } from '@/components/molecules/FilterSortBar'
+import {
+  FilterSortBar,
+  type LifecycleFilter,
+  type SortOption,
+} from '@/components/molecules/FilterSortBar'
 import { EmptyLibraryState } from '@/components/molecules/EmptyLibraryState'
 import { MediaCardOverlay } from '@/components/molecules/MediaCardOverlay'
 import { FramedCover } from '@/components/molecules/FramedCover'
@@ -50,12 +54,18 @@ export type LibraryGridProps = {
   initialStatus: WatchStatus | null
   initialSearch: string
   sortOptions?: SortOption[]
+  initialLifecycle?: LifecycleFilter | null
 }
 
 type FetchKey = readonly [
   'library',
   'movies' | 'tv' | 'anime' | 'manga' | 'games',
-  { sort: string; status: WatchStatus | null; search: string },
+  {
+    sort: string
+    status: WatchStatus | null
+    search: string
+    lifecycle: LifecycleFilter | null
+  },
 ]
 
 async function fetchLibrary(
@@ -63,6 +73,7 @@ async function fetchLibrary(
   sort: string,
   status: WatchStatus | null,
   search: string,
+  lifecycle: LifecycleFilter | null,
   signal: AbortSignal,
 ): Promise<LibraryItem[]> {
   const params = new URLSearchParams()
@@ -70,6 +81,7 @@ async function fetchLibrary(
   params.set('sort', sort)
   if (status) params.set('status', status)
   if (search.trim().length > 0) params.set('search', search.trim())
+  if (lifecycle) params.set('lifecycle', lifecycle)
   params.set('limit', '200')
   const res = await fetch(`/api/library?${params.toString()}`, {
     signal,
@@ -87,18 +99,22 @@ export function LibraryGrid({
   initialStatus,
   initialSearch,
   sortOptions = MOVIE_SORT_OPTIONS,
+  initialLifecycle = null,
 }: LibraryGridProps) {
   const [sort, setSortState] = useState(initialSort)
   const [status, setStatusState] = useState<WatchStatus | null>(initialStatus)
   const [search, setSearchState] = useState(initialSearch)
+  const [lifecycle, setLifecycleState] = useState<LifecycleFilter | null>(
+    initialLifecycle,
+  )
   const [hasScrolled, setHasScrolled] = useState(false)
   const [focusedIdx, setFocusedIdx] = useState<number | null>(null)
   const gridRef = useRef<HTMLUListElement | null>(null)
   const searchHandleRef = useRef<{ focus: () => void } | null>(null)
 
   const queryKey = useMemo<FetchKey>(
-    () => ['library', mediaType, { sort, status, search }] as const,
-    [mediaType, sort, status, search],
+    () => ['library', mediaType, { sort, status, search, lifecycle }] as const,
+    [mediaType, sort, status, search, lifecycle],
   )
 
   // initialData ONLY seeds the FIRST queryKey (the one the SSR rendered with).
@@ -111,7 +127,8 @@ export function LibraryGrid({
 
   const { data: items = initialItems, isLoading, isError } = useQuery({
     queryKey,
-    queryFn: ({ signal }) => fetchLibrary(mediaType, sort, status, search, signal),
+    queryFn: ({ signal }) =>
+      fetchLibrary(mediaType, sort, status, search, lifecycle, signal),
     initialData: initialDataForQuery,
     initialDataUpdatedAt: 0,
     staleTime: 0,
@@ -123,13 +140,19 @@ export function LibraryGrid({
   // racing with the client's TanStack Query state and producing the stale-
   // data display Cuatro reported at smoke.
   const writeUrl = useCallback(
-    (nextSort: string, nextStatus: WatchStatus | null, nextSearch: string) => {
+    (
+      nextSort: string,
+      nextStatus: WatchStatus | null,
+      nextSearch: string,
+      nextLifecycle: LifecycleFilter | null,
+    ) => {
       if (typeof window === 'undefined') return
       const params = new URLSearchParams()
       params.set('sort', nextSort)
       if (nextStatus) params.set('status', nextStatus)
       const trimmed = nextSearch.trim()
       if (trimmed.length > 0) params.set('search', trimmed)
+      if (nextLifecycle) params.set('lifecycle', nextLifecycle)
       const target = `${window.location.pathname}?${params.toString()}`
       window.history.replaceState(null, '', target)
     },
@@ -145,31 +168,40 @@ export function LibraryGrid({
   const setSort = useCallback(
     (next: string) => {
       setSortState(next)
-      writeUrl(next, status, search)
+      writeUrl(next, status, search, lifecycle)
     },
-    [status, search, writeUrl],
+    [status, search, lifecycle, writeUrl],
   )
 
   const setStatus = useCallback(
     (next: WatchStatus | null) => {
       setStatusState(next)
-      writeUrl(sort, next, search)
+      writeUrl(sort, next, search, lifecycle)
     },
-    [sort, search, writeUrl],
+    [sort, search, lifecycle, writeUrl],
   )
 
   const setSearch = useCallback(
     (next: string) => {
       setSearchState(next)
-      writeUrl(sort, status, next)
+      writeUrl(sort, status, next, lifecycle)
     },
-    [sort, status, writeUrl],
+    [sort, status, lifecycle, writeUrl],
+  )
+
+  const setLifecycle = useCallback(
+    (next: LifecycleFilter | null) => {
+      setLifecycleState(next)
+      writeUrl(sort, status, search, next)
+    },
+    [sort, status, search, writeUrl],
   )
 
   const clearFilters = useCallback(() => {
     setStatusState(null)
     setSearchState('')
-    writeUrl(sort, null, '')
+    setLifecycleState(null)
+    writeUrl(sort, null, '', null)
   }, [sort, writeUrl])
 
   // Scroll affordance: rainbow rule under the toolbar once scrolled past 80px.
@@ -196,14 +228,17 @@ export function LibraryGrid({
         searchHandleRef.current?.focus()
         return
       }
-      if (e.key === 'Escape' && (status !== null || search !== '')) {
+      if (
+        e.key === 'Escape' &&
+        (status !== null || search !== '' || lifecycle !== null)
+      ) {
         e.preventDefault()
         clearFilters()
       }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [status, search, clearFilters])
+  }, [status, search, lifecycle, clearFilters])
 
   // Grid-level arrow navigation. Right at end-of-row jumps to first card of
   // next row; Up at top-row is a no-op (no wrap to last row).
@@ -232,7 +267,8 @@ export function LibraryGrid({
   )
 
   // Loading + error + filtered-zero + empty-state branching.
-  const hasActiveQuery = status !== null || search.trim().length > 0
+  const hasActiveQuery =
+    status !== null || search.trim().length > 0 || lifecycle !== null
 
   return (
     <div className='library-grid'>
@@ -247,6 +283,8 @@ export function LibraryGrid({
         onSortChange={setSort}
         hasScrolled={hasScrolled}
         searchRef={searchHandleRef}
+        activeLifecycle={lifecycle}
+        onLifecycleChange={mediaType === 'tv' ? setLifecycle : undefined}
       />
       <div className='library-grid-region'>
         {isError ? (
@@ -321,6 +359,8 @@ export function LibraryGrid({
                         year={item.year}
                         mediaType={item.mediaType}
                         status={item.status}
+                        progressLabel={item.progressLabel}
+                        progressPct={item.progressPct}
                       />
                     </div>
                   </Link>

--- a/docs/delivery/7-2a-wire-post-api-media-tv-branch.md
+++ b/docs/delivery/7-2a-wire-post-api-media-tv-branch.md
@@ -1,0 +1,116 @@
+---
+story: 7.2a
+issue: 124
+branch: epic-7-tv
+mode: main-session-with-delivery-file
+impl_artifact: ../../_bmad-output/implementation-artifacts/7-2a-wire-post-api-media-tv-branch.md
+---
+
+# Story 7.2a — Wire POST /api/media TV branch (delivery file)
+
+This document is a future-reference summary of the in-session implementation of Story 7.2a. Authoritative AC, OI, and review notes live in the impl-artifact at `_bmad-output/implementation-artifacts/7-2a-wire-post-api-media-tv-branch.md`.
+
+## Summary
+
+Story 7.2a wires `POST /api/media` for the TV-add path (epic AC-6), completing the work that was split out of Story 7.2 at its kickoff. Three changes land together as one commit on `epic-7-tv`:
+
+1. **Dispatcher contract change** at `lib/search/media-dispatcher.ts`. The `AddMediaDispatcher.normalise` return type becomes the union `Prisma.MediaItemCreateInput | NormalisedShowWithEpisodes` where `NormalisedShowWithEpisodes = { show, episodes }`. The existing `(tmdb, MOVIE)` dispatcher is unchanged.
+
+2. **TV dispatcher entry** in `getDispatcher()`. The `(tmdb, TV_SHOW)` branch's `fetch` orchestrates `getTv(id)` + N parallel `getTvSeason(id, n)` calls — filtered to seasons with `episode_count > 0` so empty future seasons are skipped (specials with episodes are INCLUDED per Story 7.2's OI #5). Returns `{ show, seasons }` passed verbatim to `normaliseTmdbTv`.
+
+3. **Route handler TV branch** at `app/api/media/route.ts`. The single-shape handler splits into `persistSingleMediaItem` (movie path, behaviour unchanged) and `persistShowWithEpisodes` (TV branch). The TV branch runs cross-source merge with a `type === TV_SHOW` guard (so a 1984 movie can't accidentally cross-merge with a 1984 TV show), then a single atomic `db.$transaction(fn, { timeout: 30_000 })` that inserts the show + nested UserEntry + N episode rows with `parent_id` plumbing. P2002 handling: show-race → 200 idempotent recovery; episode-level (no racing show) → 500 `cross_type_tmdb_id_collision` for operator investigation.
+
+## Reasoning
+
+### Why Path 1 (discriminated `normalise` union) over Path 2 (`persist` method on the dispatcher)
+
+The dispatcher contract had to change to accommodate the TV normaliser's `{ show, episodes }` shape. Path 2 (move all persistence into the dispatcher) is the right long-term call but doubles 7.2a's scope — it requires relocating `findExistingBySourceId`, `findCrossSourceCandidates`, `patchSourceId`, `ensureUserEntry`, and the entire P2002 handling logic into the dispatcher, then refactoring the movie path to maintain symmetry. Cuatro ratified Path 1 at kickoff for scope discipline. If the discrimination grows to 3+ branches (anime episodes E8, game DLC E9), revisit Path 2 as a dedicated refactor story.
+
+### Why the same-parent re-import P2002 case is unreachable
+
+The original handoff prescribed a per-collider `findUnique` to distinguish "benign re-import within the same show" from "cross-context collision." Mid-impl I realised the same-parent case is unreachable under Prisma's atomic transaction semantics + the existing fast-path `findExistingBySourceId`: if the show is already in the DB, the fast-path catches it before the transaction runs; if not, atomic transactions can't leave orphan episodes from a partial previous run. Therefore any P2002 inside the TV transaction is either a show-level race (recoverable via post-catch `findExistingBySourceId`) or a true cross-context collision (500). The OI #2 wording was updated in the impl-artifact to reflect this refined understanding.
+
+### Why the transaction timeout is 30s
+
+Breaking Bad has 62 episodes, Game of Thrones 73, Days of Our Lives 14,000+. A bulk-insert of 100+ rows via `createMany` plus the show insert plus the UserEntry insert is ~3-5 round-trips to Postgres at 10-50ms each over localhost. Prisma's default 5s leaves no margin for slow disk or autovacuum. 30s is the standard for similar Prisma bulk-insert patterns. The cost (wedged transactions hold locks longer in the edge case where they hang) is acceptable for an interactive add path.
+
+### Failure mode / Roads not taken / Long-term cost
+
+- **Failure mode:** A single flaky season fetch in `Promise.all(getTvSeason ...)` aborts the whole insert and returns 502. Resilience hardening (`Promise.allSettled` + per-season retry) is deferred to a follow-up story (ECH-T3 in `deferred-work.md`).
+- **Failure mode:** Cross-context tmdb_id collision returns 500 without auto-recovery. The schema's global `tmdb_id @unique` is the root cause; the schema fix is the `@@unique([type, tmdb_id])` migration deferred to a follow-up (originally logged as ECH-4 from Story 7.2).
+- **Roads not taken:** Path 3 (inline TV branch in `route.ts` without changing the dispatcher contract) was considered and rejected. It paints us into a corner the moment Epic 8 (anime episodes) and Epic 9 (game DLC) need similar parent + child shapes.
+- **Long-term cost:** The `'episodes' in normalised` discriminator grows linearly with new mediums that need multi-row persistence. At 3+ mediums it's worth migrating to Path 2 (the `persist` method refactor). Surface in the Story 8.x or 9.x epic kickoff.
+
+## Files touched
+
+- `cuatro-tracker/lib/search/media-dispatcher.ts` — +34 / -1 (new `NormalisedShowWithEpisodes` type export, union return type on `AddMediaDispatcher.normalise`, new `(tmdb, TV_SHOW)` dispatcher entry).
+- `cuatro-tracker/lib/search/__tests__/media-dispatcher.test.ts` — +103 / -8 (5 new TV dispatcher tests covering happy path, skip-empty-seasons, include-specials, missing-seasons, every-wired-tuple). The "every other tuple null" test updated to account for `(tmdb, TV_SHOW)` now being wired.
+- `cuatro-tracker/app/api/media/route.ts` — +145 / -8 (handler split into `persistSingleMediaItem` + `persistShowWithEpisodes` + `logAndReturnConstraintViolation` helper; TV branch with multi-row transaction; show-race + cross-context-collision P2002 paths; `c.type === TV_SHOW` cross-source merge filter).
+- `cuatro-tracker/app/api/media/__tests__/route.test.ts` — +394 / -4 (10 new TV branch tests across 5 describe blocks; existing `(tmdb, TV_SHOW) → 501` test updated to `(tmdb, ANIME) → 501`; dbMock extended with `$transaction`; new `txMock` for transaction callback; tmdbMock extended with `getTv` + `getTvSeason`).
+
+LOC accounting (cumulative Epic 7 PR): +1162 / -72 entering 7.2a → ~+1838 / -93 after 7.2a (676 added, 21 removed). Sub-bundle cut at the 1.5K LOC ceiling per [[feedback_pr_size_ceiling]] is now likely before Story 7.5 — flag for the Epic 7 closeout planning.
+
+## Commit message
+
+`feat(api): wire POST /api/media TV branch (#124)`
+
+(Single commit on `epic-7-tv` per OI #8 and [[feedback_bundle_pr_commit_per_issue]]. The work is cohesive — dispatcher contract change + route branch + tests aren't separable units of intent.)
+
+## How to verify
+
+### Static gates (run inside `cuatro-tracker-dev-1`)
+
+```bash
+docker exec -w /workspaces/cuatro-tracker cuatro-tracker-dev-1 bash -lc \
+  'pnpm typecheck && pnpm lint --max-warnings=0 && pnpm vitest run app/api/media lib/normalise lib/search'
+```
+
+Expected: typecheck green, lint green, 120/120 scoped tests green. Full vitest sweep optional — expect the pre-existing `lib/jobs/__tests__/worker.test.ts` flake (2 failures) from Story 7.2's deferred-work log; unrelated to this story.
+
+### Manual smoke (optional, requires live Postgres + TMDB credentials)
+
+```bash
+# Inside the dev container, hit the route with a real show (Breaking Bad = 1396).
+docker exec -w /workspaces/cuatro-tracker cuatro-tracker-dev-1 bash -lc \
+  "curl -s -X POST http://localhost:3000/api/media \
+    -H 'Content-Type: application/json' \
+    -H 'Cookie: <auth cookie>' \
+    -d '{\"source\":\"tmdb\",\"sourceId\":1396,\"type\":\"TV_SHOW\"}' | jq .merged"
+# Expected: false
+```
+
+Verify episode rows landed:
+
+```bash
+docker exec -w /workspaces/cuatro-tracker cuatro-tracker-dev-1 bash -lc \
+  "psql \$DATABASE_URL -c \"SELECT count(*) FROM \\\"MediaItem\\\" WHERE type = 'TV_EPISODE' AND parent_id = (SELECT id FROM \\\"MediaItem\\\" WHERE tmdb_id = 1396);\""
+# Expected: 62 (Breaking Bad's canonical episode count).
+```
+
+Idempotent retry:
+
+```bash
+# Re-run the same POST — should return 200 (not 201) and zero new inserts.
+```
+
+### Debugging notes
+
+- **Test failures hit 422 across multiple TV tests:** the `validTmdbTv` fixture's `seasons[]` summaries are missing `id` or `name` (required by `TmdbSeasonSummarySchema`). Caught during initial test run on 2026-05-15 — the fixture was synthesised without consulting the schema. Fix: provide complete summary entries `{ id, season_number, name, episode_count }`.
+- **TV branch returns 500 unexpectedly:** the only intentional 500 path is `cross_type_tmdb_id_collision`. Confirm by inspecting `media.tmdb_id_collision` log lines + checking the inbound episode `tmdb_id`s against `SELECT id, type, tmdb_id FROM "MediaItem" WHERE tmdb_id IN (<inbound ids>)`. If any return a row with `type != TV_EPISODE` or a different show's parent, the collision is real.
+- **Transaction timeout under heavy load:** Prisma 30s timeout is on the wall-clock duration, not idle time. Long-running shows (1000+ episodes) might trip it. Mitigation if it happens: chunk `createMany` into batches of 200 inside the transaction.
+
+## Apply checklist
+
+- [x] `media-dispatcher.ts` union return type + TV dispatcher entry.
+- [x] `media-dispatcher.test.ts` updated to reflect `(tmdb, TV_SHOW)` wiring + 4 new TV dispatcher tests.
+- [x] `route.ts` split into movie + TV persist functions; TV transaction with 30s timeout; show-race + cross-context-collision P2002 paths; cross-source merge guarded by `c.type === TV_SHOW`.
+- [x] `route.test.ts` extended with TV branch describe block (10 new tests across happy path, idempotent, cross-source merge, empty seasons, error paths) + updated existing `(tmdb, TV_SHOW) → 501` to `(tmdb, ANIME) → 501`.
+- [x] Static gates green: typecheck, lint, 120/120 scoped vitest.
+- [x] `bmad-code-review` run: 9/9 ACs verified, 6/8 OIs verified (2 pending-closeout), 12+1 EC findings → 0 patch / 7 defer / 6 dismiss.
+- [x] Deferred items logged to `_bmad-output/implementation-artifacts/deferred-work.md` under "Deferred from: code review of Story 7.2a (2026-05-15)".
+- [x] Impl-artifact Status flipped to `done` + Dev Agent Record populated.
+- [x] Sprint-status flipped: `7-2a = done`. `epic-7 = in-progress` retained.
+- [x] Single commit `feat(api): wire POST /api/media TV branch (#124)` on `epic-7-tv`; pushed.
+- [x] Issue #124 stays open per per-epic-bundle pattern.
+
+(All checkboxes filled at commit time. If you're reading this and one is unchecked, the closeout was interrupted — re-run from the unchecked step.)

--- a/lib/api/__tests__/tmdb.test.ts
+++ b/lib/api/__tests__/tmdb.test.ts
@@ -98,12 +98,38 @@ const validTv = {
   original_name: 'Game of Thrones',
   overview: 'Seven noble families...',
   first_air_date: '2011-04-17',
+  last_air_date: '2019-05-19',
   poster_path: '/got-poster.jpg',
   backdrop_path: '/got-backdrop.jpg',
   vote_average: 8.4,
   popularity: 120.5,
   genres: [{ id: 18, name: 'Drama' }],
   status: 'Ended',
+  tagline: 'Winter Is Coming',
+  in_production: false,
+  number_of_seasons: 8,
+  number_of_episodes: 73,
+  episode_run_time: [60],
+  seasons: [
+    { id: 3624, season_number: 0, name: 'Specials', episode_count: 5 },
+    {
+      id: 3625,
+      season_number: 1,
+      name: 'Season 1',
+      air_date: '2011-04-17',
+      episode_count: 10,
+    },
+  ],
+  last_episode_to_air: {
+    id: 1551830,
+    name: 'The Iron Throne',
+    air_date: '2019-05-19',
+    episode_number: 6,
+    season_number: 8,
+    runtime: 80,
+  },
+  next_episode_to_air: null,
+  credits: { cast: [], crew: [] },
 }
 
 const validEpisode = {
@@ -157,6 +183,30 @@ const validMovieCredits = {
       job: 'Screenplay',
       department: 'Writing',
       profile_path: null,
+    },
+  ],
+}
+
+const validSeason = {
+  _id: '5256c89f19c2956ff60853a0',
+  id: 3625,
+  season_number: 1,
+  name: 'Season 1',
+  overview: 'In the mythical continent of Westeros...',
+  poster_path: '/s1.jpg',
+  air_date: '2011-04-17',
+  vote_average: 8.2,
+  episodes: [
+    {
+      id: 63056,
+      name: 'Winter Is Coming',
+      overview: 'Lord Ned Stark...',
+      air_date: '2011-04-17',
+      episode_number: 1,
+      season_number: 1,
+      still_path: '/still.jpg',
+      vote_average: 8.0,
+      runtime: 62,
     },
   ],
 }
@@ -399,8 +449,23 @@ describe('lib/api/tmdb', () => {
   })
 
   describe('getTv', () => {
-    it('parses a valid /tv/:id response', async () => {
-      mockFetchOk(validTv)
+    it('parses a valid augmented /tv/:id response with credits + external_ids + watch/providers', async () => {
+      mockFetchOk({
+        ...validTv,
+        credits: validMovieCredits,
+        external_ids: { imdb_id: 'tt0944947', facebook_id: 'GameOfThrones' },
+        'watch/providers': {
+          id: 1399,
+          results: {
+            US: {
+              link: 'https://www.themoviedb.org/tv/1399/watch?locale=US',
+              flatrate: [
+                { provider_id: 384, provider_name: 'HBO Max', logo_path: '/h.jpg' },
+              ],
+            },
+          },
+        },
+      })
       const { getTv } = await import('@/lib/api/tmdb')
 
       const result = await getTv(1399)
@@ -409,11 +474,116 @@ describe('lib/api/tmdb', () => {
         id: 1399,
         name: 'Game of Thrones',
         first_air_date: '2011-04-17',
+        number_of_seasons: 8,
+        number_of_episodes: 73,
+        tagline: 'Winter Is Coming',
+      })
+      expect(result.credits.cast).toHaveLength(3)
+      expect(result.external_ids?.imdb_id).toBe('tt0944947')
+      expect(result['watch/providers']?.results.US?.flatrate).toHaveLength(1)
+    })
+
+    it('always appends credits,external_ids,watch/providers to the request URL', async () => {
+      mockFetchOk({ ...validTv, credits: validMovieCredits })
+      const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+      const { getTv } = await import('@/lib/api/tmdb')
+
+      await getTv(1399)
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string
+      const parsed = new URL(calledUrl)
+      expect(parsed.pathname).toBe('/3/tv/1399')
+      expect(parsed.searchParams.get('append_to_response')).toBe(
+        'credits,external_ids,watch/providers',
+      )
+    })
+
+    it('parses next_episode_to_air as null (not undefined) when no upcoming episode', async () => {
+      mockFetchOk({
+        ...validTv,
+        credits: { cast: [], crew: [] },
+        next_episode_to_air: null,
+      })
+      const { getTv } = await import('@/lib/api/tmdb')
+
+      const result = await getTv(1399)
+
+      expect(result.next_episode_to_air).toBeNull()
+    })
+
+    it('parses last_episode_to_air as null for shows that have not aired yet', async () => {
+      mockFetchOk({
+        ...validTv,
+        last_episode_to_air: null,
+        credits: { cast: [], crew: [] },
+      })
+      const { getTv } = await import('@/lib/api/tmdb')
+
+      const result = await getTv(1399)
+
+      expect(result.last_episode_to_air).toBeNull()
+    })
+
+    it('degrades external_ids to undefined when TMDB sends a malformed appended block', async () => {
+      mockFetchOk({
+        ...validTv,
+        credits: { cast: [], crew: [] },
+        external_ids: { imdb_id: 12345 },
+      })
+      const { getTv } = await import('@/lib/api/tmdb')
+
+      const result = await getTv(1399)
+
+      expect(result.external_ids).toBeUndefined()
+    })
+
+    it('degrades watch/providers to undefined when TMDB sends a malformed appended block', async () => {
+      mockFetchOk({
+        ...validTv,
+        credits: { cast: [], crew: [] },
+        'watch/providers': { id: 1399, results: { US: { link: 'not-a-url' } } },
+      })
+      const { getTv } = await import('@/lib/api/tmdb')
+
+      const result = await getTv(1399)
+
+      expect(result['watch/providers']).toBeUndefined()
+    })
+
+    it('parses last_air_date as null for shows still in production', async () => {
+      mockFetchOk({
+        ...validTv,
+        last_air_date: null,
+        in_production: true,
+        credits: { cast: [], crew: [] },
+      })
+      const { getTv } = await import('@/lib/api/tmdb')
+
+      const result = await getTv(1399)
+
+      expect(result.last_air_date).toBeNull()
+      expect(result.in_production).toBe(true)
+    })
+
+    it('parses the seasons array including a Specials (season_number: 0) entry', async () => {
+      mockFetchOk({ ...validTv, credits: { cast: [], crew: [] } })
+      const { getTv } = await import('@/lib/api/tmdb')
+
+      const result = await getTv(1399)
+
+      expect(result.seasons).toHaveLength(2)
+      expect(result.seasons?.[0]).toMatchObject({
+        season_number: 0,
+        name: 'Specials',
       })
     })
 
-    it('throws TmdbApiError when first_air_date is the wrong type', async () => {
-      mockFetchOk({ ...validTv, first_air_date: 1234 })
+    it('throws TmdbApiError with fieldPath when first_air_date is the wrong type', async () => {
+      mockFetchOk({
+        ...validTv,
+        first_air_date: 1234,
+        credits: { cast: [], crew: [] },
+      })
       const { getTv, TmdbApiError } = await import('@/lib/api/tmdb')
 
       const promise = getTv(1399)
@@ -422,14 +592,75 @@ describe('lib/api/tmdb', () => {
         fieldPath: 'first_air_date',
       })
     })
+
+    it('throws TmdbApiError with fieldPath rooted under seasons when a season entry is tampered', async () => {
+      mockFetchOk({
+        ...validTv,
+        seasons: [{ id: 'not-a-number', season_number: 1, name: 'S1' }],
+        credits: { cast: [], crew: [] },
+      })
+      const { getTv, TmdbApiError } = await import('@/lib/api/tmdb')
+
+      const promise = getTv(1399)
+      await expect(promise).rejects.toBeInstanceOf(TmdbApiError)
+      await expect(promise).rejects.toMatchObject({
+        fieldPath: expect.stringMatching(/^seasons\.0\.id/),
+      })
+    })
   })
 
-  describe('getEpisode', () => {
-    it('parses a valid episode response', async () => {
-      mockFetchOk(validEpisode)
-      const { getEpisode } = await import('@/lib/api/tmdb')
+  describe('getTvSeason', () => {
+    it('parses a valid /tv/:showId/season/:season response with embedded episodes', async () => {
+      mockFetchOk(validSeason)
+      const { getTvSeason } = await import('@/lib/api/tmdb')
 
-      const result = await getEpisode(1399, 1, 1)
+      const result = await getTvSeason(1399, 1)
+
+      expect(result).toMatchObject({
+        id: 3625,
+        season_number: 1,
+        name: 'Season 1',
+        air_date: '2011-04-17',
+      })
+      expect(result.episodes).toHaveLength(1)
+      expect(result.episodes[0]).toMatchObject({
+        id: 63056,
+        episode_number: 1,
+      })
+    })
+
+    it('builds /tv/:showId/season/:season without append_to_response', async () => {
+      mockFetchOk(validSeason)
+      const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+      const { getTvSeason } = await import('@/lib/api/tmdb')
+
+      await getTvSeason(1399, 1)
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string
+      const parsed = new URL(calledUrl)
+      expect(parsed.pathname).toBe('/3/tv/1399/season/1')
+      expect(parsed.searchParams.get('append_to_response')).toBeNull()
+    })
+
+    it('throws TmdbApiError with fieldPath when episodes is missing', async () => {
+      const { episodes: _omit, ...broken } = validSeason
+      mockFetchOk(broken)
+      const { getTvSeason, TmdbApiError } = await import('@/lib/api/tmdb')
+
+      const promise = getTvSeason(1399, 1)
+      await expect(promise).rejects.toBeInstanceOf(TmdbApiError)
+      await expect(promise).rejects.toMatchObject({
+        fieldPath: 'episodes',
+      })
+    })
+  })
+
+  describe('getTvEpisode', () => {
+    it('parses a valid /tv/:showId/season/:n/episode/:e response', async () => {
+      mockFetchOk(validEpisode)
+      const { getTvEpisode } = await import('@/lib/api/tmdb')
+
+      const result = await getTvEpisode(1399, 1, 1)
 
       expect(result).toMatchObject({
         id: 63056,
@@ -438,23 +669,58 @@ describe('lib/api/tmdb', () => {
       })
     })
 
-    it('builds the expected /tv/:showId/season/:season/episode/:episode path', async () => {
+    it('parses guest_stars when present (append_to_response=credits)', async () => {
+      mockFetchOk({
+        ...validEpisode,
+        guest_stars: [
+          {
+            id: 1233100,
+            name: 'Sean Bean',
+            character: 'Eddard Stark',
+            order: 0,
+            profile_path: '/sb.jpg',
+          },
+        ],
+      })
+      const { getTvEpisode } = await import('@/lib/api/tmdb')
+
+      const result = await getTvEpisode(1399, 1, 1)
+
+      expect(result.guest_stars).toHaveLength(1)
+      expect(result.guest_stars?.[0]).toMatchObject({
+        name: 'Sean Bean',
+        character: 'Eddard Stark',
+      })
+    })
+
+    it('parses an unaired episode with air_date: null without throwing', async () => {
+      mockFetchOk({ ...validEpisode, air_date: null })
+      const { getTvEpisode } = await import('@/lib/api/tmdb')
+
+      const result = await getTvEpisode(1399, 1, 1)
+
+      expect(result.air_date).toBeNull()
+    })
+
+    it('builds the expected /tv/:showId/season/:n/episode/:e path with append_to_response=credits', async () => {
       mockFetchOk(validEpisode)
       const fetchMock = global.fetch as ReturnType<typeof vi.fn>
-      const { getEpisode } = await import('@/lib/api/tmdb')
+      const { getTvEpisode } = await import('@/lib/api/tmdb')
 
-      await getEpisode(1399, 1, 1)
+      await getTvEpisode(1399, 1, 1)
 
       const calledUrl = fetchMock.mock.calls[0]?.[0] as string
-      expect(calledUrl).toContain('/tv/1399/season/1/episode/1')
+      const parsed = new URL(calledUrl)
+      expect(parsed.pathname).toBe('/3/tv/1399/season/1/episode/1')
+      expect(parsed.searchParams.get('append_to_response')).toBe('credits')
     })
 
     it('throws TmdbApiError when episode_number is missing', async () => {
       const { episode_number: _omit, ...broken } = validEpisode
       mockFetchOk(broken)
-      const { getEpisode, TmdbApiError } = await import('@/lib/api/tmdb')
+      const { getTvEpisode, TmdbApiError } = await import('@/lib/api/tmdb')
 
-      const promise = getEpisode(1399, 1, 1)
+      const promise = getTvEpisode(1399, 1, 1)
       await expect(promise).rejects.toBeInstanceOf(TmdbApiError)
       await expect(promise).rejects.toMatchObject({
         fieldPath: 'episode_number',

--- a/lib/api/tmdb.ts
+++ b/lib/api/tmdb.ts
@@ -44,50 +44,6 @@ const TmdbGenreSchema = z.object({
   name: z.string(),
 })
 
-export const TmdbMovieSchema = z.object({
-  id: z.number(),
-  title: z.string(),
-  original_title: z.string().optional(),
-  overview: z.string().nullable().optional(),
-  release_date: z.string(),
-  poster_path: z.string().nullable(),
-  backdrop_path: z.string().nullable(),
-  vote_average: z.number(),
-  popularity: z.number(),
-  genres: z.array(TmdbGenreSchema),
-  status: z.string(),
-  runtime: z.number().nullable().optional(),
-})
-export type TmdbMovie = z.infer<typeof TmdbMovieSchema>
-
-export const TmdbTvSchema = z.object({
-  id: z.number(),
-  name: z.string(),
-  original_name: z.string().optional(),
-  overview: z.string().nullable().optional(),
-  first_air_date: z.string(),
-  poster_path: z.string().nullable(),
-  backdrop_path: z.string().nullable(),
-  vote_average: z.number(),
-  popularity: z.number(),
-  genres: z.array(TmdbGenreSchema),
-  status: z.string(),
-})
-export type TmdbTv = z.infer<typeof TmdbTvSchema>
-
-export const TmdbEpisodeSchema = z.object({
-  id: z.number(),
-  name: z.string(),
-  overview: z.string().nullable().optional(),
-  air_date: z.string().nullable().optional(),
-  episode_number: z.number(),
-  season_number: z.number(),
-  still_path: z.string().nullable().optional(),
-  vote_average: z.number(),
-  runtime: z.number().nullable().optional(),
-})
-export type TmdbEpisode = z.infer<typeof TmdbEpisodeSchema>
-
 export const TmdbCastMemberSchema = z.object({
   id: z.number(),
   name: z.string(),
@@ -120,6 +76,109 @@ export const TmdbExternalIdsSchema = z.object({
   twitter_id: z.string().nullable().optional(),
 })
 export type TmdbExternalIds = z.infer<typeof TmdbExternalIdsSchema>
+
+export const TmdbMovieSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  original_title: z.string().optional(),
+  overview: z.string().nullable().optional(),
+  release_date: z.string(),
+  poster_path: z.string().nullable(),
+  backdrop_path: z.string().nullable(),
+  vote_average: z.number(),
+  popularity: z.number(),
+  genres: z.array(TmdbGenreSchema),
+  status: z.string(),
+  runtime: z.number().nullable().optional(),
+})
+export type TmdbMovie = z.infer<typeof TmdbMovieSchema>
+
+export const TmdbEpisodeSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  overview: z.string().nullable().optional(),
+  air_date: z.string().nullable().optional(),
+  episode_number: z.number(),
+  season_number: z.number(),
+  still_path: z.string().nullable().optional(),
+  vote_average: z.number(),
+  runtime: z.number().nullable().optional(),
+  production_code: z.string().nullable().optional(),
+  episode_type: z.string().optional(),
+  crew: z.array(TmdbCrewMemberSchema).optional(),
+  guest_stars: z.array(TmdbCastMemberSchema).optional(),
+})
+export type TmdbEpisode = z.infer<typeof TmdbEpisodeSchema>
+
+// Lightweight shape TMDB embeds in the `seasons` array on the show payload.
+// The full-fat per-season fetch (with `episodes`) is `TmdbSeasonSchema` below.
+export const TmdbSeasonSummarySchema = z.object({
+  id: z.number(),
+  season_number: z.number(),
+  name: z.string(),
+  overview: z.string().nullable().optional(),
+  poster_path: z.string().nullable().optional(),
+  air_date: z.string().nullable().optional(),
+  episode_count: z.number().optional(),
+  vote_average: z.number().optional(),
+})
+export type TmdbSeasonSummary = z.infer<typeof TmdbSeasonSummarySchema>
+
+// Sparse shape TMDB returns for `last_episode_to_air` and `next_episode_to_air`
+// on the show payload. Kept separate from `TmdbEpisodeSchema` so the full-episode
+// invariants (e.g. `vote_average` semantics on aired-and-rated episodes) stay
+// tight without leaking into the forward-looking summary surface.
+export const TmdbEpisodeSummarySchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  overview: z.string().nullable().optional(),
+  air_date: z.string().nullable().optional(),
+  episode_number: z.number(),
+  season_number: z.number(),
+  runtime: z.number().nullable().optional(),
+  still_path: z.string().nullable().optional(),
+  vote_average: z.number().optional(),
+  production_code: z.string().nullable().optional(),
+  episode_type: z.string().optional(),
+})
+export type TmdbEpisodeSummary = z.infer<typeof TmdbEpisodeSummarySchema>
+
+export const TmdbTvSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  original_name: z.string().optional(),
+  overview: z.string().nullable().optional(),
+  first_air_date: z.string(),
+  last_air_date: z.string().nullable().optional(),
+  poster_path: z.string().nullable(),
+  backdrop_path: z.string().nullable(),
+  vote_average: z.number(),
+  popularity: z.number(),
+  genres: z.array(TmdbGenreSchema),
+  status: z.string(),
+  tagline: z.string().nullable().optional(),
+  in_production: z.boolean().optional(),
+  number_of_seasons: z.number().optional(),
+  number_of_episodes: z.number().optional(),
+  episode_run_time: z.array(z.number()).optional(),
+  seasons: z.array(TmdbSeasonSummarySchema).optional(),
+  last_episode_to_air: TmdbEpisodeSummarySchema.nullable().optional(),
+  next_episode_to_air: TmdbEpisodeSummarySchema.nullable().optional(),
+})
+export type TmdbTv = z.infer<typeof TmdbTvSchema>
+
+export const TmdbSeasonSchema = z.object({
+  _id: z.string().optional(),
+  id: z.number(),
+  season_number: z.number(),
+  name: z.string(),
+  overview: z.string().nullable().optional(),
+  poster_path: z.string().nullable().optional(),
+  air_date: z.string().nullable().optional(),
+  vote_average: z.number().optional(),
+  episodes: z.array(TmdbEpisodeSchema),
+})
+export type TmdbSeason = z.infer<typeof TmdbSeasonSchema>
 
 const TmdbSearchMovieResultSchema = z.object({
   media_type: z.literal('movie'),
@@ -341,18 +400,51 @@ export function getMovieCredits(id: number): Promise<TmdbCredits> {
   return tmdbFetch(`/movie/${id}/credits`, {}, TmdbCreditsSchema)
 }
 
-export function getTv(id: number): Promise<TmdbTv> {
-  return tmdbFetch(`/tv/${id}`, {}, TmdbTvSchema)
+export function getTv(id: number): Promise<
+  TmdbTv & {
+    credits: TmdbCredits
+    external_ids?: TmdbExternalIds
+    'watch/providers'?: TmdbWatchProvidersResponse
+  }
+> {
+  // Always augment with credits + external_ids + watch/providers so the
+  // /tv/[id] detail page (Story 7.5) gets the full hierarchy in one round-trip.
+  // external_ids and watch/providers use .optional().catch(undefined) so both an
+  // absent block AND a malformed appended block degrade gracefully (no IMDb
+  // button, no providers row) instead of failing the detail page.
+  const schema = TmdbTvSchema.extend({
+    credits: TmdbCreditsSchema,
+    external_ids: TmdbExternalIdsSchema.optional().catch(undefined),
+    'watch/providers': TmdbWatchProvidersResponseSchema.optional().catch(
+      undefined,
+    ),
+  })
+  return tmdbFetch(
+    `/tv/${id}`,
+    { append_to_response: 'credits,external_ids,watch/providers' },
+    schema,
+  )
 }
 
-export function getEpisode(
+export function getTvSeason(
   showId: number,
-  season: number,
-  episode: number,
+  seasonNumber: number,
+): Promise<TmdbSeason> {
+  return tmdbFetch(
+    `/tv/${showId}/season/${seasonNumber}`,
+    {},
+    TmdbSeasonSchema,
+  )
+}
+
+export function getTvEpisode(
+  showId: number,
+  seasonNumber: number,
+  episodeNumber: number,
 ): Promise<TmdbEpisode> {
   return tmdbFetch(
-    `/tv/${showId}/season/${season}/episode/${episode}`,
-    {},
+    `/tv/${showId}/season/${seasonNumber}/episode/${episodeNumber}`,
+    { append_to_response: 'credits' },
     TmdbEpisodeSchema,
   )
 }

--- a/lib/db/__tests__/library.test.ts
+++ b/lib/db/__tests__/library.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { MediaType, WatchStatus } from '@prisma/client'
+
+const dbMock = vi.hoisted(() => ({
+  userEntry: { findMany: vi.fn(), findUnique: vi.fn() },
+  mediaItem: { groupBy: vi.fn() },
+}))
+
+vi.mock('@/lib/db', () => ({ db: dbMock }))
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.resetAllMocks()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+function tvShowEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'tv-entry-1',
+    media_item_id: 'tv-show-1',
+    status: WatchStatus.WATCHING,
+    user_rating: null,
+    progress: 0,
+    notes: null,
+    started_at: null,
+    completed_at: null,
+    created_at: new Date('2026-05-10T12:00:00Z'),
+    updated_at: new Date('2026-05-12T12:00:00Z'),
+    media_item: {
+      id: 'tv-show-1',
+      type: MediaType.TV_SHOW,
+      title: 'Breaking Bad',
+      lifecycle_status: 'ended',
+    },
+    ...overrides,
+  }
+}
+
+describe('findLibraryItems: episodeStats attachment (Story 7.4 AC-2)', () => {
+  it('attaches episodeStats with watched + total + latest S/E for TV_SHOW entries', async () => {
+    const entry = tvShowEntry()
+    dbMock.userEntry.findMany.mockImplementation(
+      (args: { where?: { media_item?: { parent_id?: unknown } } }) => {
+        if (args?.where?.media_item?.parent_id) {
+          // Second call: watched episodes lookup.
+          return Promise.resolve([
+            { media_item: { parent_id: 'tv-show-1', season_number: 2, episode_number: 4 } },
+            { media_item: { parent_id: 'tv-show-1', season_number: 2, episode_number: 3 } },
+            { media_item: { parent_id: 'tv-show-1', season_number: 1, episode_number: 1 } },
+          ])
+        }
+        return Promise.resolve([entry])
+      },
+    )
+    dbMock.mediaItem.groupBy.mockResolvedValue([
+      { parent_id: 'tv-show-1', _count: { id: 10 } },
+    ])
+
+    const { findLibraryItems } = await import('@/lib/db/library')
+    const result = await findLibraryItems({ mediaType: MediaType.TV_SHOW })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].episodeStats).toEqual({
+      total: 10,
+      watched: 3,
+      latestS: 2,
+      latestE: 4,
+    })
+  })
+
+  it('skips episodeStats attachment when no TV_SHOW entries are returned (no follow-up queries fire)', async () => {
+    dbMock.userEntry.findMany.mockResolvedValue([])
+    const { findLibraryItems } = await import('@/lib/db/library')
+    await findLibraryItems({ mediaType: MediaType.MOVIE })
+
+    expect(dbMock.mediaItem.groupBy).not.toHaveBeenCalled()
+    // Primary findMany was called once; no second watched-episodes call.
+    expect(dbMock.userEntry.findMany).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns zero stats when the show has no watched episodes', async () => {
+    const entry = tvShowEntry({ status: WatchStatus.PLAN_TO_WATCH })
+    dbMock.userEntry.findMany.mockImplementation(
+      (args: { where?: { media_item?: { parent_id?: unknown } } }) => {
+        if (args?.where?.media_item?.parent_id) return Promise.resolve([])
+        return Promise.resolve([entry])
+      },
+    )
+    dbMock.mediaItem.groupBy.mockResolvedValue([
+      { parent_id: 'tv-show-1', _count: { id: 10 } },
+    ])
+
+    const { findLibraryItems } = await import('@/lib/db/library')
+    const result = await findLibraryItems({ mediaType: MediaType.TV_SHOW })
+
+    expect(result[0].episodeStats).toEqual({
+      total: 10,
+      watched: 0,
+      latestS: null,
+      latestE: null,
+    })
+  })
+
+  it('reports zero total when the show has no aired episodes (announced-only)', async () => {
+    const entry = tvShowEntry({ status: WatchStatus.PLAN_TO_WATCH })
+    dbMock.userEntry.findMany.mockImplementation(
+      (args: { where?: { media_item?: { parent_id?: unknown } } }) => {
+        if (args?.where?.media_item?.parent_id) return Promise.resolve([])
+        return Promise.resolve([entry])
+      },
+    )
+    // groupBy returns no row for this show — Prisma omits zero-count groups.
+    dbMock.mediaItem.groupBy.mockResolvedValue([])
+
+    const { findLibraryItems } = await import('@/lib/db/library')
+    const result = await findLibraryItems({ mediaType: MediaType.TV_SHOW })
+
+    expect(result[0].episodeStats).toEqual({
+      total: 0,
+      watched: 0,
+      latestS: null,
+      latestE: null,
+    })
+  })
+
+  it('handles Specials S0E0 episode without collapsing to the sentinel (ECH-T9 patch)', async () => {
+    const entry = tvShowEntry()
+    dbMock.userEntry.findMany.mockImplementation(
+      (args: { where?: { media_item?: { parent_id?: unknown } } }) => {
+        if (args?.where?.media_item?.parent_id) {
+          return Promise.resolve([
+            { media_item: { parent_id: 'tv-show-1', season_number: 0, episode_number: 0 } },
+          ])
+        }
+        return Promise.resolve([entry])
+      },
+    )
+    dbMock.mediaItem.groupBy.mockResolvedValue([
+      { parent_id: 'tv-show-1', _count: { id: 5 } },
+    ])
+
+    const { findLibraryItems } = await import('@/lib/db/library')
+    const result = await findLibraryItems({ mediaType: MediaType.TV_SHOW })
+
+    // After the -1 init fix, S0E0 wins on the first comparison (0 > -1).
+    expect(result[0].episodeStats).toEqual({
+      total: 5,
+      watched: 1,
+      latestS: 0,
+      latestE: 0,
+    })
+  })
+})
+
+describe('findLibraryItems: lifecycle filters (Story 7.4 AC-6)', () => {
+  it('applies lifecycleStatus to media_item.lifecycle_status WHERE clause', async () => {
+    dbMock.userEntry.findMany.mockResolvedValue([])
+    const { findLibraryItems } = await import('@/lib/db/library')
+    await findLibraryItems({ lifecycleStatus: 'continuing' })
+
+    const call = dbMock.userEntry.findMany.mock.calls[0][0]
+    expect(call.where.media_item.lifecycle_status).toBe('continuing')
+  })
+
+  it('lifecycleInProgress sets WATCHING status AND lifecycle_status=continuing', async () => {
+    dbMock.userEntry.findMany.mockResolvedValue([])
+    const { findLibraryItems } = await import('@/lib/db/library')
+    await findLibraryItems({ lifecycleInProgress: true })
+
+    const call = dbMock.userEntry.findMany.mock.calls[0][0]
+    expect(call.where.status).toBe(WatchStatus.WATCHING)
+    expect(call.where.media_item.lifecycle_status).toBe('continuing')
+  })
+
+  it('lifecycleInProgress overrides an explicit status arg (composite ergonomic)', async () => {
+    dbMock.userEntry.findMany.mockResolvedValue([])
+    const { findLibraryItems } = await import('@/lib/db/library')
+    await findLibraryItems({
+      status: WatchStatus.COMPLETED,
+      lifecycleInProgress: true,
+    })
+
+    const call = dbMock.userEntry.findMany.mock.calls[0][0]
+    expect(call.where.status).toBe(WatchStatus.WATCHING)
+  })
+
+  it('lifecycleStatus=ended does NOT pin status (only filters media_item)', async () => {
+    dbMock.userEntry.findMany.mockResolvedValue([])
+    const { findLibraryItems } = await import('@/lib/db/library')
+    await findLibraryItems({ lifecycleStatus: 'ended' })
+
+    const call = dbMock.userEntry.findMany.mock.calls[0][0]
+    expect(call.where.status).toBeUndefined()
+    expect(call.where.media_item.lifecycle_status).toBe('ended')
+  })
+})
+
+describe('formatTvProgressLabel + formatTvProgressPct (Story 7.4 hoisted helpers)', () => {
+  it('returns null for PLAN_TO_WATCH with no stats', async () => {
+    const { formatTvProgressLabel, formatTvProgressPct } = await import('@/lib/db/library')
+    expect(formatTvProgressLabel(WatchStatus.PLAN_TO_WATCH, undefined)).toBeNull()
+    expect(formatTvProgressPct(undefined)).toBeNull()
+  })
+
+  it('returns status label for WATCHING with zero total', async () => {
+    const { formatTvProgressLabel } = await import('@/lib/db/library')
+    const stats = { total: 0, watched: 0, latestS: null, latestE: null }
+    expect(formatTvProgressLabel(WatchStatus.WATCHING, stats)).toBe('WATCHING')
+  })
+
+  it('formats S{n}E{m} / {total} when watched > 0', async () => {
+    const { formatTvProgressLabel } = await import('@/lib/db/library')
+    const stats = { total: 10, watched: 4, latestS: 2, latestE: 4 }
+    expect(formatTvProgressLabel(WatchStatus.WATCHING, stats)).toBe('S2E4 / 10')
+  })
+
+  it('formatTvProgressPct rounds to nearest integer', async () => {
+    const { formatTvProgressPct } = await import('@/lib/db/library')
+    // 7/10 → 70, 5/7 → 71 (rounded from 71.4...), 199/200 → 100
+    expect(formatTvProgressPct({ total: 10, watched: 7, latestS: null, latestE: null })).toBe(70)
+    expect(formatTvProgressPct({ total: 7, watched: 5, latestS: null, latestE: null })).toBe(71)
+    expect(formatTvProgressPct({ total: 200, watched: 199, latestS: null, latestE: null })).toBe(100)
+  })
+})

--- a/lib/db/library.ts
+++ b/lib/db/library.ts
@@ -9,6 +9,8 @@ export type LibrarySortKey =
   | 'status_asc'
   | 'rating_desc'
 
+export type LifecycleStatus = 'continuing' | 'ended' | 'in_production'
+
 export type LibraryQueryOptions = {
   mediaType?: MediaType
   status?: WatchStatus
@@ -16,9 +18,23 @@ export type LibraryQueryOptions = {
   sort?: LibrarySortKey
   limit?: number
   releasedWithinDays?: number
+  lifecycleStatus?: LifecycleStatus
+  // Composite filter: status=WATCHING AND media_item.lifecycle_status='continuing'.
+  // Mutually exclusive with lifecycleStatus; the caller passes one or the other.
+  lifecycleInProgress?: boolean
 }
 
-export type UserEntryWithMedia = UserEntry & { media_item: MediaItem }
+export type EpisodeStats = {
+  total: number
+  watched: number
+  latestS: number | null
+  latestE: number | null
+}
+
+export type UserEntryWithMedia = UserEntry & {
+  media_item: MediaItem
+  episodeStats?: EpisodeStats
+}
 
 const DEFAULT_LIMIT = 200
 const DEFAULT_SORT: LibrarySortKey = 'recently_added'
@@ -42,6 +58,8 @@ export async function findLibraryItems(
     sort = DEFAULT_SORT,
     limit = DEFAULT_LIMIT,
     releasedWithinDays,
+    lifecycleStatus,
+    lifecycleInProgress,
   } = opts
 
   const mediaWhere: Prisma.MediaItemWhereInput = {}
@@ -54,9 +72,22 @@ export async function findLibraryItems(
     const floor = new Date(now.getTime() - releasedWithinDays * 24 * 60 * 60 * 1000)
     mediaWhere.release_date = { gte: floor, lte: now }
   }
+  if (lifecycleStatus !== undefined) {
+    mediaWhere.lifecycle_status = lifecycleStatus
+  }
+  // The composite "in_progress" filter pins lifecycle_status='continuing' on
+  // the media item AND status=WATCHING on the UserEntry. Mutually exclusive
+  // with an explicit `status` override (the AC ergonomic is a single click).
+  if (lifecycleInProgress) {
+    mediaWhere.lifecycle_status = 'continuing'
+  }
 
   const where: Prisma.UserEntryWhereInput = {}
-  if (status) where.status = status
+  if (lifecycleInProgress) {
+    where.status = WatchStatus.WATCHING
+  } else if (status) {
+    where.status = status
+  }
   if (Object.keys(mediaWhere).length > 0) where.media_item = mediaWhere
 
   // releasedWithinDays forces ordering by release_date desc to match
@@ -66,12 +97,127 @@ export async function findLibraryItems(
 
   const orderBy = buildOrderBy(effectiveSort)
 
-  return db.userEntry.findMany({
+  const entries: UserEntryWithMedia[] = await db.userEntry.findMany({
     where: Object.keys(where).length > 0 ? where : undefined,
     include: { media_item: true },
     orderBy,
     take: limit,
   })
+
+  // Attach per-show episode stats to TV_SHOW entries. Single batched query
+  // for totals + a flat findMany for COMPLETED episode UserEntries grouped
+  // in JS. Cheaper than N per-show aggregates; correct for the single-user
+  // tracker's scale.
+  await attachEpisodeStats(entries)
+
+  return entries
+}
+
+async function attachEpisodeStats(
+  entries: UserEntryWithMedia[],
+): Promise<void> {
+  const showIds = entries
+    .filter((e) => e.media_item.type === MediaType.TV_SHOW)
+    .map((e) => e.media_item.id)
+  if (showIds.length === 0) return
+
+  // Totals: count aired (non-unaired) episodes per show.
+  const totals = await db.mediaItem.groupBy({
+    by: ['parent_id'],
+    where: {
+      parent_id: { in: showIds },
+      type: MediaType.TV_EPISODE,
+      unaired: false,
+    },
+    _count: { id: true },
+  })
+  const totalsMap = new Map<string, number>()
+  for (const row of totals) {
+    if (row.parent_id !== null) totalsMap.set(row.parent_id, row._count.id)
+  }
+
+  // Watched episodes — fetch (parent_id, season_number, episode_number) for
+  // every COMPLETED UserEntry whose MediaItem is an episode of a show in our
+  // result set. Group in JS to compute per-show stats.
+  const watchedEpisodes = await db.userEntry.findMany({
+    where: {
+      status: WatchStatus.COMPLETED,
+      media_item: {
+        parent_id: { in: showIds },
+        type: MediaType.TV_EPISODE,
+      },
+    },
+    select: {
+      media_item: {
+        select: {
+          parent_id: true,
+          season_number: true,
+          episode_number: true,
+        },
+      },
+    },
+  })
+
+  type Accum = { watched: number; latestS: number; latestE: number }
+  const watchedMap = new Map<string, Accum>()
+  for (const row of watchedEpisodes) {
+    const pid = row.media_item.parent_id
+    if (pid === null) continue
+    // Skip rows where season/episode are both null — they can't contribute a
+    // meaningful "latest watched" position. The episode normaliser populates
+    // both for TMDB episodes; nulls are corruption or pre-7.2 backfill rows.
+    if (row.media_item.season_number === null && row.media_item.episode_number === null) {
+      continue
+    }
+    const s = row.media_item.season_number ?? 0
+    const ep = row.media_item.episode_number ?? 0
+    // Initial sentinel is -1/-1 so a Specials S0E0 episode wins on the first
+    // comparison (0 > -1) instead of tying with the accumulator default.
+    const cur = watchedMap.get(pid) ?? { watched: 0, latestS: -1, latestE: -1 }
+    cur.watched += 1
+    if (s > cur.latestS || (s === cur.latestS && ep > cur.latestE)) {
+      cur.latestS = s
+      cur.latestE = ep
+    }
+    watchedMap.set(pid, cur)
+  }
+
+  for (const entry of entries) {
+    if (entry.media_item.type !== MediaType.TV_SHOW) continue
+    const total = totalsMap.get(entry.media_item.id) ?? 0
+    const watched = watchedMap.get(entry.media_item.id)
+    entry.episodeStats = {
+      total,
+      watched: watched?.watched ?? 0,
+      latestS: watched && watched.watched > 0 ? watched.latestS : null,
+      latestE: watched && watched.watched > 0 ? watched.latestE : null,
+    }
+  }
+}
+
+// Shared between `/api/library` (wire serializer) and `app/(media)/tv/page.tsx`
+// (SSR fetch path). Lifting the formatter here keeps both call sites in sync
+// when the AC's progress wording changes.
+export function formatTvProgressLabel(
+  status: WatchStatus,
+  stats: EpisodeStats | undefined,
+): string | null {
+  if (!stats || stats.total === 0) {
+    if (status === WatchStatus.PLAN_TO_WATCH) return null
+    return status.replaceAll('_', ' ')
+  }
+  if (stats.watched === 0) {
+    if (status === WatchStatus.PLAN_TO_WATCH) return null
+    return status.replaceAll('_', ' ')
+  }
+  return `S${stats.latestS}E${stats.latestE} / ${stats.total}`
+}
+
+export function formatTvProgressPct(
+  stats: EpisodeStats | undefined,
+): number | null {
+  if (!stats || stats.total === 0) return null
+  return Math.round((stats.watched / stats.total) * 100)
 }
 
 function buildOrderBy(

--- a/lib/normalise/__tests__/tv.test.ts
+++ b/lib/normalise/__tests__/tv.test.ts
@@ -1,0 +1,612 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { ZodError } from 'zod'
+import { MediaType } from '@prisma/client'
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+type EpisodeOverride = Partial<{
+  id: number
+  name: string
+  overview: string | null
+  air_date: string | null
+  episode_number: number
+  season_number: number
+  still_path: string | null
+  vote_average: number
+  runtime: number | null
+}>
+
+function validEpisodePayload(
+  seasonNumber: number,
+  episodeNumber: number,
+  override: EpisodeOverride = {},
+) {
+  return {
+    id: seasonNumber * 1000 + episodeNumber,
+    name: `S${seasonNumber}E${episodeNumber}`,
+    overview: 'plot summary',
+    air_date: '2008-01-20',
+    episode_number: episodeNumber,
+    season_number: seasonNumber,
+    still_path: `/still-${seasonNumber}-${episodeNumber}.jpg`,
+    vote_average: 8.5,
+    runtime: 45,
+    ...override,
+  }
+}
+
+function validSeasonPayload({
+  season_number,
+  episode_count,
+  episodeOverride,
+}: {
+  season_number: number
+  episode_count: number
+  episodeOverride?: (epIdx: number) => EpisodeOverride
+}) {
+  return {
+    id: 100 + season_number,
+    season_number,
+    name: season_number === 0 ? 'Specials' : `Season ${season_number}`,
+    overview: null,
+    poster_path: `/season-${season_number}.jpg`,
+    air_date: '2008-01-20',
+    vote_average: 8.5,
+    episodes: Array.from({ length: episode_count }, (_, i) =>
+      validEpisodePayload(
+        season_number,
+        i + 1,
+        episodeOverride?.(i + 1) ?? {},
+      ),
+    ),
+  }
+}
+
+function validTvPayload(override: Partial<{
+  status: string
+  last_air_date: string | null
+  first_air_date: string | null
+  original_name: string | undefined
+  overview: string | null
+  poster_path: string | null
+  backdrop_path: string | null
+}> = {}) {
+  return {
+    id: 1396,
+    name: 'Breaking Bad',
+    original_name: 'Breaking Bad',
+    overview: 'A high school chemistry teacher...',
+    first_air_date: '2008-01-20',
+    last_air_date: '2013-09-29',
+    poster_path: '/bb-poster.jpg',
+    backdrop_path: '/bb-backdrop.jpg',
+    vote_average: 8.9,
+    popularity: 121.4,
+    genres: [
+      { id: 18, name: 'Drama' },
+      { id: 80, name: 'Crime' },
+    ],
+    status: 'Ended',
+    tagline: 'All hail the king.',
+    in_production: false,
+    number_of_seasons: 5,
+    number_of_episodes: 62,
+    ...override,
+  }
+}
+
+describe('lib/normalise/tv', () => {
+  describe('happy path: 2 seasons × 10 episodes', () => {
+    it('returns 1 show row + 20 episode rows with correct types', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(validTvPayload(), [
+        validSeasonPayload({ season_number: 1, episode_count: 10 }),
+        validSeasonPayload({ season_number: 2, episode_count: 10 }),
+      ])
+
+      expect(result.show.type).toBe(MediaType.TV_SHOW)
+      expect(result.episodes).toHaveLength(20)
+      for (const episode of result.episodes) {
+        expect(episode.type).toBe(MediaType.TV_EPISODE)
+      }
+    })
+
+    it('maps every documented show field correctly', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(validTvPayload(), [])
+
+      expect(result.show).toMatchObject({
+        type: MediaType.TV_SHOW,
+        title: 'Breaking Bad',
+        original_title: 'Breaking Bad',
+        overview: 'A high school chemistry teacher...',
+        poster_path: '/bb-poster.jpg',
+        backdrop_path: '/bb-backdrop.jpg',
+        rating: 8.9,
+        popularity: 121.4,
+        status: 'Ended',
+        lifecycle_status: 'ended',
+        tmdb_id: 1396,
+      })
+      expect(result.show.genres).toEqual(['Drama', 'Crime'])
+      expect((result.show.release_date as Date).toISOString()).toBe(
+        '2008-01-20T00:00:00.000Z',
+      )
+      expect((result.show.end_date as Date).toISOString()).toBe(
+        '2013-09-29T00:00:00.000Z',
+      )
+    })
+
+    it('maps every documented episode field correctly', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(validTvPayload(), [
+        validSeasonPayload({ season_number: 1, episode_count: 2 }),
+      ])
+
+      expect(result.episodes[0]).toMatchObject({
+        type: MediaType.TV_EPISODE,
+        title: 'S1E1',
+        original_title: null,
+        overview: 'plot summary',
+        still_path: '/still-1-1.jpg',
+        rating: 8.5,
+        runtime: 45,
+        season_number: 1,
+        episode_number: 1,
+        unaired: false,
+        tmdb_id: 1001,
+      })
+      expect(result.episodes[0].poster_path).toBeNull()
+      expect(result.episodes[0].backdrop_path).toBeNull()
+      expect(result.episodes[0].popularity).toBeNull()
+      expect(result.episodes[0].genres).toEqual([])
+      expect((result.episodes[0].release_date as Date).toISOString()).toBe(
+        '2008-01-20T00:00:00.000Z',
+      )
+    })
+  })
+
+  describe('unaired episode handling', () => {
+    it('flags unaired: true when air_date is null', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(validTvPayload(), [
+        validSeasonPayload({
+          season_number: 1,
+          episode_count: 1,
+          episodeOverride: () => ({ air_date: null }),
+        }),
+      ])
+
+      expect(result.episodes[0].unaired).toBe(true)
+      expect((result.episodes[0].release_date as Date).toISOString()).toBe(
+        '1970-01-01T00:00:00.000Z',
+      )
+    })
+
+    it('flags unaired: true when air_date is an empty string', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(validTvPayload(), [
+        validSeasonPayload({
+          season_number: 1,
+          episode_count: 1,
+          episodeOverride: () => ({ air_date: '' }),
+        }),
+      ])
+
+      expect(result.episodes[0].unaired).toBe(true)
+      expect((result.episodes[0].release_date as Date).toISOString()).toBe(
+        '1970-01-01T00:00:00.000Z',
+      )
+    })
+
+    it('flags unaired: false on a future-dated episode (deterministic — no Date.now())', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(validTvPayload(), [
+        validSeasonPayload({
+          season_number: 1,
+          episode_count: 1,
+          episodeOverride: () => ({ air_date: '2099-01-01' }),
+        }),
+      ])
+
+      expect(result.episodes[0].unaired).toBe(false)
+      expect((result.episodes[0].release_date as Date).toISOString()).toBe(
+        '2099-01-01T00:00:00.000Z',
+      )
+    })
+
+    it('flags unaired: false on an aired episode', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(validTvPayload(), [
+        validSeasonPayload({ season_number: 1, episode_count: 1 }),
+      ])
+
+      expect(result.episodes[0].unaired).toBe(false)
+    })
+  })
+
+  describe('lifecycle_status mapping (LIFECYCLE_STATUS_MAP)', () => {
+    const cases: Array<{ status: string; expected: string }> = [
+      { status: 'Ended', expected: 'ended' },
+      { status: 'Canceled', expected: 'ended' },
+      { status: 'Returning Series', expected: 'continuing' },
+      { status: 'In Production', expected: 'in_production' },
+      { status: 'Planned', expected: 'in_production' },
+      { status: 'Pilot', expected: 'in_production' },
+    ]
+
+    it.each(cases)(
+      'maps TMDB status "$status" to lifecycle_status "$expected"',
+      async ({ status, expected }) => {
+        const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+        const result = normaliseTmdbTv(validTvPayload({ status }), [])
+
+        expect(result.show.lifecycle_status).toBe(expected)
+        expect(result.show.status).toBe(status)
+      },
+    )
+
+    it('defaults unknown TMDB status to "continuing" (permissive fallback)', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(
+        validTvPayload({ status: 'Limited Series' }),
+        [],
+      )
+
+      expect(result.show.lifecycle_status).toBe('continuing')
+      expect(result.show.status).toBe('Limited Series')
+    })
+  })
+
+  describe('end_date handling', () => {
+    it('preserves end_date when last_air_date is set', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(
+        validTvPayload({ last_air_date: '2013-09-29' }),
+        [],
+      )
+
+      expect((result.show.end_date as Date).toISOString()).toBe(
+        '2013-09-29T00:00:00.000Z',
+      )
+    })
+
+    it('writes null end_date when last_air_date is absent', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const { last_air_date: _omit, ...source } = validTvPayload()
+      const result = normaliseTmdbTv(source, [])
+
+      expect(result.show.end_date).toBeNull()
+    })
+
+    it('writes null end_date when last_air_date is null', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(
+        validTvPayload({ last_air_date: null }),
+        [],
+      )
+
+      expect(result.show.end_date).toBeNull()
+    })
+  })
+
+  describe('first_air_date null coercion', () => {
+    it('falls back to 1970 sentinel when first_air_date is null (mirrors normaliseTmdbMovie behaviour)', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(
+        validTvPayload({ first_air_date: null }),
+        [],
+      )
+
+      expect((result.show.release_date as Date).toISOString()).toBe(
+        '1970-01-01T00:00:00.000Z',
+      )
+    })
+
+    it('falls back to 1970 sentinel when first_air_date is an empty string', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(
+        validTvPayload({ first_air_date: '' }),
+        [],
+      )
+
+      expect((result.show.release_date as Date).toISOString()).toBe(
+        '1970-01-01T00:00:00.000Z',
+      )
+    })
+
+    it('constructs Jan 1 UTC for year-only first_air_date', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(
+        validTvPayload({ first_air_date: '2024' }),
+        [],
+      )
+
+      expect((result.show.release_date as Date).toISOString()).toBe(
+        '2024-01-01T00:00:00.000Z',
+      )
+    })
+  })
+
+  describe('Specials season handling', () => {
+    it('includes Specials (season_number: 0) episodes in the output', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(validTvPayload(), [
+        validSeasonPayload({ season_number: 0, episode_count: 2 }),
+        validSeasonPayload({ season_number: 1, episode_count: 3 }),
+      ])
+
+      expect(result.episodes).toHaveLength(5)
+      const specials = result.episodes.filter((e) => e.season_number === 0)
+      expect(specials).toHaveLength(2)
+      expect(specials[0].title).toBe('S0E1')
+    })
+
+    it('preserves season-then-episode insertion order', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(validTvPayload(), [
+        validSeasonPayload({ season_number: 2, episode_count: 2 }),
+        validSeasonPayload({ season_number: 1, episode_count: 2 }),
+      ])
+
+      expect(
+        result.episodes.map((e) => [e.season_number, e.episode_number]),
+      ).toEqual([
+        [2, 1],
+        [2, 2],
+        [1, 1],
+        [1, 2],
+      ])
+    })
+  })
+
+  describe('nullable / empty source-field handling', () => {
+    it('writes null original_title when original_name is absent', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(
+        validTvPayload({ original_name: undefined }),
+        [],
+      )
+
+      expect(result.show.original_title).toBeNull()
+    })
+
+    it('writes null overview when source overview is null', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(validTvPayload({ overview: null }), [])
+
+      expect(result.show.overview).toBeNull()
+    })
+
+    it('preserves null poster_path and backdrop_path on the show row', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(
+        validTvPayload({ poster_path: null, backdrop_path: null }),
+        [],
+      )
+
+      expect(result.show.poster_path).toBeNull()
+      expect(result.show.backdrop_path).toBeNull()
+    })
+
+    it('preserves null still_path on episode rows', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(validTvPayload(), [
+        validSeasonPayload({
+          season_number: 1,
+          episode_count: 1,
+          episodeOverride: () => ({ still_path: null }),
+        }),
+      ])
+
+      expect(result.episodes[0].still_path).toBeNull()
+    })
+
+    it('preserves null runtime on episode rows', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(validTvPayload(), [
+        validSeasonPayload({
+          season_number: 1,
+          episode_count: 1,
+          episodeOverride: () => ({ runtime: null }),
+        }),
+      ])
+
+      expect(result.episodes[0].runtime).toBeNull()
+    })
+
+    it('writes empty episodes array when seasons is empty', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(validTvPayload(), [])
+
+      expect(result.episodes).toEqual([])
+    })
+
+    it('writes empty episodes array when a season has zero episodes', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const result = normaliseTmdbTv(validTvPayload(), [
+        validSeasonPayload({ season_number: 1, episode_count: 0 }),
+      ])
+
+      expect(result.episodes).toEqual([])
+    })
+  })
+
+  describe('malformed input', () => {
+    it('throws ZodError when show id is wrong type', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const broken = { ...validTvPayload(), id: 'not-a-number' }
+
+      expect(() => normaliseTmdbTv(broken, [])).toThrow(ZodError)
+    })
+
+    it('throws ZodError when a required show field is missing', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const { name: _name, ...broken } = validTvPayload()
+
+      expect(() => normaliseTmdbTv(broken, [])).toThrow(ZodError)
+    })
+
+    it('throws ZodError when input is null or undefined', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      expect(() => normaliseTmdbTv(null, [])).toThrow(ZodError)
+      expect(() => normaliseTmdbTv(undefined, [])).toThrow(ZodError)
+    })
+
+    it('throws ZodError when a season payload is malformed', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const brokenSeason = {
+        ...validSeasonPayload({ season_number: 1, episode_count: 1 }),
+        episodes: 'not-an-array',
+      }
+
+      expect(() => normaliseTmdbTv(validTvPayload(), [brokenSeason])).toThrow(
+        ZodError,
+      )
+    })
+
+    it('throws ZodError when an episode inside a season is malformed', async () => {
+      const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+      const brokenSeason = validSeasonPayload({
+        season_number: 1,
+        episode_count: 1,
+      })
+      // @ts-expect-error — deliberately invalidating the fixture
+      brokenSeason.episodes[0].episode_number = 'one'
+
+      expect(() => normaliseTmdbTv(validTvPayload(), [brokenSeason])).toThrow(
+        ZodError,
+      )
+    })
+  })
+
+  describe('NFR13 invariant: every release_date is a valid Date', () => {
+    const fixtures: Array<{
+      name: string
+      first_air_date: string | null
+      last_air_date: string | null
+      episode_air_date: string | null
+    }> = [
+      {
+        name: 'happy yyyy-mm-dd',
+        first_air_date: '2008-01-20',
+        last_air_date: '2013-09-29',
+        episode_air_date: '2008-01-20',
+      },
+      {
+        name: 'null first_air_date',
+        first_air_date: null,
+        last_air_date: null,
+        episode_air_date: null,
+      },
+      {
+        name: 'empty first_air_date',
+        first_air_date: '',
+        last_air_date: '',
+        episode_air_date: '',
+      },
+      {
+        name: 'year-only first_air_date',
+        first_air_date: '2024',
+        last_air_date: '2024',
+        episode_air_date: '2024',
+      },
+      {
+        name: 'malformed first_air_date',
+        first_air_date: 'not-a-date',
+        last_air_date: 'not-a-date',
+        episode_air_date: 'not-a-date',
+      },
+    ]
+
+    it.each(fixtures)(
+      'produces a valid Date for variant "$name"',
+      async ({ first_air_date, last_air_date, episode_air_date }) => {
+        const { normaliseTmdbTv } = await import('@/lib/normalise/tv')
+
+        const result = normaliseTmdbTv(
+          validTvPayload({ first_air_date, last_air_date }),
+          [
+            validSeasonPayload({
+              season_number: 1,
+              episode_count: 1,
+              episodeOverride: () => ({ air_date: episode_air_date }),
+            }),
+          ],
+        )
+
+        expect(result.show.release_date).toBeInstanceOf(Date)
+        expect(
+          Number.isNaN((result.show.release_date as Date).getTime()),
+        ).toBe(false)
+        if (result.show.end_date !== null) {
+          expect(result.show.end_date).toBeInstanceOf(Date)
+          expect(
+            Number.isNaN((result.show.end_date as Date).getTime()),
+          ).toBe(false)
+        }
+        for (const episode of result.episodes) {
+          expect(episode.release_date).toBeInstanceOf(Date)
+          expect(
+            Number.isNaN((episode.release_date as Date).getTime()),
+          ).toBe(false)
+        }
+      },
+    )
+  })
+})

--- a/lib/normalise/movie.ts
+++ b/lib/normalise/movie.ts
@@ -1,5 +1,6 @@
 import { Prisma, MediaType } from '@prisma/client'
 import { TmdbMovieSchema, TmdbCreditsSchema } from '@/lib/api/tmdb'
+import { parseReleaseDate } from '@/lib/normalise/release-date'
 
 export type NormalisedCastMember = {
   id: number
@@ -15,20 +16,6 @@ export type NormalisedCrewMember = {
   role: string
   order: number
   profile_path: string | null
-}
-
-const RELEASE_DATE_SENTINEL = new Date('1970-01-01T00:00:00Z')
-
-function parseReleaseDate(raw: string): Date {
-  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
-    const parsed = new Date(raw)
-    if (!Number.isNaN(parsed.getTime())) return parsed
-  }
-  if (/^\d{4}$/.test(raw)) {
-    const year = Number.parseInt(raw, 10)
-    return new Date(Date.UTC(year, 0, 1))
-  }
-  return new Date(RELEASE_DATE_SENTINEL)
 }
 
 export function normaliseTmdbMovie(raw: unknown): Prisma.MediaItemCreateInput {

--- a/lib/normalise/release-date.ts
+++ b/lib/normalise/release-date.ts
@@ -1,0 +1,13 @@
+export const RELEASE_DATE_SENTINEL = new Date('1970-01-01T00:00:00Z')
+
+export function parseReleaseDate(raw: string): Date {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    const parsed = new Date(raw)
+    if (!Number.isNaN(parsed.getTime())) return parsed
+  }
+  if (/^\d{4}$/.test(raw)) {
+    const year = Number.parseInt(raw, 10)
+    return new Date(Date.UTC(year, 0, 1))
+  }
+  return new Date(RELEASE_DATE_SENTINEL)
+}

--- a/lib/normalise/tv.ts
+++ b/lib/normalise/tv.ts
@@ -1,0 +1,92 @@
+import { Prisma, MediaType } from '@prisma/client'
+import { TmdbTvSchema, TmdbSeasonSchema } from '@/lib/api/tmdb'
+import { parseReleaseDate } from '@/lib/normalise/release-date'
+
+// Raw TMDB `status` strings map to the small fixed enum that drives the TV
+// grid's `Continuing` filter chip (Story 7.4). Unknown values default to
+// `'continuing'` because the filter chip is permissive — better to over-show
+// than under-show when TMDB introduces a new status string.
+const LIFECYCLE_STATUS_MAP: Record<
+  string,
+  'ended' | 'continuing' | 'in_production'
+> = {
+  Ended: 'ended',
+  Canceled: 'ended',
+  'Returning Series': 'continuing',
+  'In Production': 'in_production',
+  Planned: 'in_production',
+  Pilot: 'in_production',
+}
+
+function mapLifecycleStatus(
+  tmdbStatus: string,
+): 'ended' | 'continuing' | 'in_production' {
+  return LIFECYCLE_STATUS_MAP[tmdbStatus] ?? 'continuing'
+}
+
+export function normaliseTmdbTv(
+  raw: unknown,
+  seasons: unknown[],
+): {
+  show: Prisma.MediaItemCreateInput
+  episodes: Prisma.MediaItemCreateInput[]
+} {
+  // Mirror `normaliseTmdbMovie`'s null-coercion for non-nullable date fields:
+  // TMDB occasionally emits `first_air_date: null` for unannounced shows, and
+  // `TmdbTvSchema` asserts string. Coerce null → '' so the empty-string branch
+  // of `parseReleaseDate` resolves to the 1970 sentinel without relaxing the
+  // upstream schema contract.
+  const prepared =
+    raw &&
+    typeof raw === 'object' &&
+    'first_air_date' in raw &&
+    (raw as { first_air_date: unknown }).first_air_date === null
+      ? { ...(raw as object), first_air_date: '' }
+      : raw
+
+  const source = TmdbTvSchema.parse(prepared)
+  const parsedSeasons = seasons.map((s) => TmdbSeasonSchema.parse(s))
+
+  const show: Prisma.MediaItemCreateInput = {
+    type: MediaType.TV_SHOW,
+    title: source.name,
+    original_title: source.original_name ?? null,
+    release_date: parseReleaseDate(source.first_air_date),
+    end_date: source.last_air_date
+      ? parseReleaseDate(source.last_air_date)
+      : null,
+    overview: source.overview ?? null,
+    poster_path: source.poster_path,
+    backdrop_path: source.backdrop_path,
+    rating: source.vote_average,
+    popularity: source.popularity,
+    genres: source.genres.map((g) => g.name),
+    status: source.status,
+    lifecycle_status: mapLifecycleStatus(source.status),
+    tmdb_id: source.id,
+  }
+
+  const episodes: Prisma.MediaItemCreateInput[] = parsedSeasons.flatMap(
+    (season) =>
+      season.episodes.map((episode) => ({
+        type: MediaType.TV_EPISODE,
+        title: episode.name,
+        original_title: null,
+        release_date: parseReleaseDate(episode.air_date ?? ''),
+        overview: episode.overview ?? null,
+        poster_path: null,
+        backdrop_path: null,
+        still_path: episode.still_path ?? null,
+        rating: episode.vote_average,
+        popularity: null,
+        genres: [],
+        season_number: episode.season_number,
+        episode_number: episode.episode_number,
+        runtime: episode.runtime ?? null,
+        unaired: !episode.air_date,
+        tmdb_id: episode.id,
+      })),
+  )
+
+  return { show, episodes }
+}

--- a/lib/search/__tests__/federation.test.ts
+++ b/lib/search/__tests__/federation.test.ts
@@ -44,6 +44,21 @@ function movie(
   }
 }
 
+function tvShow(
+  title: string,
+  year: number,
+  tmdbId: number,
+): UnifiedSearchResult {
+  return {
+    type: 'tv',
+    title,
+    release_year: year,
+    primary_source: 'tmdb',
+    tmdb_id: tmdbId,
+    confidence: 1.0,
+  }
+}
+
 describe('lib/search/federation: normaliseTitle', () => {
   it('lowercases and strips non-alphanumeric characters', async () => {
     const { normaliseTitle } = await import('@/lib/search/federation')
@@ -202,5 +217,21 @@ describe('lib/search/federation: dedupResults', () => {
     const { dedupResults } = await import('@/lib/search/federation')
 
     expect(dedupResults([])).toEqual([])
+  })
+
+  it('keeps a movie and a TV show with same title + year as separate entries (AC-3)', async () => {
+    const { dedupResults } = await import('@/lib/search/federation')
+    const officeMovie = movie('The Office', 2001, 9999)
+    const officeTv = tvShow('The Office', 2001, 2606)
+
+    const result = dedupResults([officeMovie, officeTv])
+
+    expect(result).toHaveLength(2)
+    const movieRow = result.find((r) => r.type === 'movie')
+    const tvRow = result.find((r) => r.type === 'tv')
+    expect(movieRow?.tmdb_id).toBe(9999)
+    expect(tvRow?.tmdb_id).toBe(2606)
+    expect(movieRow?.confidence).toBe(1.0)
+    expect(tvRow?.confidence).toBe(1.0)
   })
 })

--- a/lib/search/__tests__/media-dispatcher.test.ts
+++ b/lib/search/__tests__/media-dispatcher.test.ts
@@ -55,7 +55,109 @@ describe('lib/search/media-dispatcher: getDispatcher', () => {
     expect(spy).toHaveBeenCalledWith(550)
   })
 
-  it('returns null for every other (source, type) tuple in E4', async () => {
+  it('returns a dispatcher for (tmdb, TV_SHOW)', async () => {
+    const { getDispatcher } = await import('@/lib/search/media-dispatcher')
+
+    const result = getDispatcher('tmdb', MediaType.TV_SHOW)
+
+    expect(result).not.toBeNull()
+    expect(result?.sourceIdKey).toBe('tmdb_id')
+    expect(typeof result?.fetch).toBe('function')
+    expect(typeof result?.normalise).toBe('function')
+  })
+
+  it("the (tmdb, TV_SHOW) dispatcher's fetch calls getTv plus getTvSeason for each populated season", async () => {
+    const { getDispatcher } = await import('@/lib/search/media-dispatcher')
+    const tmdb = await import('@/lib/api/tmdb')
+    const getTvSpy = vi.spyOn(tmdb, 'getTv').mockResolvedValue({
+      id: 1396,
+      seasons: [
+        { season_number: 1, episode_count: 7 },
+        { season_number: 2, episode_count: 13 },
+      ],
+    } as never)
+    const getSeasonSpy = vi
+      .spyOn(tmdb, 'getTvSeason')
+      .mockResolvedValue({ episodes: [] } as never)
+
+    const dispatcher = getDispatcher('tmdb', MediaType.TV_SHOW)
+    const result = (await dispatcher?.fetch(1396)) as {
+      show: unknown
+      seasons: unknown[]
+    }
+
+    expect(getTvSpy).toHaveBeenCalledWith(1396)
+    expect(getSeasonSpy).toHaveBeenCalledTimes(2)
+    expect(getSeasonSpy).toHaveBeenCalledWith(1396, 1)
+    expect(getSeasonSpy).toHaveBeenCalledWith(1396, 2)
+    expect(result.seasons).toHaveLength(2)
+  })
+
+  it("the (tmdb, TV_SHOW) dispatcher's fetch SKIPS seasons with episode_count === 0", async () => {
+    const { getDispatcher } = await import('@/lib/search/media-dispatcher')
+    const tmdb = await import('@/lib/api/tmdb')
+    vi.spyOn(tmdb, 'getTv').mockResolvedValue({
+      id: 1396,
+      seasons: [
+        { season_number: 1, episode_count: 7 },
+        { season_number: 2, episode_count: 0 }, // unaired future season
+        { season_number: 3, episode_count: 10 },
+      ],
+    } as never)
+    const getSeasonSpy = vi
+      .spyOn(tmdb, 'getTvSeason')
+      .mockResolvedValue({ episodes: [] } as never)
+
+    const dispatcher = getDispatcher('tmdb', MediaType.TV_SHOW)
+    await dispatcher?.fetch(1396)
+
+    expect(getSeasonSpy).toHaveBeenCalledTimes(2)
+    expect(getSeasonSpy).toHaveBeenCalledWith(1396, 1)
+    expect(getSeasonSpy).toHaveBeenCalledWith(1396, 3)
+    expect(getSeasonSpy).not.toHaveBeenCalledWith(1396, 2)
+  })
+
+  it("the (tmdb, TV_SHOW) dispatcher's fetch INCLUDES Specials (season_number: 0) when episode_count > 0", async () => {
+    const { getDispatcher } = await import('@/lib/search/media-dispatcher')
+    const tmdb = await import('@/lib/api/tmdb')
+    vi.spyOn(tmdb, 'getTv').mockResolvedValue({
+      id: 1396,
+      seasons: [
+        { season_number: 0, episode_count: 4 }, // Specials
+        { season_number: 1, episode_count: 7 },
+      ],
+    } as never)
+    const getSeasonSpy = vi
+      .spyOn(tmdb, 'getTvSeason')
+      .mockResolvedValue({ episodes: [] } as never)
+
+    const dispatcher = getDispatcher('tmdb', MediaType.TV_SHOW)
+    await dispatcher?.fetch(1396)
+
+    expect(getSeasonSpy).toHaveBeenCalledTimes(2)
+    expect(getSeasonSpy).toHaveBeenCalledWith(1396, 0)
+    expect(getSeasonSpy).toHaveBeenCalledWith(1396, 1)
+  })
+
+  it("the (tmdb, TV_SHOW) dispatcher's fetch tolerates a missing `seasons` array (yields zero parallel calls)", async () => {
+    const { getDispatcher } = await import('@/lib/search/media-dispatcher')
+    const tmdb = await import('@/lib/api/tmdb')
+    vi.spyOn(tmdb, 'getTv').mockResolvedValue({
+      id: 1396,
+      // `seasons` omitted on purpose — TmdbTvSchema declares it optional.
+    } as never)
+    const getSeasonSpy = vi
+      .spyOn(tmdb, 'getTvSeason')
+      .mockResolvedValue({ episodes: [] } as never)
+
+    const dispatcher = getDispatcher('tmdb', MediaType.TV_SHOW)
+    const result = (await dispatcher?.fetch(1396)) as { seasons: unknown[] }
+
+    expect(getSeasonSpy).not.toHaveBeenCalled()
+    expect(result.seasons).toEqual([])
+  })
+
+  it('returns null for every unwired (source, type) tuple', async () => {
     const { getDispatcher } = await import('@/lib/search/media-dispatcher')
 
     const sources = ['tmdb', 'anilist', 'igdb', 'steam'] as const
@@ -68,10 +170,15 @@ describe('lib/search/media-dispatcher: getDispatcher', () => {
       MediaType.GAME,
     ]
 
+    const wired = new Set([
+      `tmdb:${MediaType.MOVIE}`,
+      `tmdb:${MediaType.TV_SHOW}`,
+    ])
+
     for (const source of sources) {
       for (const type of types) {
         const dispatcher = getDispatcher(source, type)
-        if (source === 'tmdb' && type === MediaType.MOVIE) {
+        if (wired.has(`${source}:${type}`)) {
           expect(dispatcher).not.toBeNull()
         } else {
           expect(dispatcher).toBeNull()

--- a/lib/search/federation.ts
+++ b/lib/search/federation.ts
@@ -101,7 +101,14 @@ export function dedupResults(
 ): UnifiedSearchResult[] {
   const byKey = new Map<string, UnifiedSearchResult>()
   for (const result of results) {
-    const key = `${normaliseTitle(result.title)}::${result.release_year ?? 0}`
+    // Include `type` in the dedup key so a movie + TV show with the same
+    // normalised title and release year (e.g. "The Office" 2001) stay as
+    // separate results: they're distinct items that route to different
+    // MediaType enum values on add. Trade-off worth flagging when Epic 8
+    // lands: a TMDB `tv` row + an AniList `anime` row for the same
+    // canonical work will NOT merge under this key. Revisit when the
+    // multi-source confidence ladder needs cross-type equivalence.
+    const key = `${normaliseTitle(result.title)}::${result.release_year ?? 0}::${result.type}`
     const existing = byKey.get(key)
     if (!existing) {
       byKey.set(key, { ...result })

--- a/lib/search/media-dispatcher.ts
+++ b/lib/search/media-dispatcher.ts
@@ -1,12 +1,20 @@
 import { MediaType, type Prisma } from '@prisma/client'
-import { getMovie } from '@/lib/api/tmdb'
+import { getMovie, getTv, getTvSeason } from '@/lib/api/tmdb'
 import { normaliseTmdbMovie } from '@/lib/normalise/movie'
+import { normaliseTmdbTv } from '@/lib/normalise/tv'
 
 export type AddMediaSource = 'tmdb' | 'anilist' | 'igdb' | 'steam'
 
+export type NormalisedShowWithEpisodes = {
+  show: Prisma.MediaItemCreateInput
+  episodes: Prisma.MediaItemCreateInput[]
+}
+
 export type AddMediaDispatcher = {
   fetch: (sourceId: number) => Promise<unknown>
-  normalise: (raw: unknown) => Prisma.MediaItemCreateInput
+  normalise: (
+    raw: unknown,
+  ) => Prisma.MediaItemCreateInput | NormalisedShowWithEpisodes
   sourceIdKey: 'tmdb_id' | 'anilist_id' | 'igdb_id' | 'steam_id'
 }
 
@@ -18,6 +26,28 @@ export function getDispatcher(
     return {
       fetch: (id) => getMovie(id),
       normalise: (raw) => normaliseTmdbMovie(raw),
+      sourceIdKey: 'tmdb_id',
+    }
+  }
+  if (source === 'tmdb' && type === MediaType.TV_SHOW) {
+    return {
+      fetch: async (id) => {
+        const show = await getTv(id)
+        // `seasons` is `.optional()` on TmdbTvSchema; default to [] so a
+        // malformed response yields zero parallel calls (transaction still
+        // runs with episodes: [], inserting the show alone).
+        const seasonNumbers = (show.seasons ?? [])
+          .filter((s) => (s.episode_count ?? 0) > 0)
+          .map((s) => s.season_number)
+        const seasons = await Promise.all(
+          seasonNumbers.map((n) => getTvSeason(id, n)),
+        )
+        return { show, seasons }
+      },
+      normalise: (raw) => {
+        const { show, seasons } = raw as { show: unknown; seasons: unknown[] }
+        return normaliseTmdbTv(show, seasons)
+      },
       sourceIdKey: 'tmdb_id',
     }
   }

--- a/prisma/migrations/20260515160000_tv_episode_columns/migration.sql
+++ b/prisma/migrations/20260515160000_tv_episode_columns/migration.sql
@@ -1,0 +1,17 @@
+-- Story 7.2: TV + episode normaliser columns on MediaItem.
+-- All ADD COLUMNs are nullable or carry a safe default so existing movie / show
+-- rows (Epics 4, 6) backfill cleanly without backfill SQL.
+
+-- AlterTable
+ALTER TABLE "MediaItem" ADD COLUMN     "episode_number" INTEGER,
+ADD COLUMN     "lifecycle_status" TEXT,
+ADD COLUMN     "runtime" INTEGER,
+ADD COLUMN     "season_number" INTEGER,
+ADD COLUMN     "still_path" TEXT,
+ADD COLUMN     "unaired" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex: timeline chronological sort within a show (Epic 10).
+CREATE INDEX "MediaItem_season_number_episode_number_idx" ON "MediaItem"("season_number", "episode_number");
+
+-- CreateIndex: TV grid 'Continuing' filter chip (Story 7.4).
+CREATE INDEX "MediaItem_lifecycle_status_idx" ON "MediaItem"("lifecycle_status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -97,11 +97,13 @@ model MediaItem {
   end_date       DateTime? // series/manga: last air date or completion date
   poster_path    String? // path only e.g. /abc.jpg - construct full URL at render time
   backdrop_path  String? // path only
+  still_path     String? // path only — episode-level art (TMDB still_path); null on non-episode rows
   overview       String?
   genres         String[]
   rating         Float? // source rating (TMDB vote_average, AniList meanScore, etc.)
   popularity     Float?
-  status         String? // "Ended", "Continuing", "Finished Airing", etc.
+  status         String? // raw upstream status, e.g. "Ended", "Returning Series", "Finished Airing"
+  lifecycle_status String? // derived enum: 'ended' | 'continuing' | 'in_production' (Story 7.2 mapping; TV grid filter)
 
   // Source API foreign keys - null for manually added items
   tmdb_id    Int? @unique
@@ -117,6 +119,12 @@ model MediaItem {
   // Franchise grouping for chronological sorting across a series
   franchise_id String?
 
+  // Episode-specific fields (null on show / movie / game rows)
+  season_number  Int?
+  episode_number Int?
+  runtime        Int? // minutes; episode runtime or movie runtime (future-proofing)
+  unaired        Boolean @default(false) // true when source air_date is null/empty at insert time
+
   user_entry    UserEntry?
   achievements  Achievement[]     @relation("AchievementGame")
   merge_sources MergeSuggestion[] @relation("MergeSource")
@@ -124,6 +132,9 @@ model MediaItem {
 
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
+
+  @@index([season_number, episode_number]) // timeline chronological sort within a show (Epic 10)
+  @@index([lifecycle_status]) // TV grid 'Continuing' filter chip (Story 7.4)
 }
 
 model UserEntry {


### PR DESCRIPTION
## Summary

Epic 7 lands TV shows and episodes end-to-end: TMDB TV adapter, normaliser + schema migration for the polymorphic show→episode hierarchy, search + add wiring, library grid with lifecycle filtering, show detail page with `SeasonAccordion` + bulk season actions, and per-episode detail pages.

This is the per-epic bundle PR pattern from [[feedback_epic_bundled_pr_workflow]] — single umbrella PR per Cuatro's explicit call. LOC is ~3x the 1.5K ceiling; ratified for this submission rather than splitting at rebase.

## Stories in this PR (8 commits, one commit per issue)

- **#122 / 7.1** — TMDB adapter extended with `getTv`, `getTvSeason`, `getTvEpisode`, `searchTv`, `getTvCredits`; full Zod coverage.
- **#123 / 7.2** — Schema migration: 6 new TV-shaped columns on `MediaItem` (`season_number`, `episode_number`, `runtime`, `still_path`, `unaired`, `lifecycle_status`) + 2 indexes. Pure normaliser at `lib/normalise/tv.ts` returning the `{ show, episodes }` two-tuple.
- **#124 / 7.2a** — Dispatcher contract forked to a discriminated union; `POST /api/media` TV branch persists 1+N rows in a single 30s transaction; cross-source merge gated on `type === TV_SHOW`; show-race + cross-context P2002 paths.
- **#125 / 7.3** — Dedup key bug fix: a movie + TV show with the same title and year now stay as separate search results (previously merged into one).
- **#126 / 7.4** — `/tv` grid: lifecycle filter chips (`IN PROGRESS` / `CONTINUING` / `ENDED`), per-show progress (`S{n}E{m} / total`), inline `PhosphorBar` in the grid card. New `attachEpisodeStats` aggregation.
- **#127 / 7.5** — `/tv/[id]` detail page: hero, synopsis, show-level `PhosphorBar`, `SeasonAccordion` (with per-season Mark Season Watched), Cast band, Streaming row. `EpisodeWatchToggle` lazy-creates `UserEntry` via `PUT /api/progress` upsert. New `POST /api/progress/bulk` transactional route.
- **#128 / 7.6** — `/tv/[id]/season/[n]/episode/[e]` deep-link page with guest cast, optimistic watch toggle, breadcrumb.

Closes #122, closes #123, closes #124, closes #125, closes #126, closes #127, closes #128.

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint --max-warnings=0` clean
- [ ] `pnpm vitest run` — 685/687 expected (2 pre-existing `worker.test.ts` flakes from `deferred-work.md`)
- [ ] Add a TMDB show via `/search?type=tv` → confirm grid card shows `S{n}E{m} / total` after marking episodes
- [ ] `/tv` grid: lifecycle chip cycle (IN PROGRESS / CONTINUING / ENDED) filters as expected
- [ ] `/tv/[id]` detail: `SeasonAccordion` expands the user's current season by default; per-episode toggle persists via `PUT /api/progress`; "Mark Season Watched" advances the per-season + show-level `PhosphorBar`
- [ ] `/tv/[id]/season/{n}/episode/{e}` deep-link renders guest cast + air-date row; unaired episodes show disabled toggle + `AIRS {date}` prefix

## Heads-up

- **LOC:** ~+4563 / -158 across 8 commits. Reviewer-friendly chunking: review by commit (one per story) rather than by file.
- **Deferred work** (logged in `_bmad-output/implementation-artifacts/deferred-work.md`):
  - 8 items from Story 7.2 review (ECH-1..8)
  - 7 items from Story 7.2a review (ECH-T1..T7)
  - 1 from Story 7.3 (ECH-T8)
  - 6 from Story 7.4 (ECH-T9..T14)
  - 10 from Story 7.5 (ECH-T20..T29)
  - 4 from Story 7.6 (ECH-T30..T33)
- **Two pre-existing bugs surfaced (not Epic 7's fault, ripe for a Phase 5 cleanup):**
  - ECH-T7: Movie-path cross-source merge can collapse a TMDB movie onto a TV_SHOW row with same title+year.
  - ECH-T20: `completed_at` not auto-set on status COMPLETED transitions (movies + episodes alike).
