### PR TITLE
chore(db): add anime + manga metadata columns to MediaItem

### DIFF
--- a/prisma/migrations/20260519100752_add_anime_manga_fields/migration.sql
+++ b/prisma/migrations/20260519100752_add_anime_manga_fields/migration.sql
@@ -1,0 +1,21 @@
+-- Anime + manga metadata columns on MediaItem (Story 8.2 prep).
+-- All columns NULLable so existing MOVIE / TV_SHOW / TV_EPISODE / GAME rows
+-- remain valid without backfill. Anime is modelled as a single MediaItem
+-- (no per-episode rows like TV) — progress on UserEntry tracks watched-count,
+-- and episode_count holds the aired total.
+--
+-- Pure additive ALTER TABLE: no existing column is touched, no constraint
+-- (including the raw-SQL partial-unique / CHECK constraints from
+-- 20260403132636_fix_schema_constraints and 20260508133713_phase2_constraint_hardening)
+-- is modified.
+
+ALTER TABLE "MediaItem"
+  ADD COLUMN "episode_count"   INTEGER,
+  ADD COLUMN "chapter_count"   INTEGER,
+  ADD COLUMN "volume_count"    INTEGER,
+  ADD COLUMN "format"          TEXT,
+  ADD COLUMN "studio_name"     TEXT,
+  ADD COLUMN "author_name"     TEXT,
+  ADD COLUMN "season"          TEXT,
+  ADD COLUMN "season_year"     INTEGER,
+  ADD COLUMN "source_material" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -125,6 +125,20 @@ model MediaItem {
   runtime        Int? // minutes; episode runtime or movie runtime (future-proofing)
   unaired        Boolean @default(false) // true when source air_date is null/empty at insert time
 
+  // Anime + manga metadata (Story 8.2 — AniList normalisers).
+  // All nullable so existing MOVIE / TV_SHOW / TV_EPISODE / GAME rows remain valid.
+  // Anime is modelled as a single MediaItem (not per-episode rows like TV); progress
+  // on UserEntry tracks watched-count, and episode_count holds the aired total.
+  episode_count   Int? // anime: total aired / planned episodes per AniList
+  chapter_count   Int? // manga: total chapters
+  volume_count    Int? // manga: total volumes
+  format          String? // raw AniList format (TV, MOVIE, OVA, ONA, MANGA, NOVEL, ONE_SHOT, ...) - kept as string to avoid coupling to upstream enum churn
+  studio_name     String? // anime: first animation studio (AniList studios.nodes where isAnimationStudio = true)
+  author_name     String? // manga: first staff with role 'Story'
+  season          String? // AniList season enum string: WINTER / SPRING / SUMMER / FALL
+  season_year     Int? // AniList seasonYear (anime release / airing year)
+  source_material String? // AniList source: MANGA / LIGHT_NOVEL / ORIGINAL / VISUAL_NOVEL / etc.
+
   user_entry    UserEntry?
   achievements  Achievement[]     @relation("AchievementGame")
   merge_sources MergeSuggestion[] @relation("MergeSource")


### PR DESCRIPTION
## Summary

Prep migration for **Story 8.2** (AniList anime + manga normalisers). Adds nine nullable columns to `MediaItem` so AniList payloads have target slots in the existing single-table model. No data backfill needed — every new column is `NULL` for existing `MOVIE` / `TV_SHOW` / `TV_EPISODE` / `GAME` rows.

This PR lands as a standalone schema change so:
- Story 8.2''s code-only PR stays scope-clean (normalisers + tests, no migration noise).
- The migration can be reviewed in isolation against the raw-SQL constraint trap documented in CLAUDE.md.

## Columns added

| Column | Type | For | Notes |
|---|---|---|---|
| `episode_count` | `INTEGER` | anime | aired / planned total per AniList |
| `chapter_count` | `INTEGER` | manga | total chapters |
| `volume_count` | `INTEGER` | manga | total volumes |
| `format` | `TEXT` | both | AniList format string (TV / MOVIE / OVA / ONA / MANGA / NOVEL / ONE_SHOT / ...) kept as TEXT to avoid coupling the schema to upstream enum churn |
| `studio_name` | `TEXT` | anime | first AniList `studios.nodes` where `isAnimationStudio: true` |
| `author_name` | `TEXT` | manga | first staff with role `Story` |
| `season` | `TEXT` | anime | AniList season: `WINTER` / `SPRING` / `SUMMER` / `FALL` |
| `season_year` | `INTEGER` | anime | AniList `seasonYear` |
| `source_material` | `TEXT` | anime | AniList `source` (`MANGA` / `LIGHT_NOVEL` / `ORIGINAL` / `VISUAL_NOVEL` / ...) |

## Why hand-crafted SQL instead of `prisma migrate dev`

`prisma migrate dev` tried to "fix" the partial unique index on `User.email` (added by `20260403132636_fix_schema_constraints` + `20260508133713_phase2_constraint_hardening` as `WHERE email IS NOT NULL`) back to a full Prisma-DSL-expressible unique constraint. The CLAUDE.md trap is explicit:

> Prisma 6 schema has raw SQL constraints (CHECK, partial unique) that the Prisma DSL cannot express. Review any migration diff that touches constrained columns before applying.

The migration is therefore hand-written as **pure additive `ALTER TABLE ADD COLUMN`** — no existing column is touched, and none of the raw-SQL constraints (`User.email` partial unique, `UserEntry.user_rating` CHECK, `UserEntry.progress` CHECK, `MergeSuggestion.confidence` CHECK, `MergeSuggestion.source_id <> target_id` CHECK) are modified.

## Anime modelling note

Anime is modelled as a **single `MediaItem` row** (not per-episode rows like TV). `progress` on `UserEntry` tracks watched-count, `episode_count` holds the aired total. Story 8.5 (anime detail page) will surface this via the `EpisodeChecklist` organism per the epic spec.

Per-episode rows for anime can be added later as a discriminated `MediaType.ANIME_EPISODE` if/when bulk episode metadata becomes worth the storage. No decision needed at this stage.

## Verification

```powershell
cd cuatro-tracker
$env:POSTGRES_HOST_PORT="15432"; corepack pnpm infra
$env:DATABASE_URL="postgresql://tracker:<pw>@localhost:15432/tracker"
corepack pnpm prisma migrate deploy   # applies 20260519100752_add_anime_manga_fields cleanly
corepack pnpm prisma generate         # regenerates client
corepack pnpm typecheck               # clean
corepack pnpm lint                    # clean (zero warnings)
corepack pnpm test                    # 702 / 702
```

```sql
SELECT column_name, data_type, is_nullable
FROM information_schema.columns
WHERE table_name = ''MediaItem''
  AND column_name IN (
    ''episode_count'',''chapter_count'',''volume_count'',''format'',''studio_name'',
    ''author_name'',''season'',''season_year'',''source_material''
  )
ORDER BY column_name;
-- 9 rows, every is_nullable = YES.
```

## Ship order

Merge before #epic-8-story-8-2 (AniList anime + manga normalisers, opening once this lands).