### PR TITLE
feat(anilist): dispatch federated search + POST /api/media through AniList (Story 8.3 + ECH-T7)

### DIFF
--- a/app/api/media/__tests__/route.test.ts
+++ b/app/api/media/__tests__/route.test.ts
@@ -33,6 +33,21 @@ vi.mock('@/lib/api/tmdb', async () => {
   }
 })
 
+const anilistMock = vi.hoisted(() => ({
+  getMedia: vi.fn(),
+}))
+
+vi.mock('@/lib/api/anilist', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/lib/api/anilist')>(
+      '@/lib/api/anilist',
+    )
+  return {
+    ...actual,
+    getMedia: anilistMock.getMedia,
+  }
+})
+
 const txMock = vi.hoisted(() => ({
   mediaItem: {
     create: vi.fn(),
@@ -216,14 +231,14 @@ describe('POST /api/media', () => {
   })
 
   describe('dispatcher routing', () => {
-    it('returns 501 for unwired source (anilist)', async () => {
+    it('returns 501 for unwired (source, type) tuple (anilist + GAME)', async () => {
       const { POST } = await import('@/app/api/media/route')
 
       const res = await POST(
         postRequest({
           source: 'anilist',
           sourceId: 1234,
-          type: MediaType.ANIME,
+          type: MediaType.GAME,
         }),
       )
 
@@ -251,6 +266,269 @@ describe('POST /api/media', () => {
       )
 
       expect(res.status).toBe(501)
+    })
+  })
+
+  describe('AniList add path (Story 8.3)', () => {
+    const validAnilistAnime = {
+      id: 170942,
+      type: 'ANIME',
+      title: {
+        romaji: 'Sousou no Frieren',
+        english: 'Frieren',
+        native: '葬送のフリーレン',
+        userPreferred: 'Sousou no Frieren',
+      },
+      startDate: { year: 2023, month: 9, day: 29 },
+      description: 'After defeating the Demon King...',
+      coverImage: { large: 'https://s4.anilist.co/x.jpg' },
+      studios: {
+        nodes: [{ id: 11, name: 'Madhouse', isAnimationStudio: true }],
+      },
+      genres: ['Adventure'],
+      episodes: 28,
+      format: 'TV',
+      season: 'FALL',
+      seasonYear: 2023,
+      source: 'MANGA',
+      averageScore: 90,
+    }
+
+    const validAnilistManga = {
+      id: 30002,
+      type: 'MANGA',
+      title: {
+        romaji: 'Berserk',
+        english: 'Berserk',
+        native: 'ベルセルク',
+        userPreferred: 'Berserk',
+      },
+      startDate: { year: 1989, month: 8, day: 25 },
+      description: 'His name is Guts...',
+      coverImage: { large: 'https://s4.anilist.co/y.jpg' },
+      chapters: 374,
+      volumes: 41,
+      format: 'MANGA',
+      genres: ['Action'],
+      staff: {
+        edges: [
+          {
+            role: 'Story & Art',
+            node: { id: 100029, name: { full: 'Kentarou Miura' } },
+          },
+        ],
+      },
+      averageScore: 94,
+    }
+
+    it("returns 201 for source:anilist + type:ANIME when source ID is new (anilist_id set, sourceIdKey 'anilist_id')", async () => {
+      anilistMock.getMedia.mockResolvedValue(validAnilistAnime)
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      dbMock.mediaItem.findMany.mockResolvedValue([])
+      dbMock.mediaItem.create.mockResolvedValue(
+        newMediaItem({
+          id: 'cm_anime_1',
+          type: MediaType.ANIME,
+          title: 'Sousou no Frieren',
+          tmdb_id: null,
+          anilist_id: 170942,
+          user_entry: newUserEntry({ media_item_id: 'cm_anime_1' }),
+        }),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({
+          source: 'anilist',
+          sourceId: 170942,
+          type: MediaType.ANIME,
+        }),
+      )
+
+      expect(res.status).toBe(201)
+      expect(anilistMock.getMedia).toHaveBeenCalledWith(170942, 'ANIME')
+      const body = await res.json()
+      expect(body.mediaItem.anilist_id).toBe(170942)
+      expect(body.mediaItem.type).toBe(MediaType.ANIME)
+      expect(body.merged).toBe(false)
+    })
+
+    it('returns 201 for source:anilist + type:MANGA, mapping author_name + chapter_count + volume_count', async () => {
+      anilistMock.getMedia.mockResolvedValue(validAnilistManga)
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      dbMock.mediaItem.findMany.mockResolvedValue([])
+      dbMock.mediaItem.create.mockResolvedValue(
+        newMediaItem({
+          id: 'cm_manga_1',
+          type: MediaType.MANGA,
+          title: 'Berserk',
+          tmdb_id: null,
+          anilist_id: 30002,
+          user_entry: newUserEntry({ media_item_id: 'cm_manga_1' }),
+        }),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({
+          source: 'anilist',
+          sourceId: 30002,
+          type: MediaType.MANGA,
+        }),
+      )
+
+      expect(res.status).toBe(201)
+      expect(anilistMock.getMedia).toHaveBeenCalledWith(30002, 'MANGA')
+      const createArg = dbMock.mediaItem.create.mock.calls[0]?.[0]
+      expect(createArg.data).toMatchObject({
+        type: MediaType.MANGA,
+        author_name: 'Kentarou Miura',
+        chapter_count: 374,
+        volume_count: 41,
+        format: 'MANGA',
+        anilist_id: 30002,
+      })
+    })
+
+    it('idempotent fast-path: existing MediaItem.anilist_id returns 200 with merged:false', async () => {
+      dbMock.mediaItem.findUnique.mockResolvedValue(
+        newMediaItem({
+          type: MediaType.ANIME,
+          tmdb_id: null,
+          anilist_id: 170942,
+          user_entry: newUserEntry(),
+        }),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({
+          source: 'anilist',
+          sourceId: 170942,
+          type: MediaType.ANIME,
+        }),
+      )
+
+      expect(res.status).toBe(200)
+      expect(anilistMock.getMedia).not.toHaveBeenCalled()
+      const body = await res.json()
+      expect(body.merged).toBe(false)
+    })
+
+    it('502 upstream_failed when AniList rejects (network / 429 / 5xx)', async () => {
+      const { AnilistApiError } = await import('@/lib/api/anilist')
+      anilistMock.getMedia.mockRejectedValue(
+        new AnilistApiError('AniList HTTP 500: media/anime/170942', {
+          endpoint: 'media/anime/170942',
+          httpStatus: 500,
+        }),
+      )
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({
+          source: 'anilist',
+          sourceId: 170942,
+          type: MediaType.ANIME,
+        }),
+      )
+
+      expect(res.status).toBe(502)
+      const body = await res.json()
+      expect(body.error).toBe('upstream_failed')
+    })
+
+    it('cross-source merge: existing MediaItem with tmdb_id and matching type/title/year picks up anilist_id', async () => {
+      anilistMock.getMedia.mockResolvedValue(validAnilistAnime)
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      const candidate = newMediaItem({
+        id: 'cm_existing',
+        type: MediaType.ANIME,
+        title: 'Sousou no Frieren',
+        release_date: new Date('2023-09-29T00:00:00Z'),
+        tmdb_id: null,
+        anilist_id: null,
+        user_entry: newUserEntry({ media_item_id: 'cm_existing' }),
+      })
+      dbMock.mediaItem.findMany.mockResolvedValue([candidate])
+      dbMock.mediaItem.update.mockResolvedValue({
+        ...candidate,
+        anilist_id: 170942,
+      })
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({
+          source: 'anilist',
+          sourceId: 170942,
+          type: MediaType.ANIME,
+        }),
+      )
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.merged).toBe(true)
+      expect(body.mediaItem.anilist_id).toBe(170942)
+      expect(dbMock.mediaItem.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'cm_existing' },
+          data: { anilist_id: 170942 },
+        }),
+      )
+    })
+
+    it('ECH-T7 guard: cross-merge SKIPS candidates of a different MediaType', async () => {
+      // Existing 2007 TMDB-imported MOVIE "Sword of the Stranger" must NOT
+      // cross-merge with an inbound 2007 AniList ANIME of the same name -
+      // they're distinct items that should remain separate rows.
+      anilistMock.getMedia.mockResolvedValue({
+        ...validAnilistAnime,
+        id: 2199,
+        title: {
+          romaji: 'Sword of the Stranger',
+          english: 'Sword of the Stranger',
+          native: null,
+          userPreferred: 'Sword of the Stranger',
+        },
+        startDate: { year: 2007, month: 9, day: 29 },
+      })
+      dbMock.mediaItem.findUnique.mockResolvedValue(null)
+      const movieCandidate = newMediaItem({
+        id: 'cm_movie',
+        type: MediaType.MOVIE,
+        title: 'Sword of the Stranger',
+        release_date: new Date('2007-09-29T00:00:00Z'),
+        tmdb_id: 12345,
+        anilist_id: null,
+        user_entry: newUserEntry({ media_item_id: 'cm_movie' }),
+      })
+      dbMock.mediaItem.findMany.mockResolvedValue([movieCandidate])
+      dbMock.mediaItem.create.mockResolvedValue(
+        newMediaItem({
+          id: 'cm_anime_new',
+          type: MediaType.ANIME,
+          title: 'Sword of the Stranger',
+          tmdb_id: null,
+          anilist_id: 2199,
+          user_entry: newUserEntry({ media_item_id: 'cm_anime_new' }),
+        }),
+      )
+      const { POST } = await import('@/app/api/media/route')
+
+      const res = await POST(
+        postRequest({
+          source: 'anilist',
+          sourceId: 2199,
+          type: MediaType.ANIME,
+        }),
+      )
+
+      expect(res.status).toBe(201)
+      expect(dbMock.mediaItem.update).not.toHaveBeenCalled()
+      expect(dbMock.mediaItem.create).toHaveBeenCalledTimes(1)
+      const body = await res.json()
+      expect(body.merged).toBe(false)
     })
   })
 

--- a/app/api/media/route.ts
+++ b/app/api/media/route.ts
@@ -5,6 +5,7 @@ import { db } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import { withRequest } from '@/lib/request-context'
 import { TmdbApiError } from '@/lib/api/tmdb'
+import { AnilistApiError } from '@/lib/api/anilist'
 import {
   getDispatcher,
   type AddMediaSource,
@@ -199,7 +200,7 @@ async function handler(req: NextRequest): Promise<NextResponse> {
   try {
     raw = await dispatcher.fetch(sourceId)
   } catch (err) {
-    if (err instanceof TmdbApiError) {
+    if (err instanceof TmdbApiError || err instanceof AnilistApiError) {
       logger.warn(
         {
           event: 'media.upstream_failed',
@@ -267,8 +268,13 @@ async function persistSingleMediaItem(
       releaseYear === 1970
         ? []
         : await findCrossSourceCandidates(source, releaseYear)
+    // Filter to the same MediaType. Without this, a 2007 TMDB movie titled
+    // "Sword of the Stranger" would collapse with a 2007 AniList anime of the
+    // same name — patching anilist_id onto the movie row and silently changing
+    // the canonical type. Closes ECH-T7 (movie cross-source merge type filter
+    // missing). Same invariant already enforced for TV in persistShowWithEpisodes.
     const crossMatch = candidates.find(
-      (c) => normaliseTitle(c.title) === normalisedKey,
+      (c) => c.type === type && normaliseTitle(c.title) === normalisedKey,
     )
 
     if (crossMatch) {

--- a/app/api/search/__tests__/route.test.ts
+++ b/app/api/search/__tests__/route.test.ts
@@ -23,6 +23,48 @@ vi.mock('@/lib/api/tmdb', () => ({
   searchMulti: tmdbMock.searchMulti,
 }))
 
+const anilistMock = vi.hoisted(() => ({
+  searchAnime: vi.fn(),
+  searchManga: vi.fn(),
+}))
+
+vi.mock('@/lib/api/anilist', () => ({
+  searchAnime: anilistMock.searchAnime,
+  searchManga: anilistMock.searchManga,
+}))
+
+function anilistMedia(
+  id: number,
+  type: 'ANIME' | 'MANGA',
+  overrides: Partial<{
+    title: { romaji: string | null; english: string | null; native: string | null; userPreferred: string | null }
+    year: number | null
+    description: string | null
+    coverLarge: string | null
+  }> = {},
+) {
+  return {
+    id,
+    type,
+    title: overrides.title ?? {
+      romaji: `Title ${id}`,
+      english: null,
+      native: null,
+      userPreferred: `Title ${id}`,
+    },
+    startDate: {
+      year: overrides.year === undefined ? 2020 : overrides.year,
+      month: null,
+      day: null,
+    },
+    description: overrides.description ?? null,
+    coverImage:
+      overrides.coverLarge === null
+        ? undefined
+        : { large: overrides.coverLarge ?? `https://cdn.example/${id}.jpg` },
+  }
+}
+
 const validEnv: Record<string, string> = {
   NEXTAUTH_SECRET: 'a'.repeat(32),
   NEXTAUTH_URL: 'http://localhost:3000',
@@ -46,6 +88,12 @@ beforeEach(() => {
   vi.resetModules()
   vi.resetAllMocks()
   for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+  // Default AniList to empty so tests that don't explicitly mock it (existing
+  // TMDB-only tests) keep passing now that the AniList adapter is in the
+  // federation registry and is called whenever the requested type matches
+  // its supportedTypes (anime, manga) or the type filter is undefined.
+  anilistMock.searchAnime.mockResolvedValue([])
+  anilistMock.searchManga.mockResolvedValue([])
 })
 
 afterEach(() => {
@@ -265,15 +313,106 @@ describe('GET /api/search', () => {
       expect(body.results[0].type).toBe('tv')
     })
 
-    it('type=anime returns empty + partialFailure:false (no adapters wired in E4)', async () => {
+    it('type=anime dispatches ONLY to AniList (TMDB skipped, manga search not called)', async () => {
+      anilistMock.searchAnime.mockResolvedValue([
+        anilistMedia(170942, 'ANIME', {
+          title: {
+            romaji: 'Sousou no Frieren',
+            english: 'Frieren',
+            native: null,
+            userPreferred: 'Sousou no Frieren',
+          },
+          year: 2023,
+        }),
+      ])
       const { GET } = await import('@/app/api/search/route')
 
-      const res = await GET(makeRequest('/api/search?q=foo&type=anime'))
+      const res = await GET(makeRequest('/api/search?q=frieren&type=anime'))
 
       expect(res.status).toBe(200)
       const body = await res.json()
-      expect(body).toEqual({ results: [], partialFailure: false })
+      expect(body.results).toHaveLength(1)
+      expect(body.results[0]).toMatchObject({
+        type: 'anime',
+        title: 'Sousou no Frieren',
+        anilist_id: 170942,
+        primary_source: 'anilist',
+        release_year: 2023,
+        confidence: 1.0,
+      })
       expect(tmdbMock.searchMulti).not.toHaveBeenCalled()
+      expect(anilistMock.searchManga).not.toHaveBeenCalled()
+      expect(anilistMock.searchAnime).toHaveBeenCalledWith('frieren')
+    })
+
+    it('type=manga dispatches ONLY to AniList manga (TMDB + anime search skipped)', async () => {
+      anilistMock.searchManga.mockResolvedValue([
+        anilistMedia(30002, 'MANGA', {
+          title: {
+            romaji: 'Berserk',
+            english: 'Berserk',
+            native: null,
+            userPreferred: 'Berserk',
+          },
+          year: 1989,
+        }),
+      ])
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search?q=berserk&type=manga'))
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.results).toHaveLength(1)
+      expect(body.results[0]).toMatchObject({
+        type: 'manga',
+        title: 'Berserk',
+        anilist_id: 30002,
+        primary_source: 'anilist',
+        release_year: 1989,
+      })
+      expect(tmdbMock.searchMulti).not.toHaveBeenCalled()
+      expect(anilistMock.searchAnime).not.toHaveBeenCalled()
+      expect(anilistMock.searchManga).toHaveBeenCalledWith('berserk')
+    })
+
+    it('no type filter fans out to BOTH adapters in parallel (TMDB + AniList anime + AniList manga)', async () => {
+      tmdbMock.searchMulti.mockResolvedValue({
+        page: 1,
+        results: [movieResult],
+        total_pages: 1,
+        total_results: 1,
+      })
+      anilistMock.searchAnime.mockResolvedValue([
+        anilistMedia(170942, 'ANIME', {
+          title: {
+            romaji: 'Sousou no Frieren',
+            english: null,
+            native: null,
+            userPreferred: 'Sousou no Frieren',
+          },
+        }),
+      ])
+      anilistMock.searchManga.mockResolvedValue([
+        anilistMedia(30002, 'MANGA', {
+          title: {
+            romaji: 'Berserk',
+            english: null,
+            native: null,
+            userPreferred: 'Berserk',
+          },
+        }),
+      ])
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search?q=mixed'))
+
+      const body = await res.json()
+      expect(tmdbMock.searchMulti).toHaveBeenCalledTimes(1)
+      expect(anilistMock.searchAnime).toHaveBeenCalledTimes(1)
+      expect(anilistMock.searchManga).toHaveBeenCalledTimes(1)
+      const types = body.results.map((r: { type: string }) => r.type).sort()
+      expect(types).toEqual(['anime', 'manga', 'movie'])
     })
 
     it('type=game returns empty + partialFailure:false (no adapters wired in E4)', async () => {
@@ -284,20 +423,52 @@ describe('GET /api/search', () => {
       const body = await res.json()
       expect(body).toEqual({ results: [], partialFailure: false })
       expect(tmdbMock.searchMulti).not.toHaveBeenCalled()
+      expect(anilistMock.searchAnime).not.toHaveBeenCalled()
+      expect(anilistMock.searchManga).not.toHaveBeenCalled()
     })
   })
 
   describe('partial failure', () => {
-    it('flags partialFailure: true when TMDB rejects, returns empty results', async () => {
+    it('flags partialFailure: true when TMDB rejects, but AniList still returns', async () => {
       tmdbMock.searchMulti.mockRejectedValue(new Error('boom'))
+      anilistMock.searchAnime.mockResolvedValue([
+        anilistMedia(170942, 'ANIME'),
+      ])
       const { GET } = await import('@/app/api/search/route')
 
       const res = await GET(makeRequest('/api/search?q=foo'))
 
       expect(res.status).toBe(200)
       const body = await res.json()
-      expect(body.results).toEqual([])
       expect(body.partialFailure).toBe(true)
+      // AniList successes survive the TMDB rejection (Promise.allSettled
+      // semantics from Story 4.3).
+      expect(body.results).toHaveLength(1)
+      expect(body.results[0]).toMatchObject({
+        type: 'anime',
+        anilist_id: 170942,
+      })
+    })
+
+    it('flags partialFailure: true when AniList rejects (e.g. 429), TMDB still returns', async () => {
+      tmdbMock.searchMulti.mockResolvedValue({
+        page: 1,
+        results: [movieResult],
+        total_pages: 1,
+        total_results: 1,
+      })
+      anilistMock.searchAnime.mockRejectedValue(
+        new Error('AniList rate limited (429)'),
+      )
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search?q=foo'))
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.partialFailure).toBe(true)
+      expect(body.results).toHaveLength(1)
+      expect(body.results[0]).toMatchObject({ type: 'movie', tmdb_id: 550 })
     })
 
     it('logs each adapter rejection at warn with { source, durationMs, err }', async () => {

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -13,7 +13,7 @@ export const dynamic = 'force-dynamic'
 
 const SearchQuerySchema = z.object({
   q: z.string().trim().min(1).max(200),
-  type: z.enum(['movie', 'tv', 'anime', 'game']).optional(),
+  type: z.enum(['movie', 'tv', 'anime', 'manga', 'game']).optional(),
 })
 
 async function handler(req: NextRequest): Promise<NextResponse> {

--- a/components/molecules/SearchResultRow/SearchResultRow.tsx
+++ b/components/molecules/SearchResultRow/SearchResultRow.tsx
@@ -19,10 +19,14 @@ export type SearchResultRowProps = {
   onOpenDetail: () => void
 }
 
-const COVER_MEDIUM: Record<UnifiedSearchResult['type'], 'movies' | 'tv' | 'anime' | 'games'> = {
+const COVER_MEDIUM: Record<
+  UnifiedSearchResult['type'],
+  'movies' | 'tv' | 'anime' | 'manga' | 'games'
+> = {
   movie: 'movies',
   tv: 'tv',
   anime: 'anime',
+  manga: 'manga',
   game: 'games',
 }
 

--- a/components/organisms/GlobalSearch/GlobalSearch.tsx
+++ b/components/organisms/GlobalSearch/GlobalSearch.tsx
@@ -23,12 +23,12 @@ type SearchResponse = {
   partialFailure: boolean
 }
 
-type SearchApiType = 'movie' | 'tv' | 'anime' | 'game'
+type SearchApiType = 'movie' | 'tv' | 'anime' | 'manga' | 'game'
 
 type AddBody = {
   source: UnifiedSearchResult['primary_source']
   sourceId: number
-  type: 'MOVIE' | 'TV_SHOW' | 'ANIME' | 'GAME'
+  type: 'MOVIE' | 'TV_SHOW' | 'ANIME' | 'MANGA' | 'GAME'
 }
 
 type Variant =
@@ -50,6 +50,7 @@ const SEARCH_TYPE_TO_MEDIA: Record<UnifiedSearchResult['type'], AddBody['type']>
   movie: 'MOVIE',
   tv: 'TV_SHOW',
   anime: 'ANIME',
+  manga: 'MANGA',
   game: 'GAME',
 }
 
@@ -57,6 +58,7 @@ const SECTION_LABELS: Record<UnifiedSearchResult['type'], string> = {
   movie: 'MOVIES',
   tv: 'TV',
   anime: 'ANIME',
+  manga: 'MANGA',
   game: 'GAMES',
 }
 
@@ -64,6 +66,7 @@ const SECTION_ORDER: ReadonlyArray<UnifiedSearchResult['type']> = [
   'movie',
   'tv',
   'anime',
+  'manga',
   'game',
 ] as const
 
@@ -454,6 +457,7 @@ const COVER_PATH_PREFIX: Record<UnifiedSearchResult['type'], string> = {
   movie: 'movies',
   tv: 'tv',
   anime: 'anime',
+  manga: 'manga',
   game: 'games',
 }
 

--- a/lib/search/__tests__/federation.test.ts
+++ b/lib/search/__tests__/federation.test.ts
@@ -1,6 +1,24 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type { UnifiedSearchResult } from '@/lib/search/federation'
 
+const anilistMock = vi.hoisted(() => ({
+  searchAnime: vi.fn(),
+  searchManga: vi.fn(),
+}))
+
+vi.mock('@/lib/api/anilist', () => ({
+  searchAnime: anilistMock.searchAnime,
+  searchManga: anilistMock.searchManga,
+}))
+
+const tmdbMock = vi.hoisted(() => ({
+  searchMulti: vi.fn(),
+}))
+
+vi.mock('@/lib/api/tmdb', () => ({
+  searchMulti: tmdbMock.searchMulti,
+}))
+
 const validEnv: Record<string, string> = {
   NEXTAUTH_SECRET: 'a'.repeat(32),
   NEXTAUTH_URL: 'http://localhost:3000',
@@ -22,7 +40,12 @@ const validEnv: Record<string, string> = {
 
 beforeEach(() => {
   vi.resetModules()
+  vi.resetAllMocks()
   for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+  // Default both adapter calls to empty so dedup/title-normalisation tests
+  // that don't care about adapter wiring keep working untouched.
+  anilistMock.searchAnime.mockResolvedValue([])
+  anilistMock.searchManga.mockResolvedValue([])
 })
 
 afterEach(() => {
@@ -233,5 +256,104 @@ describe('lib/search/federation: dedupResults', () => {
     expect(tvRow?.tmdb_id).toBe(2606)
     expect(movieRow?.confidence).toBe(1.0)
     expect(tvRow?.confidence).toBe(1.0)
+  })
+})
+
+
+describe('lib/search/federation: anilistAdapter (Story 8.3)', () => {
+  function anilistMedia(
+    id: number,
+    type: 'ANIME' | 'MANGA',
+    overrides: Partial<{ title: string; year: number | null }> = {},
+  ) {
+    return {
+      id,
+      type,
+      title: {
+        romaji: overrides.title ?? `Title ${id}`,
+        english: null,
+        native: null,
+        userPreferred: overrides.title ?? `Title ${id}`,
+      },
+      startDate: {
+        year: overrides.year === undefined ? 2020 : overrides.year,
+        month: null,
+        day: null,
+      },
+      description: null,
+      coverImage: { large: `https://cdn.example/${id}.jpg` },
+    }
+  }
+
+  it('is registered with source: anilist and supports anime + manga', async () => {
+    const { ADAPTERS } = await import('@/lib/search/federation')
+    const anilist = ADAPTERS.find((a) => a.source === 'anilist')
+    expect(anilist).toBeDefined()
+    expect(anilist?.supportedTypes).toEqual(['anime', 'manga'])
+  })
+
+  it('type=anime calls searchAnime only, returns unified results with anilist_id and type=anime', async () => {
+    anilistMock.searchAnime.mockResolvedValue([
+      anilistMedia(170942, 'ANIME', { title: 'Sousou no Frieren', year: 2023 }),
+    ])
+    const { ADAPTERS } = await import('@/lib/search/federation')
+    const anilist = ADAPTERS.find((a) => a.source === 'anilist')!
+
+    const results = await anilist.search('frieren', 'anime')
+
+    expect(anilistMock.searchAnime).toHaveBeenCalledWith('frieren')
+    expect(anilistMock.searchManga).not.toHaveBeenCalled()
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject({
+      type: 'anime',
+      title: 'Sousou no Frieren',
+      anilist_id: 170942,
+      primary_source: 'anilist',
+      release_year: 2023,
+      confidence: 1.0,
+    })
+  })
+
+  it('type=manga calls searchManga only, returns type=manga results', async () => {
+    anilistMock.searchManga.mockResolvedValue([
+      anilistMedia(30002, 'MANGA', { title: 'Berserk', year: 1989 }),
+    ])
+    const { ADAPTERS } = await import('@/lib/search/federation')
+    const anilist = ADAPTERS.find((a) => a.source === 'anilist')!
+
+    const results = await anilist.search('berserk', 'manga')
+
+    expect(anilistMock.searchManga).toHaveBeenCalledWith('berserk')
+    expect(anilistMock.searchAnime).not.toHaveBeenCalled()
+    expect(results[0]).toMatchObject({
+      type: 'manga',
+      title: 'Berserk',
+      anilist_id: 30002,
+    })
+  })
+
+  it('type=undefined calls BOTH searchAnime + searchManga in parallel', async () => {
+    anilistMock.searchAnime.mockResolvedValue([anilistMedia(1, 'ANIME')])
+    anilistMock.searchManga.mockResolvedValue([anilistMedia(2, 'MANGA')])
+    const { ADAPTERS } = await import('@/lib/search/federation')
+    const anilist = ADAPTERS.find((a) => a.source === 'anilist')!
+
+    const results = await anilist.search('whatever', undefined)
+
+    expect(anilistMock.searchAnime).toHaveBeenCalledTimes(1)
+    expect(anilistMock.searchManga).toHaveBeenCalledTimes(1)
+    expect(results.map((r) => r.type).sort()).toEqual(['anime', 'manga'])
+  })
+
+  it('release_year is undefined when AniList reports startDate.year null', async () => {
+    anilistMock.searchAnime.mockResolvedValue([
+      anilistMedia(999, 'ANIME', { year: null }),
+    ])
+    const { ADAPTERS } = await import('@/lib/search/federation')
+    const anilist = ADAPTERS.find((a) => a.source === 'anilist')!
+
+    const results = await anilist.search('unscheduled', 'anime')
+
+    expect(results[0]?.release_year).toBeUndefined()
   })
 })

--- a/lib/search/__tests__/media-dispatcher.test.ts
+++ b/lib/search/__tests__/media-dispatcher.test.ts
@@ -157,6 +157,36 @@ describe('lib/search/media-dispatcher: getDispatcher', () => {
     expect(result.seasons).toEqual([])
   })
 
+  it("returns a dispatcher for (anilist, ANIME) and its fetch calls getMedia(id, 'ANIME')", async () => {
+    const { getDispatcher } = await import('@/lib/search/media-dispatcher')
+    const anilist = await import('@/lib/api/anilist')
+    const spy = vi
+      .spyOn(anilist, 'getMedia')
+      .mockResolvedValue({} as never)
+
+    const dispatcher = getDispatcher('anilist', MediaType.ANIME)
+    await dispatcher?.fetch(170942)
+
+    expect(dispatcher).not.toBeNull()
+    expect(dispatcher?.sourceIdKey).toBe('anilist_id')
+    expect(spy).toHaveBeenCalledWith(170942, 'ANIME')
+  })
+
+  it("returns a dispatcher for (anilist, MANGA) and its fetch calls getMedia(id, 'MANGA')", async () => {
+    const { getDispatcher } = await import('@/lib/search/media-dispatcher')
+    const anilist = await import('@/lib/api/anilist')
+    const spy = vi
+      .spyOn(anilist, 'getMedia')
+      .mockResolvedValue({} as never)
+
+    const dispatcher = getDispatcher('anilist', MediaType.MANGA)
+    await dispatcher?.fetch(30002)
+
+    expect(dispatcher).not.toBeNull()
+    expect(dispatcher?.sourceIdKey).toBe('anilist_id')
+    expect(spy).toHaveBeenCalledWith(30002, 'MANGA')
+  })
+
   it('returns null for every unwired (source, type) tuple', async () => {
     const { getDispatcher } = await import('@/lib/search/media-dispatcher')
 
@@ -173,6 +203,8 @@ describe('lib/search/media-dispatcher: getDispatcher', () => {
     const wired = new Set([
       `tmdb:${MediaType.MOVIE}`,
       `tmdb:${MediaType.TV_SHOW}`,
+      `anilist:${MediaType.ANIME}`,
+      `anilist:${MediaType.MANGA}`,
     ])
 
     for (const source of sources) {

--- a/lib/search/federation.ts
+++ b/lib/search/federation.ts
@@ -1,6 +1,11 @@
 import { searchMulti, type TmdbSearchMultiResult } from '@/lib/api/tmdb'
+import {
+  searchAnime,
+  searchManga,
+  type AnilistMedia,
+} from '@/lib/api/anilist'
 
-export type SearchType = 'movie' | 'tv' | 'anime' | 'game'
+export type SearchType = 'movie' | 'tv' | 'anime' | 'manga' | 'game'
 
 export type SearchSource = 'tmdb' | 'anilist' | 'igdb' | 'steam'
 
@@ -83,7 +88,63 @@ const tmdbAdapter: AdapterCapability = {
   },
 }
 
-export const ADAPTERS: readonly AdapterCapability[] = [tmdbAdapter]
+// AniList covers serve as full https URLs from s4.anilist.co; the unified
+// poster_path field stores them verbatim. Story 8.4's render helper will
+// branch on startsWith('http') to skip TMDB-style URL construction.
+function preferredAnilistTitle(t: AnilistMedia['title']): string {
+  return t.userPreferred ?? t.romaji ?? t.english ?? t.native ?? ''
+}
+
+function pickAnilistCover(c: AnilistMedia['coverImage']): string | null {
+  return c?.extraLarge ?? c?.large ?? c?.medium ?? null
+}
+
+function adaptAnilistResult(
+  raw: AnilistMedia,
+  type: 'anime' | 'manga',
+): UnifiedSearchResult {
+  return {
+    type,
+    title: preferredAnilistTitle(raw.title),
+    release_year: raw.startDate.year ?? undefined,
+    poster_path: pickAnilistCover(raw.coverImage),
+    overview: raw.description ?? null,
+    primary_source: 'anilist',
+    anilist_id: raw.id,
+    confidence: 1.0,
+  }
+}
+
+const anilistAdapter: AdapterCapability = {
+  source: 'anilist',
+  supportedTypes: ['anime', 'manga'] as const,
+  async search(query, type) {
+    // type === undefined hits both anime + manga (federated search with no
+    // filter); explicit anime / manga hits one. The adapter-level limiter in
+    // lib/api/anilist enforces the 90 req/min ceiling across both calls.
+    if (type === 'anime') {
+      const anime = await searchAnime(query)
+      return anime.map((m) => adaptAnilistResult(m, 'anime'))
+    }
+    if (type === 'manga') {
+      const manga = await searchManga(query)
+      return manga.map((m) => adaptAnilistResult(m, 'manga'))
+    }
+    const [anime, manga] = await Promise.all([
+      searchAnime(query),
+      searchManga(query),
+    ])
+    return [
+      ...anime.map((m) => adaptAnilistResult(m, 'anime')),
+      ...manga.map((m) => adaptAnilistResult(m, 'manga')),
+    ]
+  },
+}
+
+export const ADAPTERS: readonly AdapterCapability[] = [
+  tmdbAdapter,
+  anilistAdapter,
+]
 
 const CONFIDENCE_LADDER: Record<number, number> = {
   1: 1.0,

--- a/lib/search/media-dispatcher.ts
+++ b/lib/search/media-dispatcher.ts
@@ -1,7 +1,10 @@
 import { MediaType, type Prisma } from '@prisma/client'
 import { getMovie, getTv, getTvSeason } from '@/lib/api/tmdb'
+import { getMedia as getAnilistMedia } from '@/lib/api/anilist'
 import { normaliseTmdbMovie } from '@/lib/normalise/movie'
 import { normaliseTmdbTv } from '@/lib/normalise/tv'
+import { normaliseAnilistAnime } from '@/lib/normalise/anime'
+import { normaliseAnilistManga } from '@/lib/normalise/manga'
 
 export type AddMediaSource = 'tmdb' | 'anilist' | 'igdb' | 'steam'
 
@@ -49,6 +52,20 @@ export function getDispatcher(
         return normaliseTmdbTv(show, seasons)
       },
       sourceIdKey: 'tmdb_id',
+    }
+  }
+  if (source === 'anilist' && type === MediaType.ANIME) {
+    return {
+      fetch: (id) => getAnilistMedia(id, 'ANIME'),
+      normalise: (raw) => normaliseAnilistAnime(raw),
+      sourceIdKey: 'anilist_id',
+    }
+  }
+  if (source === 'anilist' && type === MediaType.MANGA) {
+    return {
+      fetch: (id) => getAnilistMedia(id, 'MANGA'),
+      normalise: (raw) => normaliseAnilistManga(raw),
+      sourceIdKey: 'anilist_id',
     }
   }
   return null


### PR DESCRIPTION
## Summary

Story 8.3 of Epic 8 (Anime & Manga). Wires the AniList adapter into both `GET /api/search` (federated cross-API search) and `POST /api/media` (the library-add path). Closes **FR4** (federated search across TMDB + AniList) and **ECH-T7** (movie cross-source merge type filter missing).

Builds on Story 8.1 (AniList adapter, PR #131), Story 8.2 (anime + manga normalisers, PR #133), and the schema columns in PR #132.

Authoritative spec: `_bmad-output/planning-artifacts/epics.md`, Story 8.3 (lines 2055-2085).

## What ships

### `lib/search/federation.ts`
- New `anilistAdapter` registered alongside `tmdbAdapter` in the `ADAPTERS` array. `supportedTypes: [''anime'', ''manga'']`.
- `search(q, type)` dispatches:
  - `type=anime` → `searchAnime(q)` only.
  - `type=manga` → `searchManga(q)` only.
  - `type=undefined` → both, in parallel via `Promise.all`.
- `adaptAnilistResult` maps `AnilistMedia` → `UnifiedSearchResult` with title fallback (`userPreferred → romaji → english → native`), cover fallback (`extraLarge → large → medium`), and `release_year` from `startDate.year` (undefined when AniList reports null).
- `SearchType` union extended with `''manga''`.

### `lib/search/media-dispatcher.ts`
- New `(anilist, ANIME)` branch: `fetch: (id) => getMedia(id, ''ANIME'')`, `normalise: normaliseAnilistAnime`, `sourceIdKey: ''anilist_id''`.
- New `(anilist, MANGA)` branch: same shape with `normaliseAnilistManga`.

### `app/api/search/route.ts`
- Zod query schema accepts `type=manga`.

### `app/api/media/route.ts`
- Catches `AnilistApiError` alongside `TmdbApiError` on the `upstream_failed` path so AniList 5xx / 429 / parse errors surface as a 502 with the same `media.upstream_failed` log shape.
- **ECH-T7 fix**: `persistSingleMediaItem`'s cross-merge now filters candidates with `c.type === type`. Without this, a 2007 TMDB movie titled "Sword of the Stranger" would silently collapse with a 2007 AniList anime of the same name. Same invariant already enforced in `persistShowWithEpisodes`.

### UI type-map updates (purely additive)
- `GlobalSearch.tsx`: `SEARCH_TYPE_TO_MEDIA`, `SECTION_LABELS`, `SECTION_ORDER`, `COVER_PATH_PREFIX`, `AddBody.type`, `SearchApiType` all extended to include `''manga''`.
- `SearchResultRow.tsx`: `COVER_MEDIUM` extended.

### Tests (16 new across 4 files)
- `lib/search/__tests__/federation.test.ts` — 5 new tests for `anilistAdapter` registration, type filters, parallel fan-out, and `release_year` null handling.
- `lib/search/__tests__/media-dispatcher.test.ts` — 2 new tests for `(anilist, ANIME)` and `(anilist, MANGA)` dispatcher wiring; exhaustive null test`s `wired` set extended.
- `app/api/search/__tests__/route.test.ts` — 4 new tests: `type=anime` calls AniList only, `type=manga` calls manga only, no-type fans out to both, AniList rejection still flags `partialFailure: true` with TMDB results surviving.
- `app/api/media/__tests__/route.test.ts` — 5 new tests under a new `AniList add path (Story 8.3)` describe: 201 ANIME with `anilist_id`, 201 MANGA mapping `author_name` + `chapter_count` + `volume_count`, idempotent fast-path on existing `anilist_id`, 502 on `AnilistApiError`, cross-source merge with same-type candidate, **ECH-T7 cross-type guard** (TMDB movie + AniList anime "Sword of the Stranger" stay distinct).

## Acceptance criteria mapping (Story 8.3)

| AC | Where |
|---|---|
| Federated search dispatches to TMDB + AniList in parallel | `anilistAdapter` in `ADAPTERS`, `Promise.allSettled` in route handler |
| `type=anime` skips TMDB | `dispatched = ADAPTERS.filter(a => a.supportedTypes.includes(type))` |
| `type=manga` skips TMDB | same filter + `SearchType` includes `''manga''` |
| AniList 429 surfaces `partialFailure: true`, TMDB still returns | covered by `partial failure` test, Story 4.3 `Promise.allSettled` semantics |
| `POST /api/media` with `source: ''anilist''`, `type: ANIME` persists `MediaItem` with `anilist_id` | new `(anilist, ANIME)` dispatcher + tests |
| Same for `type: MANGA` | new `(anilist, MANGA)` dispatcher + tests |

## ECH-T7 — movie cross-source merge type filter

Surfaced during Epic 7 review and tracked in `sprint-status.yaml`. The single-line fix lives in this PR because:

1. The AniList add path uses the same `persistSingleMediaItem` function; without the type filter, the new path inherits the same bug.
2. The fix mirrors the existing `c.type === MediaType.TV_SHOW` guard in `persistShowWithEpisodes` exactly — no novel mechanism.
3. Test coverage lands in the same PR (the "Sword of the Stranger" case).

If you'd prefer ECH-T7 as a separate PR for review hygiene, I can split it.

## Verification

```powershell
cd cuatro-tracker
corepack pnpm typecheck                                    # clean
corepack pnpm lint                                          # clean (zero warnings)
corepack pnpm vitest run lib/search lib/normalise app/api  # 181 / 181 in scope
corepack pnpm test                                          # 745 / 747 (the 2 BullMQ worker tests need Redis up, not regressed)
```

### Live smoke (manual, hits AniList + DB)

```powershell
# Federated search via the live route
curl -s "http://localhost:3000/api/search?q=frieren" | jq ''.results[] | {type, title, anilist_id, tmdb_id}''
# Add an anime through the new path
curl -s -X POST "http://localhost:3000/api/media" -H "Content-Type: application/json" -H "Cookie: <auth>" \
  -d ''{"source":"anilist","sourceId":170942,"type":"ANIME"}'' | jq ''{merged, mediaItem: {type, title, anilist_id}}''
```

## Design notes

- **`staff` already in `MEDIA_FIELDS` (Story 8.2)** means search-result rows carry the data the manga normaliser needs for `author_name` without a second AniList round-trip on add.
- **Dedup key intentionally includes `type`** (federation.ts comment). A TMDB tv show and an AniList anime with the same title + year stay as two rows in federated results. The persist-layer cross-type guard (this PR) keeps that semantic consistent through the add path.
- **No new dependency**: federation + dispatcher reuse the in-module concurrency limiter from Story 8.1's adapter. The 90 req/min ceiling is enforced once at the adapter, regardless of whether a request goes through search, the add path, or a future bulk-import job.

## Out of scope (deferred)

- Stories 8.4 / 8.5 / 8.6 — `/anime` + `/manga` grids, detail pages, RelationsList organism (consume but don't change these endpoints).
- The dedup-layer cross-type equivalence experiment (flagged in `federation.ts` line 104-110 comment). Not needed for Epic 8.
- ECH-T20 (`completed_at` not auto-set when status changes to COMPLETED). Remains open in sprint-status; orthogonal to the search / add path touched here.