### PR TITLE
chore(docker): parameterize dev ports and add override hook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ DB_PASS="your-postgres-password"
 # Redis
 REDIS_URL="redis://localhost:6379"
 
+# Optional - remap dev infra host ports to avoid conflicts with other docker projects.
+# DATABASE_URL / REDIS_URL above must match if you change these.
+POSTGRES_HOST_PORT=5432
+REDIS_HOST_PORT=6379
+
 # Cloudflare API Token
 CLOUDFLARE_API_TOKEN=""
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 # misc
 .DS_Store
 *.pem
+docker-compose.override.yml
 
 # debug
 npm-debug.log*

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,7 +14,7 @@ services:
       - POSTGRES_USER=tracker
       - "POSTGRES_PASSWORD=${DB_PASS:?DB_PASS is required; see .env.example}"
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:${POSTGRES_HOST_PORT:-5432}:5432"
     volumes:
       - pg_dev_data:/var/lib/postgresql/data
     restart: unless-stopped
@@ -27,7 +27,7 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"
+      - "127.0.0.1:${REDIS_HOST_PORT:-6379}:6379"
     volumes:
       - redis_dev_data:/data
     restart: unless-stopped

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,0 +1,21 @@
+# Copy to docker-compose.override.yml (gitignored) to namespace this stack
+# off the default ports so it does not collide with other docker projects on
+# this machine. Compose auto-loads docker-compose.override.yml alongside
+# docker-compose.yml; the dev workflow (pnpm infra) merges this on top of
+# docker-compose.dev.yml when invoked with the same -f flag chain.
+#
+# Simpler alternative: set POSTGRES_HOST_PORT / REDIS_HOST_PORT in .env. Use
+# this override file when you also want isolated container names or volumes.
+#
+# Remember to update DATABASE_URL / REDIS_URL in .env to match the remapped
+# host ports below.
+
+name: cuatro-tracker
+
+services:
+  postgres:
+    ports: !override
+      - "127.0.0.1:15432:5432"
+  redis:
+    ports: !override
+      - "127.0.0.1:16379:6379"


### PR DESCRIPTION
## Summary

Lets multiple cuatro-tracker workspaces (or any other docker project that binds 5432 / 6379) coexist on the same host without port collisions. Defaults preserve today behaviour for anyone who doesn''t set the new env vars.

## Changes

- `docker-compose.dev.yml` now reads `POSTGRES_HOST_PORT` and `REDIS_HOST_PORT` with defaults `5432` / `6379`, so `pnpm infra` keeps working untouched.
- Tighten Redis bind from `0.0.0.0` to `127.0.0.1` to match Postgres and avoid exposing dev Redis on the LAN.
- `.env.example` documents the two new optional vars next to `DATABASE_URL` / `REDIS_URL`, with a reminder that the URLs must match if the ports change.
- `.gitignore` covers `docker-compose.override.yml`. Compose auto-merges that file when present, so devs can locally namespace ports / volumes / container names without touching tracked files.
- Ship `docker-compose.override.example.yml` (committed) as a starter that remaps Postgres to `15432` and Redis to `16379`, matching the workspace-prefix scheme already used by `.devcontainer/docker-compose.yml`.

## Why

Demonstrated live on the working machine while writing this PR: `pnpm infra` failed because port 5432 was already held by another project''s Postgres container. With this change, the dev can drop the override file (or set the env vars in `.env`) and unblock immediately.

## Verification

```powershell
cd cuatro-tracker
pnpm infra:down

# Defaults preserved.
pnpm infra
docker compose -f docker-compose.dev.yml ps   # postgres on 5432, redis on 6379

# Custom ports honour the env vars.
pnpm infra:down
$env:POSTGRES_HOST_PORT="15432"; $env:REDIS_HOST_PORT="16379"; pnpm infra
docker compose -f docker-compose.dev.yml ps   # postgres on 15432, redis on 16379

# Compose file parses cleanly.
docker compose -f docker-compose.dev.yml config --quiet
```

## Ship order

Recommend landing this before #epic-8-anilist (Story 8.1) so any reviewer cloning fresh isn''t blocked by the same port collision.