### PR TITLE
feat(anilist): establish AniList GraphQL adapter (Story 8.1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,9 @@ TMDB_API_KEY=""
 # ISO 3166-1 alpha-2 country code for TMDB watch-provider lookups (CO=Colombia, US=United States, etc.)
 TMDB_WATCH_PROVIDER_COUNTRY="CO"
 
+# AniList - public GraphQL endpoint (no API key). Set a contact-friendly UA per AniList community guidance.
+ANILIST_USER_AGENT="cuatro-tracker/1.0"
+
 # IGDB (Twitch app) - dev.twitch.tv/console
 IGDB_CLIENT_ID=""
 IGDB_CLIENT_SECRET=""

--- a/docs/delivery/8-1-anilist-graphql-adapter.md
+++ b/docs/delivery/8-1-anilist-graphql-adapter.md
@@ -1,0 +1,107 @@
+---
+story: 8.1
+branch: epic-8-anilist
+mode: direct-from-epic-spec
+spec_source: ../../../_bmad-output/planning-artifacts/epics.md (lines 1999-2029)
+---
+
+# Story 8.1 — Establish AniList GraphQL adapter (delivery file)
+
+This document is a future-reference summary of the in-session implementation of Story 8.1. The authoritative acceptance criteria live in `_bmad-output/planning-artifacts/epics.md` (Epic 8, Story 8.1, lines 1999-2029). No separate impl-artifact was generated; we worked from the epic spec plus the existing TMDB adapter as the pattern reference.
+
+## Summary
+
+Story 8.1 establishes the typed AniList GraphQL client at `lib/api/anilist.ts`, mirroring the structure of the existing TMDB adapter. It is the foundation Stories 8.2 (anime + manga normalisers) and 8.3 (federated search dispatch) build on. Four changes land together as one commit on `epic-8-anilist`:
+
+1. **`lib/api/anilist.ts`** — typed GraphQL client. `AnilistApiError` carries `endpoint`, `httpStatus`, `fieldPath`, optional `retryAfterMs`, and `cause`. Zod schemas cover the `Media` surface the normalisers in 8.2 will consume (title, fuzzy date, cover image, studios, relation edges, etc.). In-module concurrency limiter caps in-flight requests at 2. `anilistFetch` POSTs JSON, validates via Zod, and surfaces 429 / GraphQL-envelope / parse-failure paths distinctly. Public exports: `searchAnime`, `searchManga`, `getMedia(id, format)`, `getMediaRelations(id)`, plus the `partialDateToDate` helper.
+
+2. **`lib/env.ts`** — adds `ANILIST_USER_AGENT: z.string().default('cuatro-tracker/1.0')`. AniList has no API key for public queries but their community guidance asks callers to identify themselves; the env var lets each deploy override with a contact-friendly UA.
+
+3. **`.env.example`** — documents `ANILIST_USER_AGENT` next to the other external-API entries.
+
+4. **`lib/api/__tests__/anilist.test.ts`** — 14 unit tests covering every AC-5 case plus the GraphQL error envelope and field-path parse failure.
+
+## Reasoning
+
+### Why an in-module concurrency limiter instead of `p-limit`
+
+AC-2 references `pLimit(2)` as a possible implementation. `p-limit` is in the transitive tree (via BullMQ) but isn't a direct dependency. Adding it as a direct dep for a five-line primitive isn't worth the supply-chain surface — the in-module `Set<Promise<unknown>>` + `Promise.race` pattern is six lines, has no closure-over-promise bugs (the promise is added to the set before its `then` runs), and never has to release a slot manually (every promise's `finally` handler does it). If a future story needs cross-process rate coordination (Epic 11 bulk imports running across N workers), revisit and replace with a Redis token bucket; the public surface stays identical.
+
+### Why `partialDateToDate` returns `null` instead of a 1970 sentinel
+
+NFR14 is about the construction shape (`new Date(year, (month ?? 1) - 1, day ?? 1)`) — not about what to do when `year` itself is missing. The 1970-01-01 sentinel is a normaliser concern (Story 8.2), not an adapter concern. Returning `null` here keeps the helper truthful: "we cannot anchor a date without a year" is a different statement than "this thing happened in 1970." The normaliser will translate `null → sentinel` and add the test for that.
+
+### Why GraphQL error envelopes are surfaced as `AnilistApiError`
+
+AniList returns HTTP 200 with `{ errors: [...] }` for schema-level failures (unknown field, type mismatch, deprecated arg). The TMDB adapter doesn't have an analogue because TMDB uses HTTP status codes for everything. Folding these into the same error class (with `httpStatus: 200` and the first error's `message` in the thrown message) keeps callers from having to branch on transport vs schema bugs at the call site — both surface as "adapter said no, log and move on."
+
+### Failure mode / Roads not taken / Long-term cost
+
+- **Failure mode:** AniList's 429 `Retry-After` header is in seconds and is advisory; the adapter throws immediately and does not retry. Callers are expected to honor `retryAfterMs` themselves. For BullMQ jobs that's natural; for interactive route handlers it means a 429 surfaces as a `partialFailure: true` in Story 8.3's federated search response (per that story's spec).
+- **Failure mode:** The in-module limiter is per-process. Two Node processes (the Next.js app + the BullMQ worker) running concurrently can each send up to 2 in flight, so effective worst case is 4 concurrent against the 90/min budget. Still well within budget for normal traffic; flagged in case Epic 11 bulk imports start tripping 429s in practice.
+- **Roads not taken:** Building a Redis-backed token bucket up front. Rejected — premature for a single-tenant single-host app. Revisit if bulk imports scale up or a second app process is added.
+- **Roads not taken:** Returning a discriminated `{ ok, data } | { ok: false, error }` result from each public function instead of throwing. Rejected for symmetry with `tmdb.ts` and because the route-handler layer already centralises error-to-status mapping via try/catch.
+- **Long-term cost:** The Zod schemas in this file overlap with what Story 8.2 normalisers will project. If 8.2 introduces a smaller "internal AniList shape" type that the normaliser maps from, prune the unused `optional()` chains on the adapter side at that time.
+
+## Files touched
+
+- `cuatro-tracker/lib/api/anilist.ts` — +508 / 0 (new file: error class, Zod schemas, `partialDateToDate`, concurrency limiter, `anilistFetch`, four public exports, inline GraphQL operations).
+- `cuatro-tracker/lib/api/__tests__/anilist.test.ts` — +364 / 0 (new file: 14 tests across `partialDateToDate` (5), `searchAnime` (2), `searchManga` (1), `getMedia` (3), `getMediaRelations` (1), rate limiting + GraphQL envelope (2)).
+- `cuatro-tracker/lib/env.ts` — +3 / 0 (`ANILIST_USER_AGENT` added to the Zod env schema with default `cuatro-tracker/1.0` and an explanatory comment).
+- `cuatro-tracker/.env.example` — +3 / 0 (`ANILIST_USER_AGENT="cuatro-tracker/1.0"` documented next to the other external-API vars).
+
+Total: +878 / 0 across 4 files (2 new, 2 modified).
+
+## Commit message
+
+`feat(anilist): establish AniList GraphQL adapter`
+
+(Single commit on `epic-8-anilist`. The four files are one cohesive unit — the adapter cannot land without the env var, the tests assert the adapter behaviour, and `.env.example` mirrors the env schema by convention.)
+
+## How to verify
+
+### Static gates
+
+```powershell
+cd cuatro-tracker
+corepack pnpm typecheck
+corepack pnpm lint
+corepack pnpm vitest run lib/api/__tests__/anilist.test.ts
+```
+
+Expected: typecheck green, lint green (zero warnings), 14/14 tests green.
+
+Full sweep:
+
+```powershell
+corepack pnpm test
+```
+
+Expected: 702/702 unit tests green when Redis is up (`pnpm infra` first). The two `lib/jobs/__tests__/worker.test.ts` cases require a running Redis per repo convention; they pass on a clean Redis and are not regressed by this story.
+
+### Live smoke (optional, hits the real AniList API)
+
+```powershell
+# Inside cuatro-tracker:
+corepack pnpm tsx -e "import('./lib/api/anilist').then(async m => { const r = await m.searchAnime('Frieren'); console.log(r.length, r[0]?.title) })"
+```
+
+Expected: a small integer (1-25) and a Frieren title object. This validates the Zod schemas against a live response once before merge; do not commit the snippet.
+
+### Debugging notes
+
+- **Tests timeout in the 429 case:** the limiter's `Promise.race` waits on whatever's in `inflight`. If a test's mock `fetch` never resolves (forgot to return a `Response`), the next call's `withLimit` will block forever. Always have the mock return a `Response` — even for the rejecting path, throw inside the schema validation, not before the fetch returns.
+- **Schema parse failure with a confusing `fieldPath`:** AniList sometimes returns enum strings that aren't in the documented set (e.g. status `CANCELLED` vs `CANCELED`). When that happens the parse error's `fieldPath` will point at the enum field. Add the missing variant to the Zod enum and re-run.
+- **`User-Agent` not landing on the request:** Node's `fetch` (undici) silently strips some headers in restricted contexts. The User-Agent test asserts the spy received it as an init arg — if a future runtime strips it on the wire, switch to a `Request` instance construction.
+
+## Apply checklist
+
+- [x] `lib/api/anilist.ts` created with `AnilistApiError`, Zod schemas, `partialDateToDate`, concurrency limiter, `anilistFetch`, and four public exports (`searchAnime`, `searchManga`, `getMedia`, `getMediaRelations`).
+- [x] `lib/api/__tests__/anilist.test.ts` covers every AC-5 case plus GraphQL-envelope errors and schema-mismatch field paths (14/14 green).
+- [x] `lib/env.ts` extends the Zod env schema with `ANILIST_USER_AGENT` and a default.
+- [x] `.env.example` documents the new optional env var.
+- [x] Static gates green: typecheck, lint (zero warnings), full vitest (702/702 with Redis up).
+- [x] Single commit `feat(anilist): establish AniList GraphQL adapter` on `epic-8-anilist`.
+- [ ] Branch pushed to origin and PR opened (deferred — Cuatro pushes manually per project policy).
+- [ ] Sprint-status flipped: `8-1-establish-anilist-graphql-adapter = done`, `epic-8 = in-progress` (queue for the closeout step).
+- [ ] Story 8.2 (anime + manga normalisers) and 8.3 (federated search dispatch) opened as follow-up PRs.

--- a/lib/api/__tests__/anilist.test.ts
+++ b/lib/api/__tests__/anilist.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+const loggerMock = vi.hoisted(() => ({
+  fatal: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: loggerMock,
+  createLogger: () => loggerMock,
+}))
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  ANILIST_USER_AGENT: 'cuatro-tracker/test',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.resetAllMocks()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+})
+
+function mockFetchData(data: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      () =>
+        new Response(JSON.stringify({ data }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    ),
+  )
+}
+
+function mockFetchSequence(responses: Response[]) {
+  let i = 0
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => {
+      const r = responses[i] ?? responses[responses.length - 1]
+      i += 1
+      return r
+    }),
+  )
+}
+
+function makeMedia(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 170942,
+    idMal: 52991,
+    type: 'ANIME',
+    format: 'TV',
+    status: 'FINISHED',
+    title: {
+      romaji: 'Sousou no Frieren',
+      english: 'Frieren: Beyond Journeys End',
+      native: '葬送のフリーレン',
+      userPreferred: 'Sousou no Frieren',
+    },
+    description: 'After defeating the Demon King...',
+    startDate: { year: 2023, month: 9, day: 29 },
+    endDate: { year: 2024, month: 3, day: 22 },
+    season: 'FALL',
+    seasonYear: 2023,
+    episodes: 28,
+    chapters: null,
+    volumes: null,
+    duration: 24,
+    genres: ['Adventure', 'Drama', 'Fantasy'],
+    averageScore: 90,
+    popularity: 350000,
+    coverImage: {
+      extraLarge: 'https://s4.anilist.co/file/anilistcdn/media/anime/cover/large/bx170942-x.jpg',
+      large: 'https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/bx170942-x.jpg',
+      medium: 'https://s4.anilist.co/file/anilistcdn/media/anime/cover/small/bx170942-x.jpg',
+      color: '#aee4f1',
+    },
+    bannerImage: 'https://s4.anilist.co/file/anilistcdn/media/anime/banner/170942-x.jpg',
+    studios: {
+      nodes: [{ id: 11, name: 'Madhouse', isAnimationStudio: true }],
+    },
+    source: 'MANGA',
+    isAdult: false,
+    ...overrides,
+  }
+}
+
+describe('partialDateToDate', () => {
+  it('builds full date from year/month/day', async () => {
+    const { partialDateToDate } = await import('@/lib/api/anilist')
+    const d = partialDateToDate(2020, 3, 15)
+    expect(d).not.toBeNull()
+    expect(d?.getFullYear()).toBe(2020)
+    expect(d?.getMonth()).toBe(2)
+    expect(d?.getDate()).toBe(15)
+  })
+
+  it('falls back day to 1 when null', async () => {
+    const { partialDateToDate } = await import('@/lib/api/anilist')
+    const d = partialDateToDate(2020, 3, null)
+    expect(d?.getFullYear()).toBe(2020)
+    expect(d?.getMonth()).toBe(2)
+    expect(d?.getDate()).toBe(1)
+  })
+
+  it('falls back month to January (index 0) when null', async () => {
+    const { partialDateToDate } = await import('@/lib/api/anilist')
+    const d = partialDateToDate(2020, null, 15)
+    expect(d?.getFullYear()).toBe(2020)
+    expect(d?.getMonth()).toBe(0)
+    expect(d?.getDate()).toBe(15)
+  })
+
+  it('falls back to Jan 1 when month and day are both null', async () => {
+    const { partialDateToDate } = await import('@/lib/api/anilist')
+    const d = partialDateToDate(2020, null, null)
+    expect(d?.getFullYear()).toBe(2020)
+    expect(d?.getMonth()).toBe(0)
+    expect(d?.getDate()).toBe(1)
+  })
+
+  it('returns null when year is null (no anchor)', async () => {
+    const { partialDateToDate } = await import('@/lib/api/anilist')
+    expect(partialDateToDate(null, null, null)).toBeNull()
+    expect(partialDateToDate(null, 3, 15)).toBeNull()
+  })
+})
+
+describe('searchAnime', () => {
+  it('returns parsed media array from Page.media on happy path', async () => {
+    mockFetchData({
+      Page: {
+        pageInfo: { total: 1, perPage: 25, currentPage: 1, lastPage: 1, hasNextPage: false },
+        media: [makeMedia()],
+      },
+    })
+    const { searchAnime } = await import('@/lib/api/anilist')
+    const results = await searchAnime('Frieren')
+    expect(results).toHaveLength(1)
+    expect(results[0]?.id).toBe(170942)
+    expect(results[0]?.title.english).toContain('Frieren')
+  })
+
+  it('POSTs JSON with the configured User-Agent header', async () => {
+    const fetchSpy = vi.fn(
+      (_url: string, _init?: RequestInit) =>
+        new Response(JSON.stringify({ data: { Page: { media: [] } } }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    )
+    vi.stubGlobal('fetch', fetchSpy)
+    const { searchAnime } = await import('@/lib/api/anilist')
+    await searchAnime('Frieren')
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchSpy.mock.calls[0] ?? []
+    expect(url).toBe('https://graphql.anilist.co')
+    expect(init).toBeDefined()
+    if (!init) return
+    expect(init.method).toBe('POST')
+    expect((init.headers as Record<string, string>)['User-Agent']).toBe(
+      'cuatro-tracker/test',
+    )
+    const body = JSON.parse(String(init.body))
+    expect(body.variables).toEqual({ search: 'Frieren', type: 'ANIME' })
+    expect(body.query).toContain('Page(')
+  })
+})
+
+describe('searchManga', () => {
+  it('returns parsed manga media on happy path', async () => {
+    const mangaFixture = makeMedia({
+      id: 30002,
+      type: 'MANGA',
+      format: 'MANGA',
+      title: {
+        romaji: 'Berserk',
+        english: 'Berserk',
+        native: 'ベルセルク',
+        userPreferred: 'Berserk',
+      },
+      episodes: null,
+      chapters: 374,
+      volumes: 41,
+      season: null,
+      seasonYear: null,
+      duration: null,
+      studios: undefined,
+    })
+    mockFetchData({ Page: { media: [mangaFixture] } })
+    const { searchManga } = await import('@/lib/api/anilist')
+    const results = await searchManga('Berserk')
+    expect(results).toHaveLength(1)
+    expect(results[0]?.type).toBe('MANGA')
+    expect(results[0]?.chapters).toBe(374)
+  })
+})
+
+describe('getMedia', () => {
+  it('returns full Media payload with full startDate', async () => {
+    mockFetchData({ Media: makeMedia() })
+    const { getMedia } = await import('@/lib/api/anilist')
+    const media = await getMedia(170942, 'ANIME')
+    expect(media.id).toBe(170942)
+    expect(media.startDate).toEqual({ year: 2023, month: 9, day: 29 })
+  })
+
+  it('preserves partial startDate where month and day are null', async () => {
+    mockFetchData({
+      Media: makeMedia({ startDate: { year: 2020, month: null, day: null } }),
+    })
+    const { getMedia, partialDateToDate } = await import('@/lib/api/anilist')
+    const media = await getMedia(170942, 'ANIME')
+    expect(media.startDate).toEqual({ year: 2020, month: null, day: null })
+
+    const built = partialDateToDate(
+      media.startDate.year,
+      media.startDate.month,
+      media.startDate.day,
+    )
+    expect(built?.toISOString().slice(0, 10)).toBe('2020-01-01')
+  })
+
+  it('throws AnilistApiError with field path on schema mismatch', async () => {
+    mockFetchData({ Media: { ...makeMedia(), id: 'not-a-number' } })
+    const { getMedia, AnilistApiError } = await import('@/lib/api/anilist')
+    await expect(getMedia(170942, 'ANIME')).rejects.toBeInstanceOf(
+      AnilistApiError,
+    )
+    await expect(getMedia(170942, 'ANIME')).rejects.toMatchObject({
+      httpStatus: 200,
+      fieldPath: expect.stringContaining('id'),
+    })
+  })
+})
+
+describe('getMediaRelations', () => {
+  it('buckets relation edges into sequel / prequel / sideStory / parent / adaptation', async () => {
+    const relationNode = (id: number, type: 'ANIME' | 'MANGA' = 'ANIME') => ({
+      id,
+      type,
+      format: type === 'ANIME' ? 'TV' : 'MANGA',
+      title: {
+        romaji: `Title ${id}`,
+        english: `Title ${id}`,
+        native: `Title ${id}`,
+        userPreferred: `Title ${id}`,
+      },
+      coverImage: { large: `https://s4.anilist.co/${id}.jpg` },
+    })
+    mockFetchData({
+      Media: {
+        id: 170942,
+        relations: {
+          edges: [
+            { relationType: 'SEQUEL', node: relationNode(1) },
+            { relationType: 'PREQUEL', node: relationNode(2) },
+            { relationType: 'SIDE_STORY', node: relationNode(3) },
+            { relationType: 'PARENT', node: relationNode(4) },
+            { relationType: 'ADAPTATION', node: relationNode(5, 'MANGA') },
+            { relationType: 'CHARACTER', node: relationNode(6) },
+            { relationType: 'SPIN_OFF', node: relationNode(7) },
+          ],
+        },
+      },
+    })
+    const { getMediaRelations } = await import('@/lib/api/anilist')
+    const buckets = await getMediaRelations(170942)
+    expect(buckets.sequel.map((n) => n.id)).toEqual([1])
+    expect(buckets.prequel.map((n) => n.id)).toEqual([2])
+    expect(buckets.sideStory.map((n) => n.id)).toEqual([3])
+    expect(buckets.parent.map((n) => n.id)).toEqual([4])
+    expect(buckets.adaptation.map((n) => n.id)).toEqual([5])
+    // CHARACTER and SPIN_OFF are intentionally not surfaced.
+  })
+})
+
+describe('rate limiting', () => {
+  it('on 429 throws AnilistApiError with httpStatus 429 + retryAfterMs, and limiter releases for next call', async () => {
+    mockFetchSequence([
+      new Response('', {
+        status: 429,
+        headers: { 'Retry-After': '30' },
+      }),
+      new Response(
+        JSON.stringify({ data: { Page: { media: [makeMedia()] } } }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    ])
+
+    const { searchAnime, AnilistApiError } = await import('@/lib/api/anilist')
+
+    let caught: unknown
+    try {
+      await searchAnime('Frieren')
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(AnilistApiError)
+    expect(caught).toMatchObject({
+      httpStatus: 429,
+      retryAfterMs: 30_000,
+    })
+
+    // Slot was released after the 429; a follow-up call must resolve.
+    const ok = await searchAnime('Frieren')
+    expect(ok).toHaveLength(1)
+  })
+
+  it('surfaces a GraphQL error envelope (200 with errors[]) as AnilistApiError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Response(
+            JSON.stringify({
+              errors: [
+                { message: 'Internal Server Error', status: 500 },
+              ],
+              data: null,
+            }),
+            {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            },
+          ),
+      ),
+    )
+    const { searchAnime, AnilistApiError } = await import('@/lib/api/anilist')
+    await expect(searchAnime('Frieren')).rejects.toBeInstanceOf(
+      AnilistApiError,
+    )
+  })
+})

--- a/lib/api/anilist.ts
+++ b/lib/api/anilist.ts
@@ -1,0 +1,508 @@
+import { z } from 'zod'
+import { env } from '@/lib/env'
+import { logger } from '@/lib/logger'
+
+const ANILIST_ENDPOINT = 'https://graphql.anilist.co'
+const ANILIST_TIMEOUT_MS = 8000
+
+// AniList caps the public API at 90 req/min (NFR21). Holding two concurrent
+// in-flight requests keeps a comfortable safety margin even on the burstiest
+// detail-page fetch (Story 8.2 normaliser pulls media + relations in parallel).
+// Bulk imports (Epic 11) layer a per-job 700ms delay via BullMQ on top of this.
+const ANILIST_CONCURRENCY = 2
+
+export class AnilistApiError extends Error {
+  readonly endpoint: string
+  readonly httpStatus?: number
+  readonly fieldPath?: string
+  readonly retryAfterMs?: number
+
+  constructor(
+    message: string,
+    opts: {
+      endpoint: string
+      httpStatus?: number
+      fieldPath?: string
+      retryAfterMs?: number
+      cause?: unknown
+    },
+  ) {
+    super(message, opts.cause ? { cause: opts.cause } : undefined)
+    this.name = 'AnilistApiError'
+    this.endpoint = opts.endpoint
+    this.httpStatus = opts.httpStatus
+    this.fieldPath = opts.fieldPath
+    this.retryAfterMs = opts.retryAfterMs
+  }
+}
+
+export const AnilistMediaTypeSchema = z.enum(['ANIME', 'MANGA'])
+export type AnilistMediaType = z.infer<typeof AnilistMediaTypeSchema>
+
+export const AnilistMediaFormatSchema = z.enum([
+  'TV',
+  'TV_SHORT',
+  'MOVIE',
+  'SPECIAL',
+  'OVA',
+  'ONA',
+  'MUSIC',
+  'MANGA',
+  'NOVEL',
+  'ONE_SHOT',
+])
+export type AnilistMediaFormat = z.infer<typeof AnilistMediaFormatSchema>
+
+export const AnilistFuzzyDateSchema = z.object({
+  year: z.number().int().nullable(),
+  month: z.number().int().min(1).max(12).nullable(),
+  day: z.number().int().min(1).max(31).nullable(),
+})
+export type AnilistFuzzyDate = z.infer<typeof AnilistFuzzyDateSchema>
+
+export const AnilistTitleSchema = z.object({
+  romaji: z.string().nullable(),
+  english: z.string().nullable(),
+  native: z.string().nullable(),
+  userPreferred: z.string().nullable().optional(),
+})
+export type AnilistTitle = z.infer<typeof AnilistTitleSchema>
+
+export const AnilistCoverImageSchema = z.object({
+  extraLarge: z.string().nullable().optional(),
+  large: z.string().nullable().optional(),
+  medium: z.string().nullable().optional(),
+  color: z.string().nullable().optional(),
+})
+export type AnilistCoverImage = z.infer<typeof AnilistCoverImageSchema>
+
+export const AnilistStudioSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  isAnimationStudio: z.boolean().optional(),
+})
+
+export const AnilistStudiosSchema = z.object({
+  nodes: z.array(AnilistStudioSchema),
+})
+
+export const AnilistRelationTypeSchema = z.enum([
+  'ADAPTATION',
+  'PREQUEL',
+  'SEQUEL',
+  'PARENT',
+  'SIDE_STORY',
+  'CHARACTER',
+  'SUMMARY',
+  'ALTERNATIVE',
+  'SPIN_OFF',
+  'OTHER',
+  'SOURCE',
+  'COMPILATION',
+  'CONTAINS',
+])
+export type AnilistRelationType = z.infer<typeof AnilistRelationTypeSchema>
+
+export const AnilistRelationNodeSchema = z.object({
+  id: z.number(),
+  type: AnilistMediaTypeSchema,
+  format: AnilistMediaFormatSchema.nullable().optional(),
+  title: AnilistTitleSchema,
+  coverImage: AnilistCoverImageSchema.optional(),
+})
+export type AnilistRelationNode = z.infer<typeof AnilistRelationNodeSchema>
+
+export const AnilistRelationEdgeSchema = z.object({
+  relationType: AnilistRelationTypeSchema,
+  node: AnilistRelationNodeSchema,
+})
+export type AnilistRelationEdge = z.infer<typeof AnilistRelationEdgeSchema>
+
+export const AnilistRelationsSchema = z.object({
+  edges: z.array(AnilistRelationEdgeSchema),
+})
+
+export const AnilistMediaSchema = z.object({
+  id: z.number(),
+  idMal: z.number().nullable().optional(),
+  type: AnilistMediaTypeSchema,
+  format: AnilistMediaFormatSchema.nullable().optional(),
+  status: z.string().nullable().optional(),
+  title: AnilistTitleSchema,
+  description: z.string().nullable().optional(),
+  startDate: AnilistFuzzyDateSchema,
+  endDate: AnilistFuzzyDateSchema.optional(),
+  season: z.string().nullable().optional(),
+  seasonYear: z.number().nullable().optional(),
+  episodes: z.number().nullable().optional(),
+  chapters: z.number().nullable().optional(),
+  volumes: z.number().nullable().optional(),
+  duration: z.number().nullable().optional(),
+  genres: z.array(z.string()).optional(),
+  averageScore: z.number().nullable().optional(),
+  popularity: z.number().nullable().optional(),
+  coverImage: AnilistCoverImageSchema.optional(),
+  bannerImage: z.string().nullable().optional(),
+  studios: AnilistStudiosSchema.optional(),
+  source: z.string().nullable().optional(),
+  isAdult: z.boolean().optional(),
+  relations: AnilistRelationsSchema.optional(),
+})
+export type AnilistMedia = z.infer<typeof AnilistMediaSchema>
+
+const AnilistPageInfoSchema = z.object({
+  total: z.number().optional(),
+  perPage: z.number().optional(),
+  currentPage: z.number().optional(),
+  lastPage: z.number().optional(),
+  hasNextPage: z.boolean().optional(),
+})
+
+const AnilistSearchPageSchema = z.object({
+  Page: z.object({
+    pageInfo: AnilistPageInfoSchema.optional(),
+    media: z.array(AnilistMediaSchema),
+  }),
+})
+
+const AnilistGetMediaSchema = z.object({
+  Media: AnilistMediaSchema,
+})
+
+const AnilistGetRelationsSchema = z.object({
+  Media: z.object({
+    id: z.number(),
+    relations: AnilistRelationsSchema,
+  }),
+})
+
+const AnilistGraphQLErrorSchema = z.object({
+  message: z.string(),
+  status: z.number().optional(),
+  locations: z
+    .array(z.object({ line: z.number(), column: z.number() }))
+    .optional(),
+})
+
+// NFR14: AniList fuzzy dates may have null month or day. `new Date(year, null, null)`
+// produces "Invalid Date" silently. Always build via (month ?? 1) - 1, day ?? 1.
+// Returns null when year is null (no anchor); callers map that to a sentinel.
+export function partialDateToDate(
+  year: number | null,
+  month: number | null,
+  day: number | null,
+): Date | null {
+  if (year === null) return null
+  return new Date(year, (month ?? 1) - 1, day ?? 1)
+}
+
+const inflight = new Set<Promise<unknown>>()
+async function withLimit<T>(fn: () => Promise<T>): Promise<T> {
+  while (inflight.size >= ANILIST_CONCURRENCY) {
+    await Promise.race(inflight)
+  }
+  const p = (async () => fn())()
+  inflight.add(p)
+  try {
+    return await p
+  } finally {
+    inflight.delete(p)
+  }
+}
+
+async function anilistFetch<T extends z.ZodType>(
+  query: string,
+  variables: Record<string, unknown>,
+  schema: T,
+  endpointLabel: string,
+): Promise<z.infer<T>> {
+  const startedAt = Date.now()
+  let response: Response
+  try {
+    response = await fetch(ANILIST_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'User-Agent': env.ANILIST_USER_AGENT,
+      },
+      body: JSON.stringify({ query, variables }),
+      cache: 'no-store',
+      signal: AbortSignal.timeout(ANILIST_TIMEOUT_MS),
+    })
+  } catch (err) {
+    const durationMs = Date.now() - startedAt
+    const isTimeout =
+      err instanceof Error &&
+      (err.name === 'TimeoutError' || err.name === 'AbortError')
+    logger.error(
+      { endpoint: endpointLabel, durationMs, err },
+      isTimeout ? 'anilist_fetch_timeout' : 'anilist_fetch_network_error',
+    )
+    throw new AnilistApiError(
+      isTimeout
+        ? `AniList request timed out after ${ANILIST_TIMEOUT_MS}ms: ${endpointLabel}`
+        : `AniList fetch failed: ${endpointLabel}`,
+      { endpoint: endpointLabel, cause: err },
+    )
+  }
+
+  const durationMs = Date.now() - startedAt
+
+  if (response.status === 429) {
+    const retryAfterRaw = response.headers.get('Retry-After')
+    const retryAfterSeconds = retryAfterRaw ? Number(retryAfterRaw) : NaN
+    const retryAfterMs = Number.isFinite(retryAfterSeconds)
+      ? retryAfterSeconds * 1000
+      : undefined
+    logger.warn(
+      { endpoint: endpointLabel, durationMs, retryAfterMs },
+      'anilist_fetch_rate_limited',
+    )
+    throw new AnilistApiError(`AniList rate limited (429): ${endpointLabel}`, {
+      endpoint: endpointLabel,
+      httpStatus: 429,
+      retryAfterMs,
+    })
+  }
+
+  if (!response.ok) {
+    logger.error(
+      { endpoint: endpointLabel, status: response.status, durationMs },
+      'anilist_fetch_http_error',
+    )
+    throw new AnilistApiError(
+      `AniList HTTP ${response.status}: ${endpointLabel}`,
+      { endpoint: endpointLabel, httpStatus: response.status },
+    )
+  }
+
+  let payload: unknown
+  try {
+    payload = await response.json()
+  } catch (err) {
+    logger.error(
+      { endpoint: endpointLabel, durationMs, err },
+      'anilist_fetch_invalid_json',
+    )
+    throw new AnilistApiError(
+      `AniList returned invalid JSON: ${endpointLabel}`,
+      {
+        endpoint: endpointLabel,
+        httpStatus: response.status,
+        cause: err,
+      },
+    )
+  }
+
+  // AniList returns 200 with { errors: [...] } for schema-level failures
+  // (unknown field, type mismatch). Surface the first error message with the
+  // same logging shape so callers can distinguish transport vs query bugs.
+  if (
+    typeof payload === 'object' &&
+    payload !== null &&
+    'errors' in payload &&
+    Array.isArray((payload as { errors?: unknown }).errors)
+  ) {
+    const errors = (payload as { errors: unknown[] }).errors
+    const first = AnilistGraphQLErrorSchema.safeParse(errors[0])
+    const message = first.success ? first.data.message : 'unknown GraphQL error'
+    logger.error(
+      { endpoint: endpointLabel, durationMs, errors },
+      'anilist_fetch_graphql_error',
+    )
+    throw new AnilistApiError(
+      `AniList GraphQL error: ${endpointLabel} - ${message}`,
+      { endpoint: endpointLabel, httpStatus: response.status },
+    )
+  }
+
+  const dataEnvelope = (payload as { data?: unknown }).data ?? payload
+  const parsed = schema.safeParse(dataEnvelope)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    const fieldPath = issue?.path.join('.') ?? '(root)'
+    logger.error(
+      {
+        endpoint: endpointLabel,
+        status: response.status,
+        durationMs,
+        fieldPath,
+        err: parsed.error,
+      },
+      'anilist_fetch_parse_error',
+    )
+    throw new AnilistApiError(
+      `AniList response parse failed at "${fieldPath}": ${endpointLabel}`,
+      {
+        endpoint: endpointLabel,
+        httpStatus: response.status,
+        fieldPath,
+        cause: parsed.error,
+      },
+    )
+  }
+
+  return parsed.data
+}
+
+const MEDIA_FIELDS = `
+  id
+  idMal
+  type
+  format
+  status
+  title { romaji english native userPreferred }
+  description(asHtml: false)
+  startDate { year month day }
+  endDate { year month day }
+  season
+  seasonYear
+  episodes
+  chapters
+  volumes
+  duration
+  genres
+  averageScore
+  popularity
+  coverImage { extraLarge large medium color }
+  bannerImage
+  studios { nodes { id name isAnimationStudio } }
+  source
+  isAdult
+`
+
+const RELATIONS_FRAGMENT = `
+  relations {
+    edges {
+      relationType
+      node {
+        id
+        type
+        format
+        title { romaji english native userPreferred }
+        coverImage { extraLarge large medium }
+      }
+    }
+  }
+`
+
+const SEARCH_QUERY = `
+  query Search($search: String!, $type: MediaType!) {
+    Page(page: 1, perPage: 25) {
+      pageInfo { total perPage currentPage lastPage hasNextPage }
+      media(search: $search, type: $type, sort: SEARCH_MATCH) {
+        ${MEDIA_FIELDS}
+      }
+    }
+  }
+`
+
+const GET_MEDIA_QUERY = `
+  query GetMedia($id: Int!, $type: MediaType!) {
+    Media(id: $id, type: $type) {
+      ${MEDIA_FIELDS}
+      ${RELATIONS_FRAGMENT}
+    }
+  }
+`
+
+const GET_RELATIONS_QUERY = `
+  query GetRelations($id: Int!) {
+    Media(id: $id) {
+      id
+      ${RELATIONS_FRAGMENT}
+    }
+  }
+`
+
+export function searchAnime(query: string): Promise<AnilistMedia[]> {
+  return withLimit(async () => {
+    const result = await anilistFetch(
+      SEARCH_QUERY,
+      { search: query, type: 'ANIME' },
+      AnilistSearchPageSchema,
+      'search/anime',
+    )
+    return result.Page.media
+  })
+}
+
+export function searchManga(query: string): Promise<AnilistMedia[]> {
+  return withLimit(async () => {
+    const result = await anilistFetch(
+      SEARCH_QUERY,
+      { search: query, type: 'MANGA' },
+      AnilistSearchPageSchema,
+      'search/manga',
+    )
+    return result.Page.media
+  })
+}
+
+export function getMedia(
+  id: number,
+  format: AnilistMediaType,
+): Promise<AnilistMedia> {
+  return withLimit(async () => {
+    const result = await anilistFetch(
+      GET_MEDIA_QUERY,
+      { id, type: format },
+      AnilistGetMediaSchema,
+      `media/${format.toLowerCase()}/${id}`,
+    )
+    return result.Media
+  })
+}
+
+export interface AnilistRelationBuckets {
+  sequel: AnilistRelationNode[]
+  prequel: AnilistRelationNode[]
+  sideStory: AnilistRelationNode[]
+  parent: AnilistRelationNode[]
+  adaptation: AnilistRelationNode[]
+}
+
+export function getMediaRelations(
+  id: number,
+): Promise<AnilistRelationBuckets> {
+  return withLimit(async () => {
+    const result = await anilistFetch(
+      GET_RELATIONS_QUERY,
+      { id },
+      AnilistGetRelationsSchema,
+      `media/relations/${id}`,
+    )
+    const buckets: AnilistRelationBuckets = {
+      sequel: [],
+      prequel: [],
+      sideStory: [],
+      parent: [],
+      adaptation: [],
+    }
+    for (const edge of result.Media.relations.edges) {
+      switch (edge.relationType) {
+        case 'SEQUEL':
+          buckets.sequel.push(edge.node)
+          break
+        case 'PREQUEL':
+          buckets.prequel.push(edge.node)
+          break
+        case 'SIDE_STORY':
+          buckets.sideStory.push(edge.node)
+          break
+        case 'PARENT':
+          buckets.parent.push(edge.node)
+          break
+        case 'ADAPTATION':
+          buckets.adaptation.push(edge.node)
+          break
+        default:
+          // Other relation types (CHARACTER, SPIN_OFF, etc.) are not surfaced
+          // in the relations panel; raw edges remain available via getMedia().
+          break
+      }
+    }
+    return buckets
+  })
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -22,6 +22,9 @@ const EnvSchema = z.object({
   // Defaults to CO (Colombia); future Settings page (Phase 11+) will let
   // Cuatro override at runtime.
   TMDB_WATCH_PROVIDER_COUNTRY: z.string().length(2).default('CO'),
+  // AniList public GraphQL has no API key but asks callers to identify
+  // themselves. Override per-deploy if you need a contact-friendly UA.
+  ANILIST_USER_AGENT: z.string().default('cuatro-tracker/1.0'),
   IGDB_CLIENT_ID: z.string().min(1),
   IGDB_CLIENT_SECRET: z.string().min(1),
   STEAM_API_KEY: z.string().min(1),


### PR DESCRIPTION
## Summary

Story 8.1 of Epic 8 (Anime & Manga). Adds a typed AniList GraphQL client at `lib/api/anilist.ts` mirroring the structure of the existing TMDB adapter. Foundation for Stories 8.2 (anime + manga normalisers) and 8.3 (federated search dispatch into AniList).

Authoritative spec: `_bmad-output/planning-artifacts/epics.md`, Story 8.1 (lines 1999-2029).
Delivery file: `docs/delivery/8-1-anilist-graphql-adapter.md`.

## What ships

- **`lib/api/anilist.ts`** (new):
  - `AnilistApiError` with `endpoint`, `httpStatus`, `fieldPath`, optional `retryAfterMs`, and `cause`.
  - Zod schemas covering the `Media` surface Stories 8.2 / 8.3 will consume (title, fuzzy date, cover image, studios, relations edges, etc.).
  - `partialDateToDate(year, month, day)` helper applying NFR14: `new Date(year, (month ?? 1) - 1, day ?? 1)`. Returns `null` when `year` is null so callers map to the sentinel themselves.
  - In-module concurrency limiter capping the adapter at **2 concurrent requests** under the 90 req/min ceiling (NFR21). Bulk-import jobs (Epic 11) layer a 700ms BullMQ delay on top.
  - `anilistFetch` handling **429 with `Retry-After`** (converted to `retryAfterMs`), **GraphQL error envelopes** (200 with `errors[]`), schema parse failures with `fieldPath`, network / timeout / invalid-JSON paths.
  - Public exports: `searchAnime`, `searchManga`, `getMedia`, `getMediaRelations` (returns `{ sequel, prequel, sideStory, parent, adaptation }` buckets).
- **`lib/env.ts`**: adds `ANILIST_USER_AGENT: z.string().default(''cuatro-tracker/1.0'')`.
- **`.env.example`**: documents the new optional env var.
- **`lib/api/__tests__/anilist.test.ts`** (new): **14 unit tests** covering every AC-5 case plus the GraphQL error envelope and schema-mismatch field path.

## Acceptance criteria mapping (Story 8.1)

| AC | Where |
|---|---|
| AC-1 (Export API + UA) | `lib/api/anilist.ts` public exports + `env.ANILIST_USER_AGENT` header |
| AC-2 (Rate limit: pLimit(2) equivalent) | `withLimit` + `inflight` set, capped at `ANILIST_CONCURRENCY = 2` |
| AC-3 (Partial-date helper, NFR14) | `partialDateToDate` |
| AC-4 (Error handling, Retry-After) | 429 branch in `anilistFetch` reads `Retry-After`, logs `anilist_fetch_rate_limited`, throws with `retryAfterMs` |
| AC-5 (Tests) | 14 tests in `__tests__/anilist.test.ts` |

## Verification

```powershell
cd cuatro-tracker
corepack pnpm typecheck                                       # clean
corepack pnpm lint                                            # clean (zero warnings)
corepack pnpm vitest run lib/api/__tests__/anilist.test.ts    # 14 / 14 green
corepack pnpm test                                            # 702 / 702 with Redis up
```

The two `lib/jobs/__tests__/worker.test.ts` cases require Redis per repo convention; pass on a clean Redis and are not regressed by this story.

### Live smoke (manual, not committed)

```powershell
corepack pnpm tsx -e "import(''./lib/api/anilist'').then(async m => { const r = await m.searchAnime(''Frieren''); console.log(r.length, r[0]?.title) })"
```

Validates the Zod schemas against a live AniList response.

## Out of scope (deferred)

- `lib/normalise/anime.ts` + `lib/normalise/manga.ts` -> Story 8.2.
- Wiring AniList into `lib/search/federation.ts` and `lib/search/media-dispatcher.ts` -> Story 8.3.
- Any UI work (`/anime`, `/manga` routes) -> Stories 8.4-8.6.

## Design notes (long-version in delivery file)

- **No `p-limit` dep:** the limiter is six lines of `Set<Promise<unknown>>` + `Promise.race`. Adding a direct dep for that isn''t worth the supply-chain surface.
- **GraphQL error envelopes (200 + `errors[]`) surface as `AnilistApiError`:** TMDB uses HTTP status codes for everything, AniList doesn''t. Folding both into one error class keeps the call site simple.
- **`partialDateToDate` returns `null` for missing year, not the 1970 sentinel:** the sentinel is a normaliser concern (Story 8.2), not an adapter concern. The helper stays truthful about the absence of an anchor.