### PR TITLE
feat(anilist): anime + manga normalisers and relations projector (Story 8.2)

### DIFF
--- a/lib/api/anilist.ts
+++ b/lib/api/anilist.ts
@@ -86,6 +86,26 @@ export const AnilistStudiosSchema = z.object({
   nodes: z.array(AnilistStudioSchema),
 })
 
+export const AnilistStaffNameSchema = z.object({
+  full: z.string(),
+  native: z.string().nullable().optional(),
+})
+
+export const AnilistStaffNodeSchema = z.object({
+  id: z.number(),
+  name: AnilistStaffNameSchema,
+})
+
+export const AnilistStaffEdgeSchema = z.object({
+  role: z.string(),
+  node: AnilistStaffNodeSchema,
+})
+export type AnilistStaffEdge = z.infer<typeof AnilistStaffEdgeSchema>
+
+export const AnilistStaffSchema = z.object({
+  edges: z.array(AnilistStaffEdgeSchema),
+})
+
 export const AnilistRelationTypeSchema = z.enum([
   'ADAPTATION',
   'PREQUEL',
@@ -144,6 +164,7 @@ export const AnilistMediaSchema = z.object({
   coverImage: AnilistCoverImageSchema.optional(),
   bannerImage: z.string().nullable().optional(),
   studios: AnilistStudiosSchema.optional(),
+  staff: AnilistStaffSchema.optional(),
   source: z.string().nullable().optional(),
   isAdult: z.boolean().optional(),
   relations: AnilistRelationsSchema.optional(),
@@ -368,6 +389,7 @@ const MEDIA_FIELDS = `
   coverImage { extraLarge large medium color }
   bannerImage
   studios { nodes { id name isAnimationStudio } }
+  staff(perPage: 8) { edges { role node { id name { full native } } } }
   source
   isAdult
 `

--- a/lib/normalise/__tests__/anilist-relations.test.ts
+++ b/lib/normalise/__tests__/anilist-relations.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { normaliseRelations } from '@/lib/normalise/anilist-relations'
+import type {
+  AnilistMediaFormat,
+  AnilistRelationBuckets,
+  AnilistRelationNode,
+} from '@/lib/api/anilist'
+
+function relationNode(
+  id: number,
+  type: 'ANIME' | 'MANGA' = 'ANIME',
+  overrides: Partial<{
+    format: AnilistMediaFormat | null
+    romaji: string | null
+    english: string | null
+    native: string | null
+    userPreferred: string | null
+    coverLarge: string | null
+  }> = {},
+): AnilistRelationNode {
+  const defaultFormat: AnilistMediaFormat = type === 'ANIME' ? 'TV' : 'MANGA'
+  return {
+    id,
+    type,
+    format: overrides.format === null ? null : overrides.format ?? defaultFormat,
+    title: {
+      romaji: overrides.romaji ?? `Romaji ${id}`,
+      english: overrides.english ?? null,
+      native: overrides.native ?? null,
+      userPreferred: overrides.userPreferred ?? `Romaji ${id}`,
+    },
+    coverImage:
+      overrides.coverLarge === null
+        ? undefined
+        : { large: overrides.coverLarge ?? `https://cdn.example/${id}.jpg` },
+  }
+}
+
+const emptyBuckets: AnilistRelationBuckets = {
+  sequel: [],
+  prequel: [],
+  sideStory: [],
+  parent: [],
+  adaptation: [],
+}
+
+describe('lib/normalise/anilist-relations', () => {
+  it('projects every bucket into the unified NormalisedRelation shape', () => {
+    const buckets: AnilistRelationBuckets = {
+      sequel: [relationNode(1)],
+      prequel: [relationNode(2)],
+      sideStory: [relationNode(3)],
+      parent: [relationNode(4)],
+      adaptation: [relationNode(5, 'MANGA')],
+    }
+
+    const result = normaliseRelations(buckets)
+
+    expect(result.sequel).toEqual([
+      {
+        id: 1,
+        title: 'Romaji 1',
+        format: 'TV',
+        cover_path: 'https://cdn.example/1.jpg',
+        relationType: 'SEQUEL',
+      },
+    ])
+    expect(result.prequel[0]?.relationType).toBe('PREQUEL')
+    expect(result.sideStory[0]?.relationType).toBe('SIDE_STORY')
+    expect(result.parent[0]?.relationType).toBe('PARENT')
+    expect(result.adaptation[0]).toMatchObject({
+      id: 5,
+      format: 'MANGA',
+      relationType: 'ADAPTATION',
+    })
+  })
+
+  it('returns empty arrays (never null) when the source buckets are empty', () => {
+    const result = normaliseRelations(emptyBuckets)
+    expect(result.sequel).toEqual([])
+    expect(result.prequel).toEqual([])
+    expect(result.sideStory).toEqual([])
+    expect(result.parent).toEqual([])
+    expect(result.adaptation).toEqual([])
+  })
+
+  it('honours userPreferred title before falling back to romaji', () => {
+    const buckets: AnilistRelationBuckets = {
+      ...emptyBuckets,
+      sequel: [
+        relationNode(1, 'ANIME', { userPreferred: 'Locale Title' }),
+      ],
+    }
+    expect(normaliseRelations(buckets).sequel[0]?.title).toBe('Locale Title')
+  })
+
+  it('keeps cover_path null when coverImage is absent', () => {
+    const buckets: AnilistRelationBuckets = {
+      ...emptyBuckets,
+      sequel: [relationNode(1, 'ANIME', { coverLarge: null })],
+    }
+    expect(normaliseRelations(buckets).sequel[0]?.cover_path).toBeNull()
+  })
+})

--- a/lib/normalise/__tests__/anime.test.ts
+++ b/lib/normalise/__tests__/anime.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { MediaType } from '@prisma/client'
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  ANILIST_USER_AGENT: 'cuatro-tracker/test',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+function makeAnime(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 170942,
+    idMal: 52991,
+    type: 'ANIME',
+    format: 'TV',
+    status: 'FINISHED',
+    title: {
+      romaji: 'Sousou no Frieren',
+      english: 'Frieren Beyond Journeys End',
+      native: '葬送のフリーレン',
+      userPreferred: 'Sousou no Frieren',
+    },
+    description: 'After defeating the Demon King...',
+    startDate: { year: 2023, month: 9, day: 29 },
+    endDate: { year: 2024, month: 3, day: 22 },
+    season: 'FALL',
+    seasonYear: 2023,
+    episodes: 28,
+    chapters: null,
+    volumes: null,
+    duration: 24,
+    genres: ['Adventure', 'Drama', 'Fantasy'],
+    averageScore: 90,
+    popularity: 350000,
+    coverImage: {
+      extraLarge:
+        'https://s4.anilist.co/file/anilistcdn/media/anime/cover/large/bx170942-x.jpg',
+      large:
+        'https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/bx170942-x.jpg',
+      medium:
+        'https://s4.anilist.co/file/anilistcdn/media/anime/cover/small/bx170942-x.jpg',
+      color: '#aee4f1',
+    },
+    bannerImage:
+      'https://s4.anilist.co/file/anilistcdn/media/anime/banner/170942-x.jpg',
+    studios: {
+      nodes: [
+        { id: 11, name: 'Madhouse', isAnimationStudio: true },
+        { id: 2, name: 'Aniplex', isAnimationStudio: false },
+      ],
+    },
+    source: 'MANGA',
+    isAdult: false,
+    ...overrides,
+  }
+}
+
+describe('lib/normalise/anime', () => {
+  describe('happy path', () => {
+    it('maps every documented field correctly', async () => {
+      const { normaliseAnilistAnime } = await import('@/lib/normalise/anime')
+
+      const result = normaliseAnilistAnime(makeAnime())
+
+      expect(result).toMatchObject({
+        type: MediaType.ANIME,
+        title: 'Sousou no Frieren',
+        original_title: '葬送のフリーレン',
+        overview: 'After defeating the Demon King...',
+        poster_path:
+          'https://s4.anilist.co/file/anilistcdn/media/anime/cover/large/bx170942-x.jpg',
+        backdrop_path:
+          'https://s4.anilist.co/file/anilistcdn/media/anime/banner/170942-x.jpg',
+        rating: 90,
+        popularity: 350000,
+        genres: ['Adventure', 'Drama', 'Fantasy'],
+        status: 'FINISHED',
+        episode_count: 28,
+        format: 'TV',
+        studio_name: 'Madhouse',
+        season: 'FALL',
+        season_year: 2023,
+        source_material: 'MANGA',
+        anilist_id: 170942,
+      })
+      expect(result.release_date).toBeInstanceOf(Date)
+      expect((result.release_date as Date).getFullYear()).toBe(2023)
+      expect((result.release_date as Date).getMonth()).toBe(8) // September is 8 (0-indexed)
+      expect((result.release_date as Date).getDate()).toBe(29)
+    })
+  })
+
+  describe('title fallback chain', () => {
+    it('honours userPreferred when present (locale-aware default)', async () => {
+      const { normaliseAnilistAnime } = await import('@/lib/normalise/anime')
+      const result = normaliseAnilistAnime(
+        makeAnime({
+          title: {
+            romaji: 'Romaji X',
+            english: 'English X',
+            native: 'Native X',
+            userPreferred: 'Preferred X',
+          },
+        }),
+      )
+      expect(result.title).toBe('Preferred X')
+    })
+
+    it('falls back to romaji when userPreferred missing', async () => {
+      const { normaliseAnilistAnime } = await import('@/lib/normalise/anime')
+      const result = normaliseAnilistAnime(
+        makeAnime({
+          title: {
+            romaji: 'Romaji X',
+            english: 'English X',
+            native: 'Native X',
+            userPreferred: null,
+          },
+        }),
+      )
+      expect(result.title).toBe('Romaji X')
+    })
+
+    it('falls back to english when romaji null', async () => {
+      const { normaliseAnilistAnime } = await import('@/lib/normalise/anime')
+      const result = normaliseAnilistAnime(
+        makeAnime({
+          title: {
+            romaji: null,
+            english: 'English X',
+            native: 'Native X',
+            userPreferred: null,
+          },
+        }),
+      )
+      expect(result.title).toBe('English X')
+    })
+
+    it('falls back to native when romaji and english both null', async () => {
+      const { normaliseAnilistAnime } = await import('@/lib/normalise/anime')
+      const result = normaliseAnilistAnime(
+        makeAnime({
+          title: {
+            romaji: null,
+            english: null,
+            native: 'Native X',
+            userPreferred: null,
+          },
+        }),
+      )
+      expect(result.title).toBe('Native X')
+    })
+  })
+
+  describe('partial-date handling (NFR13 + NFR14)', () => {
+    it('builds Jan 1 from year-only startDate', async () => {
+      const { normaliseAnilistAnime } = await import('@/lib/normalise/anime')
+      const result = normaliseAnilistAnime(
+        makeAnime({ startDate: { year: 2020, month: null, day: null } }),
+      )
+      const date = result.release_date as Date
+      expect(date).toBeInstanceOf(Date)
+      expect(date.getFullYear()).toBe(2020)
+      expect(date.getMonth()).toBe(0)
+      expect(date.getDate()).toBe(1)
+      expect(Number.isNaN(date.getTime())).toBe(false)
+    })
+
+    it('builds month/Jan 1 when only year+month present', async () => {
+      const { normaliseAnilistAnime } = await import('@/lib/normalise/anime')
+      const result = normaliseAnilistAnime(
+        makeAnime({ startDate: { year: 2020, month: 6, day: null } }),
+      )
+      const date = result.release_date as Date
+      expect(date.getFullYear()).toBe(2020)
+      expect(date.getMonth()).toBe(5) // June
+      expect(date.getDate()).toBe(1)
+    })
+
+    it('falls through to 1970 sentinel when year is null (all-null fuzzy date)', async () => {
+      const { normaliseAnilistAnime } = await import('@/lib/normalise/anime')
+      const result = normaliseAnilistAnime(
+        makeAnime({ startDate: { year: null, month: null, day: null } }),
+      )
+      const date = result.release_date as Date
+      expect(date).toBeInstanceOf(Date)
+      expect(Number.isNaN(date.getTime())).toBe(false)
+      expect(date.toISOString()).toBe('1970-01-01T00:00:00.000Z')
+    })
+
+    it('keeps NFR13 invariant for every fixture variant', async () => {
+      const { normaliseAnilistAnime } = await import('@/lib/normalise/anime')
+      const variants = [
+        makeAnime(),
+        makeAnime({ startDate: { year: 2020, month: null, day: null } }),
+        makeAnime({ startDate: { year: null, month: null, day: null } }),
+        makeAnime({ endDate: undefined }),
+      ]
+      for (const variant of variants) {
+        const result = normaliseAnilistAnime(variant)
+        expect(result.release_date).toBeInstanceOf(Date)
+        expect(
+          Number.isNaN((result.release_date as Date).getTime()),
+        ).toBe(false)
+      }
+    })
+  })
+
+  describe('studio selection', () => {
+    it('picks first studio flagged isAnimationStudio = true', async () => {
+      const { normaliseAnilistAnime } = await import('@/lib/normalise/anime')
+      const result = normaliseAnilistAnime(
+        makeAnime({
+          studios: {
+            nodes: [
+              { id: 100, name: 'Producer Co', isAnimationStudio: false },
+              { id: 200, name: 'Real Animation Inc', isAnimationStudio: true },
+              { id: 300, name: 'Another Animation', isAnimationStudio: true },
+            ],
+          },
+        }),
+      )
+      expect(result.studio_name).toBe('Real Animation Inc')
+    })
+
+    it('returns null when no studio is flagged isAnimationStudio', async () => {
+      const { normaliseAnilistAnime } = await import('@/lib/normalise/anime')
+      const result = normaliseAnilistAnime(
+        makeAnime({
+          studios: {
+            nodes: [
+              { id: 100, name: 'Producer Co', isAnimationStudio: false },
+            ],
+          },
+        }),
+      )
+      expect(result.studio_name).toBeNull()
+    })
+
+    it('returns null when studios block is missing', async () => {
+      const { normaliseAnilistAnime } = await import('@/lib/normalise/anime')
+      const result = normaliseAnilistAnime(
+        makeAnime({ studios: undefined }),
+      )
+      expect(result.studio_name).toBeNull()
+    })
+  })
+
+  describe('cover image fallback chain', () => {
+    it('prefers extraLarge over large over medium', async () => {
+      const { normaliseAnilistAnime } = await import('@/lib/normalise/anime')
+      const onlyMedium = normaliseAnilistAnime(
+        makeAnime({
+          coverImage: {
+            extraLarge: null,
+            large: null,
+            medium: 'https://cdn.example/medium.jpg',
+            color: null,
+          },
+        }),
+      )
+      expect(onlyMedium.poster_path).toBe('https://cdn.example/medium.jpg')
+
+      const onlyLarge = normaliseAnilistAnime(
+        makeAnime({
+          coverImage: {
+            extraLarge: null,
+            large: 'https://cdn.example/large.jpg',
+            medium: 'https://cdn.example/medium.jpg',
+            color: null,
+          },
+        }),
+      )
+      expect(onlyLarge.poster_path).toBe('https://cdn.example/large.jpg')
+    })
+
+    it('returns null when coverImage missing entirely', async () => {
+      const { normaliseAnilistAnime } = await import('@/lib/normalise/anime')
+      const result = normaliseAnilistAnime(
+        makeAnime({ coverImage: undefined }),
+      )
+      expect(result.poster_path).toBeNull()
+    })
+  })
+})

--- a/lib/normalise/__tests__/manga.test.ts
+++ b/lib/normalise/__tests__/manga.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { MediaType } from '@prisma/client'
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  ANILIST_USER_AGENT: 'cuatro-tracker/test',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+function makeManga(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 30002,
+    idMal: 2,
+    type: 'MANGA',
+    format: 'MANGA',
+    status: 'RELEASING',
+    title: {
+      romaji: 'Berserk',
+      english: 'Berserk',
+      native: 'ベルセルク',
+      userPreferred: 'Berserk',
+    },
+    description: 'His name is Guts...',
+    startDate: { year: 1989, month: 8, day: 25 },
+    endDate: { year: null, month: null, day: null },
+    season: null,
+    seasonYear: null,
+    episodes: null,
+    chapters: 374,
+    volumes: 41,
+    duration: null,
+    genres: ['Action', 'Adventure', 'Drama', 'Fantasy', 'Horror'],
+    averageScore: 94,
+    popularity: 500000,
+    coverImage: {
+      extraLarge:
+        'https://s4.anilist.co/file/anilistcdn/media/manga/cover/large/bx30002-x.jpg',
+      large:
+        'https://s4.anilist.co/file/anilistcdn/media/manga/cover/medium/bx30002-x.jpg',
+      medium: null,
+      color: '#c43d3d',
+    },
+    bannerImage: null,
+    staff: {
+      edges: [
+        {
+          role: 'Story & Art',
+          node: {
+            id: 100029,
+            name: { full: 'Kentarou Miura', native: '三浦 建太郎' },
+          },
+        },
+        {
+          role: 'Assistant',
+          node: { id: 100030, name: { full: 'Studio Gaga', native: null } },
+        },
+      ],
+    },
+    source: null,
+    isAdult: false,
+    ...overrides,
+  }
+}
+
+describe('lib/normalise/manga', () => {
+  describe('happy path', () => {
+    it('maps every documented field correctly', async () => {
+      const { normaliseAnilistManga } = await import('@/lib/normalise/manga')
+
+      const result = normaliseAnilistManga(makeManga())
+
+      expect(result).toMatchObject({
+        type: MediaType.MANGA,
+        title: 'Berserk',
+        original_title: 'ベルセルク',
+        overview: 'His name is Guts...',
+        poster_path:
+          'https://s4.anilist.co/file/anilistcdn/media/manga/cover/large/bx30002-x.jpg',
+        backdrop_path: null,
+        rating: 94,
+        popularity: 500000,
+        genres: ['Action', 'Adventure', 'Drama', 'Fantasy', 'Horror'],
+        status: 'RELEASING',
+        chapter_count: 374,
+        volume_count: 41,
+        format: 'MANGA',
+        author_name: 'Kentarou Miura',
+        anilist_id: 30002,
+      })
+      expect(result.release_date).toBeInstanceOf(Date)
+      expect((result.release_date as Date).getFullYear()).toBe(1989)
+    })
+  })
+
+  describe('author selection', () => {
+    it('picks "Story & Art" before plain "Story"', async () => {
+      const { normaliseAnilistManga } = await import('@/lib/normalise/manga')
+      const result = normaliseAnilistManga(
+        makeManga({
+          staff: {
+            edges: [
+              {
+                role: 'Story',
+                node: { id: 1, name: { full: 'Plain Story Person' } },
+              },
+              {
+                role: 'Story & Art',
+                node: { id: 2, name: { full: 'The Real Author' } },
+              },
+            ],
+          },
+        }),
+      )
+      expect(result.author_name).toBe('The Real Author')
+    })
+
+    it('falls back to plain "Story" when no "Story & Art" edge', async () => {
+      const { normaliseAnilistManga } = await import('@/lib/normalise/manga')
+      const result = normaliseAnilistManga(
+        makeManga({
+          staff: {
+            edges: [
+              {
+                role: 'Story',
+                node: { id: 1, name: { full: 'Tsugumi Ohba' } },
+              },
+              {
+                role: 'Art',
+                node: { id: 2, name: { full: 'Takeshi Obata' } },
+              },
+            ],
+          },
+        }),
+      )
+      expect(result.author_name).toBe('Tsugumi Ohba')
+    })
+
+    it('returns null when staff has no Story or Story & Art edge', async () => {
+      const { normaliseAnilistManga } = await import('@/lib/normalise/manga')
+      const result = normaliseAnilistManga(
+        makeManga({
+          staff: {
+            edges: [
+              {
+                role: 'Translator',
+                node: { id: 1, name: { full: 'Some Translator' } },
+              },
+            ],
+          },
+        }),
+      )
+      expect(result.author_name).toBeNull()
+    })
+
+    it('returns null when staff block missing', async () => {
+      const { normaliseAnilistManga } = await import('@/lib/normalise/manga')
+      const result = normaliseAnilistManga(
+        makeManga({ staff: undefined }),
+      )
+      expect(result.author_name).toBeNull()
+    })
+
+    it('returns null when staff has no edges', async () => {
+      const { normaliseAnilistManga } = await import('@/lib/normalise/manga')
+      const result = normaliseAnilistManga(
+        makeManga({ staff: { edges: [] } }),
+      )
+      expect(result.author_name).toBeNull()
+    })
+  })
+
+  describe('title fallback chain', () => {
+    it('falls back to native when romaji + english + userPreferred all null', async () => {
+      const { normaliseAnilistManga } = await import('@/lib/normalise/manga')
+      const result = normaliseAnilistManga(
+        makeManga({
+          title: {
+            romaji: null,
+            english: null,
+            native: 'ベルセルク',
+            userPreferred: null,
+          },
+        }),
+      )
+      expect(result.title).toBe('ベルセルク')
+    })
+  })
+
+  describe('partial-date handling (NFR13 + NFR14)', () => {
+    it('builds Jan 1 from year-only startDate', async () => {
+      const { normaliseAnilistManga } = await import('@/lib/normalise/manga')
+      const result = normaliseAnilistManga(
+        makeManga({ startDate: { year: 2020, month: null, day: null } }),
+      )
+      const date = result.release_date as Date
+      expect(date.getFullYear()).toBe(2020)
+      expect(date.getMonth()).toBe(0)
+      expect(date.getDate()).toBe(1)
+      expect(Number.isNaN(date.getTime())).toBe(false)
+    })
+
+    it('falls through to 1970 sentinel when year is null', async () => {
+      const { normaliseAnilistManga } = await import('@/lib/normalise/manga')
+      const result = normaliseAnilistManga(
+        makeManga({ startDate: { year: null, month: null, day: null } }),
+      )
+      const date = result.release_date as Date
+      expect(date.toISOString()).toBe('1970-01-01T00:00:00.000Z')
+    })
+
+    it('keeps NFR13 invariant for every fixture variant', async () => {
+      const { normaliseAnilistManga } = await import('@/lib/normalise/manga')
+      const variants = [
+        makeManga(),
+        makeManga({ startDate: { year: 2020, month: null, day: null } }),
+        makeManga({ startDate: { year: null, month: null, day: null } }),
+        makeManga({ endDate: undefined }),
+      ]
+      for (const variant of variants) {
+        const result = normaliseAnilistManga(variant)
+        expect(result.release_date).toBeInstanceOf(Date)
+        expect(
+          Number.isNaN((result.release_date as Date).getTime()),
+        ).toBe(false)
+      }
+    })
+  })
+
+  describe('ongoing-manga end_date handling', () => {
+    it('end_date is null when AniList reports endDate.year as null (manga still releasing)', async () => {
+      const { normaliseAnilistManga } = await import('@/lib/normalise/manga')
+      const result = normaliseAnilistManga(makeManga())
+      expect(result.end_date).toBeNull()
+    })
+  })
+})

--- a/lib/normalise/anilist-relations.ts
+++ b/lib/normalise/anilist-relations.ts
@@ -1,0 +1,82 @@
+import type {
+  AnilistRelationBuckets,
+  AnilistRelationNode,
+  AnilistRelationType,
+} from '@/lib/api/anilist'
+
+// Story 8.5's RelationsList organism consumes this shape. Kept distinct from
+// AnilistRelationNode so the UI layer never sees raw AniList camelCase fields
+// (consistency with the rest of the unified MediaItem surface).
+export interface NormalisedRelation {
+  id: number
+  title: string
+  format: string | null
+  cover_path: string | null
+  relationType: AnilistRelationType
+}
+
+export interface NormalisedRelationBuckets {
+  sequel: NormalisedRelation[]
+  prequel: NormalisedRelation[]
+  sideStory: NormalisedRelation[]
+  parent: NormalisedRelation[]
+  adaptation: NormalisedRelation[]
+}
+
+function preferredTitle(title: {
+  userPreferred?: string | null
+  romaji: string | null
+  english: string | null
+  native: string | null
+}): string {
+  // Story 8.2 AC: title fallback chain is romaji -> english -> native.
+  // userPreferred is AniList's pre-computed convenience field that already
+  // honours the viewer's locale; we use it when present so a future "Display
+  // titles as: English" setting (Phase 11+) does not require a normaliser
+  // change. Falls back to the spec'd chain otherwise.
+  return (
+    title.userPreferred ?? title.romaji ?? title.english ?? title.native ?? ''
+  )
+}
+
+function pickCover(coverImage?: {
+  extraLarge?: string | null
+  large?: string | null
+  medium?: string | null
+}): string | null {
+  // AniList cover paths are full URLs (e.g. https://s4.anilist.co/...) so the
+  // unified poster_path / cover_path field stores them verbatim. Render-time
+  // code distinguishes URL vs TMDB-style path via startsWith('http'). Prefer
+  // extraLarge when present for the relations panel hero treatment; downstream
+  // can render a smaller variant via the AniList CDN's query-param resize.
+  return coverImage?.extraLarge ?? coverImage?.large ?? coverImage?.medium ?? null
+}
+
+function toRelation(
+  node: AnilistRelationNode,
+  relationType: AnilistRelationType,
+): NormalisedRelation {
+  return {
+    id: node.id,
+    title: preferredTitle(node.title),
+    format: node.format ?? null,
+    cover_path: pickCover(node.coverImage),
+    relationType,
+  }
+}
+
+// Project AniList relation buckets (from getMediaRelations or from the
+// .relations field on a getMedia payload) into the unified shape Story 8.5's
+// RelationsList consumes. Empty input -> all-empty arrays (never null), so
+// callers can map / iterate without optional-chain noise.
+export function normaliseRelations(
+  buckets: AnilistRelationBuckets,
+): NormalisedRelationBuckets {
+  return {
+    sequel: buckets.sequel.map((n) => toRelation(n, 'SEQUEL')),
+    prequel: buckets.prequel.map((n) => toRelation(n, 'PREQUEL')),
+    sideStory: buckets.sideStory.map((n) => toRelation(n, 'SIDE_STORY')),
+    parent: buckets.parent.map((n) => toRelation(n, 'PARENT')),
+    adaptation: buckets.adaptation.map((n) => toRelation(n, 'ADAPTATION')),
+  }
+}

--- a/lib/normalise/anime.ts
+++ b/lib/normalise/anime.ts
@@ -1,0 +1,99 @@
+import { Prisma, MediaType } from '@prisma/client'
+import {
+  AnilistMediaSchema,
+  partialDateToDate,
+  type AnilistMedia,
+  type AnilistStaffEdge,
+} from '@/lib/api/anilist'
+import { RELEASE_DATE_SENTINEL } from '@/lib/normalise/release-date'
+
+// Story 8.2 AC: title fallback chain is romaji -> english -> native.
+// userPreferred is AniList's pre-computed convenience field that already
+// honours the viewer's locale; we honour it first so a future "Display titles
+// as: English" setting (Phase 11+) does not require a normaliser change.
+// Falls back to the spec'd chain otherwise. Final '' fallback covers the
+// pathological case where AniList returns every title field null, which
+// shouldn't happen but keeps the type non-nullable per the schema.
+function preferredTitle(title: AnilistMedia['title']): string {
+  return (
+    title.userPreferred ?? title.romaji ?? title.english ?? title.native ?? ''
+  )
+}
+
+// AniList covers are full CDN URLs (e.g. https://s4.anilist.co/...); the
+// unified MediaItem.poster_path stores them verbatim. Render-time code
+// distinguishes URL-vs-path via startsWith('http'). Prefer extraLarge for the
+// detail-page hero treatment; the grid can resize down via the AniList CDN.
+function pickCover(coverImage?: AnilistMedia['coverImage']): string | null {
+  return (
+    coverImage?.extraLarge ??
+    coverImage?.large ??
+    coverImage?.medium ??
+    null
+  )
+}
+
+// Story 8.2 AC: studio_name = first studio with isAnimationStudio = true.
+// We do NOT fall back to a non-animation producer studio - if no animation
+// studio is flagged, the field stays null. Surfacing 'Production I.G.' for a
+// licensing-only producer would be worse than showing nothing.
+function pickAnimationStudio(
+  studios?: AnilistMedia['studios'],
+): string | null {
+  if (!studios) return null
+  const animation = studios.nodes.find((s) => s.isAnimationStudio === true)
+  return animation?.name ?? null
+}
+
+export function normaliseAnilistAnime(
+  raw: unknown,
+): Prisma.MediaItemCreateInput {
+  const source = AnilistMediaSchema.parse(raw)
+
+  // NFR13 invariant: release_date must be a valid Date, never null / NaN.
+  // partialDateToDate returns null when AniList reports year=null (unannounced
+  // titles); fall through to the project-wide 1970 sentinel that the timeline
+  // sort already groups under "unknown release".
+  const releaseDate =
+    partialDateToDate(
+      source.startDate.year,
+      source.startDate.month,
+      source.startDate.day,
+    ) ?? new Date(RELEASE_DATE_SENTINEL)
+
+  const endDate = source.endDate
+    ? partialDateToDate(
+        source.endDate.year,
+        source.endDate.month,
+        source.endDate.day,
+      )
+    : null
+
+  return {
+    type: MediaType.ANIME,
+    title: preferredTitle(source.title),
+    original_title: source.title.native ?? null,
+    release_date: releaseDate,
+    end_date: endDate,
+    overview: source.description ?? null,
+    poster_path: pickCover(source.coverImage),
+    backdrop_path: source.bannerImage ?? null,
+    rating: source.averageScore ?? null,
+    popularity: source.popularity ?? null,
+    genres: source.genres ?? [],
+    status: source.status ?? null,
+    episode_count: source.episodes ?? null,
+    format: source.format ?? null,
+    studio_name: pickAnimationStudio(source.studios),
+    season: source.season ?? null,
+    season_year: source.seasonYear ?? null,
+    source_material: source.source ?? null,
+    anilist_id: source.id,
+  }
+}
+
+// Exported for parity with normaliseAnilistManga and for unit-test ergonomics;
+// route handlers should depend on the exported normalisers rather than the
+// helper directly.
+export { preferredTitle as _animeTitlePreferred }
+export type { AnilistStaffEdge }

--- a/lib/normalise/manga.ts
+++ b/lib/normalise/manga.ts
@@ -1,0 +1,88 @@
+import { Prisma, MediaType } from '@prisma/client'
+import {
+  AnilistMediaSchema,
+  partialDateToDate,
+  type AnilistMedia,
+  type AnilistStaffEdge,
+} from '@/lib/api/anilist'
+import { RELEASE_DATE_SENTINEL } from '@/lib/normalise/release-date'
+
+// Story 8.2 AC: title fallback chain is romaji -> english -> native.
+// Same shape as the anime normaliser; kept inline (rather than shared) so each
+// medium's normaliser remains a self-contained read.
+function preferredTitle(title: AnilistMedia['title']): string {
+  return (
+    title.userPreferred ?? title.romaji ?? title.english ?? title.native ?? ''
+  )
+}
+
+function pickCover(coverImage?: AnilistMedia['coverImage']): string | null {
+  return (
+    coverImage?.extraLarge ??
+    coverImage?.large ??
+    coverImage?.medium ??
+    null
+  )
+}
+
+// Story 8.2 AC: author_name = first staff with role 'Story'.
+// AniList tags single-author manga as 'Story & Art' (e.g. Berserk -> Miura);
+// split-creator manga gets separate 'Story' and 'Art' edges (e.g. Death Note ->
+// Ohba / Obata). Try 'Story & Art' first because that's a stronger signal of
+// the canonical author. Fall back to plain 'Story'. We do NOT fall back to
+// the first staff edge of any role - if neither matches, return null instead
+// of mis-attributing a Translator or Letterer.
+function pickAuthor(staff?: { edges: AnilistStaffEdge[] }): string | null {
+  if (!staff || staff.edges.length === 0) return null
+  const storyAndArt = staff.edges.find((e) =>
+    /^\s*Story\s*&\s*Art\s*$/i.test(e.role),
+  )
+  if (storyAndArt) return storyAndArt.node.name.full
+  const story = staff.edges.find((e) => /^\s*Story\s*$/i.test(e.role))
+  return story?.node.name.full ?? null
+}
+
+export function normaliseAnilistManga(
+  raw: unknown,
+): Prisma.MediaItemCreateInput {
+  const source = AnilistMediaSchema.parse(raw)
+
+  // NFR13 invariant: release_date is never null / NaN. AniList's startDate may
+  // be `{ year: null, month: null, day: null }` for unannounced manga; the
+  // partial-date helper returns null in that case, and we fall through to the
+  // project-wide 1970 sentinel.
+  const releaseDate =
+    partialDateToDate(
+      source.startDate.year,
+      source.startDate.month,
+      source.startDate.day,
+    ) ?? new Date(RELEASE_DATE_SENTINEL)
+
+  const endDate = source.endDate
+    ? partialDateToDate(
+        source.endDate.year,
+        source.endDate.month,
+        source.endDate.day,
+      )
+    : null
+
+  return {
+    type: MediaType.MANGA,
+    title: preferredTitle(source.title),
+    original_title: source.title.native ?? null,
+    release_date: releaseDate,
+    end_date: endDate,
+    overview: source.description ?? null,
+    poster_path: pickCover(source.coverImage),
+    backdrop_path: source.bannerImage ?? null,
+    rating: source.averageScore ?? null,
+    popularity: source.popularity ?? null,
+    genres: source.genres ?? [],
+    status: source.status ?? null,
+    chapter_count: source.chapters ?? null,
+    volume_count: source.volumes ?? null,
+    format: source.format ?? null,
+    author_name: pickAuthor(source.staff),
+    anilist_id: source.id,
+  }
+}


### PR DESCRIPTION
## Summary

Story 8.2 of Epic 8 (Anime & Manga). Adds the two AniList normalisers and a shared relations projector. Builds on Story 8.1 (PR #131) and the schema columns landed in PR #132.

Authoritative spec: `_bmad-output/planning-artifacts/epics.md`, Story 8.2 (lines 2030-2054).

## What ships

- **`lib/normalise/anime.ts`** (new) — `normaliseAnilistAnime(raw)` → `Prisma.MediaItemCreateInput` with `type: ANIME`. Title via `userPreferred -> romaji -> english -> native -> ''`. `release_date` via Story 8.1''s `partialDateToDate` helper, falling through to the 1970 sentinel when AniList reports `{ year: null, month: null, day: null }`. `studio_name` is the first `studios.nodes` entry where `isAnimationStudio: true`, with a null fallback (no producer mis-attribution). Projects `episodes -> episode_count`, `season`, `seasonYear`, `source -> source_material`, `format`.

- **`lib/normalise/manga.ts`** (new) — `normaliseAnilistManga(raw)` → `Prisma.MediaItemCreateInput` with `type: MANGA`. Same title + release-date treatment. `author_name` prefers `Story & Art` over plain `Story`. Null fallback if neither matches — better than mis-attributing a translator. Projects `chapters -> chapter_count`, `volumes -> volume_count`, `format`.

- **`lib/normalise/anilist-relations.ts`** (new) — `normaliseRelations(buckets)` projects the `AnilistRelationBuckets` shape from Story 8.1''s `getMediaRelations` into `NormalisedRelationBuckets` (the future RelationsList organism in Story 8.5 consumes this). Empty input → all-empty arrays, never null.

- **`lib/api/anilist.ts`** (modified) — extends `MEDIA_FIELDS` GraphQL fragment with `staff(perPage: 8) { edges { role node { id name { full native } } } }` and adds the matching Zod schemas (`AnilistStaffNameSchema`, `AnilistStaffNodeSchema`, `AnilistStaffEdgeSchema`, `AnilistStaffSchema`). `staff` is optional on `AnilistMediaSchema` so prior call sites and Story 8.1 tests parse unchanged.

- **29 unit tests** across `lib/normalise/__tests__/{anime,manga,anilist-relations}.test.ts`:
  - happy path
  - title fallback chain (all 4 levels)
  - partial-date Jan-1 fallback
  - all-null fuzzy date → 1970 sentinel
  - NFR13 invariants across multiple fixture variants
  - studio selection (animation-studio filter + null fallback)
  - author selection (Story & Art > Story > null)
  - cover-image fallback chain
  - ongoing-manga `end_date: null`
  - relations bucket projection
  - empty-input contract
  - `userPreferred` title precedence in relations

## Acceptance criteria mapping (Story 8.2)

| AC | Where |
|---|---|
| AC-1: anime normaliser fields (`type`, `title`, `original_title`, `release_date`, `overview`, `cover_path`, `episode_count`, `studio_name`, `format`, `season`, `season_year`, `source_material`, `anilist_id`) | `lib/normalise/anime.ts` |
| AC-2: manga normaliser fields (`type`, `title`, `original_title`, `release_date`, `overview`, `cover_path`, `chapter_count`, `volume_count`, `format`, `author_name`, `anilist_id`) | `lib/normalise/manga.ts` |
| AC-3: tests cover happy / partial-date / all-null fuzzy / title fallback / NFR13 invariant | `lib/normalise/__tests__/anime.test.ts` + `manga.test.ts` |
| AC-4: `normaliseRelations` returns 5 buckets, empty arrays not null | `lib/normalise/anilist-relations.ts` + `anilist-relations.test.ts` |

## Verification

```powershell
cd cuatro-tracker
corepack pnpm typecheck                  # clean
corepack pnpm lint                        # clean (zero warnings)
corepack pnpm vitest run lib/normalise    # 29 new tests + existing movie + tv suites green
corepack pnpm test                        # 729 / 731 (BullMQ worker tests require Redis; not regressed)
```

### Live smoke (manual, hits AniList)

```powershell
$env:ANILIST_USER_AGENT="cuatro-tracker/dev"; corepack pnpm tsx -e "
import(''./lib/api/anilist'').then(async m => {
  const [r] = await m.searchAnime(''Frieren'')
  const { normaliseAnilistAnime } = await import(''./lib/normalise/anime'')
  console.log(JSON.stringify(normaliseAnilistAnime(r), null, 2))
})"
```

Expect a `MediaItemCreateInput` with `type: ''ANIME''`, `studio_name: ''Madhouse''`, `episode_count: 28`, `format: ''TV''`, etc.

## Out of scope (deferred)

- **Story 8.3** — wire `POST /api/search` + `POST /api/media` to dispatch through these normalisers for the `anilist` source.
- **Stories 8.4 / 8.5 / 8.6** — `/anime` + `/manga` grids, detail pages, and RelationsList organism.
- **Render-layer `getCoverUrl(path, source)`** helper to bridge AniList full URLs vs TMDB paths — lands with Story 8.4.

## Design notes

- **`studio_name` null fallback over "first studio"**: AniList tags producers + licensors alongside animation studios. Surfacing "Aniplex" instead of "Madhouse" is worse than null.
- **`author_name` prefers `Story & Art` before `Story`**: handles both single-creator manga (Berserk) and split-creator manga (Death Note) deterministically. No off-role fallback — refuses to surface translators / letterers.
- **AniList cover URLs stored verbatim**: the `MediaItem.poster_path` "path-only" comment is a TMDB-centric assumption. AniList returns full CDN URLs; storing them as-is keeps the data truthful. Story 8.4''s render helper will branch on `startsWith(''http'')`.
- **`staff` in `MEDIA_FIELDS` (not just `getMedia`)**: search results must also pass through `normaliseAnilistManga` for the federated-search add path (Story 8.3). ~200 bytes per result, negligible.

## Ship order

Independent — Stories 8.1 + 8.2 schema columns + 8.2 normalisers form a clean foundation. Story 8.3 (search + media dispatch) is the natural next PR once this lands.