### PR TITLE
chore(epic-8): apply retroactive code-review followups (#138)

### DIFF
--- a/app/api/media/route.ts
+++ b/app/api/media/route.ts
@@ -5,7 +5,7 @@ import { db } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import { withRequest } from '@/lib/request-context'
 import { TmdbApiError } from '@/lib/api/tmdb'
-import { AnilistApiError } from '@/lib/api/anilist'
+import { AnilistApiError, AnilistNotFoundError } from '@/lib/api/anilist'
 import {
   getDispatcher,
   type AddMediaSource,
@@ -56,33 +56,41 @@ function findExistingBySourceId(
 function findCrossSourceCandidates(
   source: AddMediaSource,
   releaseYear: number,
+  type: MediaType,
 ): Promise<MediaItemWithUserEntry[]> {
   const include = { user_entry: true } as const
   const yearStart = new Date(Date.UTC(releaseYear, 0, 1))
   const yearEnd = new Date(Date.UTC(releaseYear + 1, 0, 1))
   const release_date = { gte: yearStart, lt: yearEnd }
+  // ECH-8-3-6: filter by type in the WHERE clause so the 50-row take cap
+  // is spent only on rows that are eligible candidates. Without this filter,
+  // saturated years (e.g. 1989 with hundreds of TV_EPISODE rows) can starve
+  // the per-type cross-merge match - the real ANIME or MANGA candidate at
+  // row 51+ would be missed. The redundant JS-side `c.type === type` filter
+  // in persistSingleMediaItem / persistShowWithEpisodes is now defence in
+  // depth, not the primary guard.
   switch (source) {
     case 'tmdb':
       return db.mediaItem.findMany({
-        where: { tmdb_id: null, release_date },
+        where: { tmdb_id: null, release_date, type },
         include,
         take: 50,
       })
     case 'anilist':
       return db.mediaItem.findMany({
-        where: { anilist_id: null, release_date },
+        where: { anilist_id: null, release_date, type },
         include,
         take: 50,
       })
     case 'igdb':
       return db.mediaItem.findMany({
-        where: { igdb_id: null, release_date },
+        where: { igdb_id: null, release_date, type },
         include,
         take: 50,
       })
     case 'steam':
       return db.mediaItem.findMany({
-        where: { steam_id: null, release_date },
+        where: { steam_id: null, release_date, type },
         include,
         take: 50,
       })
@@ -200,6 +208,21 @@ async function handler(req: NextRequest): Promise<NextResponse> {
   try {
     raw = await dispatcher.fetch(sourceId)
   } catch (err) {
+    // AniList returned `Media: null` (HTTP 200) for the requested id-type
+    // tuple. The user posted a sourceId that resolves to a different format
+    // (e.g. type=ANIME but the id is actually a manga). 404 is the correct
+    // surface, not the generic 502 upstream_failed - the upstream call
+    // succeeded; the user's input was the problem. ECH-8-3-8.
+    if (err instanceof AnilistNotFoundError) {
+      logger.warn(
+        { event: 'media.not_found', source, sourceId, type },
+        'AniList Media not found for id-type tuple',
+      )
+      return jsonResponse(
+        { error: 'not_found', source, sourceId, type },
+        404,
+      )
+    }
     if (err instanceof TmdbApiError || err instanceof AnilistApiError) {
       logger.warn(
         {
@@ -262,15 +285,15 @@ async function persistSingleMediaItem(
       ? normalised.release_date.getUTCFullYear()
       : new Date(normalised.release_date as string).getUTCFullYear()
     const normalisedKey = normaliseTitle(normalised.title)
-    // Skip cross-merge when the normaliser fell back to the 1970 sentinel —
-    // every undated item shares that year bucket and would falsely collide.
+    // Skip cross-merge when the normaliser fell back to the 1970 sentinel.
+    // Every undated item shares that year bucket and would falsely collide.
     const candidates =
       releaseYear === 1970
         ? []
-        : await findCrossSourceCandidates(source, releaseYear)
+        : await findCrossSourceCandidates(source, releaseYear, type)
     // Filter to the same MediaType. Without this, a 2007 TMDB movie titled
     // "Sword of the Stranger" would collapse with a 2007 AniList anime of the
-    // same name — patching anilist_id onto the movie row and silently changing
+    // same name, patching anilist_id onto the movie row and silently changing
     // the canonical type. Closes ECH-T7 (movie cross-source merge type filter
     // missing). Same invariant already enforced for TV in persistShowWithEpisodes.
     const crossMatch = candidates.find(
@@ -323,12 +346,12 @@ async function persistShowWithEpisodes(
       ? normalised.show.release_date.getUTCFullYear()
       : new Date(normalised.show.release_date as string).getUTCFullYear()
     const normalisedKey = normaliseTitle(normalised.show.title)
-    // Skip cross-merge when the normaliser fell back to the 1970 sentinel —
-    // every undated item shares that year bucket and would falsely collide.
+    // Skip cross-merge when the normaliser fell back to the 1970 sentinel.
+    // Every undated item shares that year bucket and would falsely collide.
     const candidates =
       releaseYear === 1970
         ? []
-        : await findCrossSourceCandidates(source, releaseYear)
+        : await findCrossSourceCandidates(source, releaseYear, type)
     // Filter to TV_SHOW only: a 1984 movie and a 1984 TV show with the same
     // normalised title (e.g. "Dune") must not collapse.
     const crossMatch = candidates.find(
@@ -339,7 +362,7 @@ async function persistShowWithEpisodes(
 
     if (crossMatch) {
       // Patch the source ID onto the existing show row; the inbound episodes
-      // are DISCARDED — the cross-source sibling's episodes from the original
+      // are DISCARDED. The cross-source sibling's episodes from the original
       // adapter remain authoritative (per OI #6 in the impl-artifact).
       const patched = await patchSourceId(crossMatch.id, source, sourceId)
       const ensured = await ensureUserEntry(patched)
@@ -386,7 +409,7 @@ async function persistShowWithEpisodes(
         }
         // Episode tmdb_id collided with a foreign MediaItem row. Atomic
         // transactions can't leave orphan episodes, so the "same-parent
-        // re-import" case is unreachable here — this is a real cross-context
+        // re-import" case is unreachable here. This is a real cross-context
         // collision worth surfacing for operator investigation. The schema
         // fix is the @@unique([type, tmdb_id]) follow-up migration (ECH-4).
         logger.error(

--- a/app/api/search/__tests__/route.test.ts
+++ b/app/api/search/__tests__/route.test.ts
@@ -450,7 +450,13 @@ describe('GET /api/search', () => {
       })
     })
 
-    it('flags partialFailure: true when AniList rejects (e.g. 429), TMDB still returns', async () => {
+    it('flags partialFailure: true when BOTH AniList branches reject (e.g. 429 saturation), TMDB still returns', async () => {
+      // ECH-8-3-1 chore PR (#138): the anilistAdapter now uses
+      // Promise.allSettled internally, so a single rejected branch (anime
+      // OR manga) no longer fails the whole adapter - the surviving branch's
+      // results are returned. For outer partialFailure to flip, BOTH branches
+      // must reject. A separate Vitest at the adapter layer covers the
+      // partial-success behaviour (lib/search/__tests__/federation.test.ts).
       tmdbMock.searchMulti.mockResolvedValue({
         page: 1,
         results: [movieResult],
@@ -458,6 +464,9 @@ describe('GET /api/search', () => {
         total_results: 1,
       })
       anilistMock.searchAnime.mockRejectedValue(
+        new Error('AniList rate limited (429)'),
+      )
+      anilistMock.searchManga.mockRejectedValue(
         new Error('AniList rate limited (429)'),
       )
       const { GET } = await import('@/app/api/search/route')
@@ -469,6 +478,40 @@ describe('GET /api/search', () => {
       expect(body.partialFailure).toBe(true)
       expect(body.results).toHaveLength(1)
       expect(body.results[0]).toMatchObject({ type: 'movie', tmdb_id: 550 })
+    })
+
+    it('partialFailure stays false when only ONE AniList branch rejects (the other survives)', async () => {
+      // Companion to the test above: documents the new partial-success
+      // semantics. The half-failure is still observable via the warn log
+      // emitted in lib/search/federation.ts (event: anilist.partial_failure).
+      tmdbMock.searchMulti.mockResolvedValue({
+        page: 1,
+        results: [],
+        total_pages: 1,
+        total_results: 0,
+      })
+      anilistMock.searchAnime.mockRejectedValue(
+        new Error('AniList rate limited (429)'),
+      )
+      anilistMock.searchManga.mockResolvedValue([
+        anilistMedia(30002, 'MANGA', {
+          title: {
+            romaji: 'Berserk',
+            english: null,
+            native: null,
+            userPreferred: 'Berserk',
+          },
+        }),
+      ])
+      const { GET } = await import('@/app/api/search/route')
+
+      const res = await GET(makeRequest('/api/search?q=foo'))
+
+      const body = await res.json()
+      expect(body.partialFailure).toBe(false)
+      // Surviving manga result is returned.
+      expect(body.results).toHaveLength(1)
+      expect(body.results[0]).toMatchObject({ type: 'manga' })
     })
 
     it('logs each adapter rejection at warn with { source, durationMs, err }', async () => {

--- a/components/molecules/FilterChips/FilterChips.tsx
+++ b/components/molecules/FilterChips/FilterChips.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-export type FilterId = 'ALL' | 'MOVIES' | 'TV' | 'ANIME' | 'GAMES'
+export type FilterId = 'ALL' | 'MOVIES' | 'TV' | 'ANIME' | 'MANGA' | 'GAMES'
 
 export type FilterChipsProps = {
   active: FilterId
@@ -13,7 +13,10 @@ const CHIPS: readonly ChipDef[] = [
   { id: 'ALL', label: 'All', muted: false },
   { id: 'MOVIES', label: 'Movies', muted: false },
   { id: 'TV', label: 'TV', muted: false },
-  { id: 'ANIME', label: 'Anime', muted: true },
+  // Anime + Manga active as of Story 8.3 (federated search dispatches AniList
+  // for both). Games remain muted until Epic 9 lands the IGDB / Steam adapter.
+  { id: 'ANIME', label: 'Anime', muted: false },
+  { id: 'MANGA', label: 'Manga', muted: false },
   { id: 'GAMES', label: 'Games', muted: true },
 ] as const
 

--- a/components/molecules/FilterChips/__tests__/FilterChips.test.tsx
+++ b/components/molecules/FilterChips/__tests__/FilterChips.test.tsx
@@ -7,13 +7,14 @@ describe('FilterChips', () => {
     cleanup()
   })
 
-  it('renders 5 chips: ALL, MOVIES, TV, ANIME, GAMES', () => {
+  it('renders 6 chips: ALL, MOVIES, TV, ANIME, MANGA, GAMES', () => {
     render(<FilterChips active='ALL' onChange={() => {}} />)
 
     expect(screen.getByRole('tab', { name: /^ALL/ })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: /^MOVIES/ })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: /^TV/ })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: /^ANIME/ })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /^MANGA/ })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: /^GAMES/ })).toBeInTheDocument()
   })
 
@@ -29,28 +30,40 @@ describe('FilterChips', () => {
     expect(inactive.getAttribute('data-active')).toBe('false')
   })
 
-  it('renders the (soon) suffix on muted chips (ANIME, GAMES)', () => {
+  it('renders the (soon) suffix on muted chips (GAMES only, after Epic 8)', () => {
     render(<FilterChips active='ALL' onChange={() => {}} />)
 
-    const anime = screen.getByRole('tab', { name: /^ANIME/ })
     const games = screen.getByRole('tab', { name: /^GAMES/ })
     const movies = screen.getByRole('tab', { name: /^MOVIES/ })
+    const anime = screen.getByRole('tab', { name: /^ANIME/ })
+    const manga = screen.getByRole('tab', { name: /^MANGA/ })
 
-    expect(anime.textContent).toContain('(soon)')
     expect(games.textContent).toContain('(soon)')
     expect(movies.textContent).not.toContain('(soon)')
+    // ANIME + MANGA unmuted as of Epic 8 retroactive followups; the federated
+    // search route dispatches AniList for both.
+    expect(anime.textContent).not.toContain('(soon)')
+    expect(manga.textContent).not.toContain('(soon)')
   })
 
-  it('marks muted chips with aria-disabled + data-muted', () => {
+  it('marks muted chips with aria-disabled + data-muted (GAMES only)', () => {
     render(<FilterChips active='ALL' onChange={() => {}} />)
 
-    const anime = screen.getByRole('tab', { name: /^ANIME/ })
-    expect(anime.getAttribute('aria-disabled')).toBe('true')
-    expect(anime.getAttribute('data-muted')).toBe('true')
+    const games = screen.getByRole('tab', { name: /^GAMES/ })
+    expect(games.getAttribute('aria-disabled')).toBe('true')
+    expect(games.getAttribute('data-muted')).toBe('true')
 
     const all = screen.getByRole('tab', { name: /^ALL/ })
     expect(all.getAttribute('aria-disabled')).toBe('false')
     expect(all.getAttribute('data-muted')).toBe('false')
+
+    const anime = screen.getByRole('tab', { name: /^ANIME/ })
+    expect(anime.getAttribute('aria-disabled')).toBe('false')
+    expect(anime.getAttribute('data-muted')).toBe('false')
+
+    const manga = screen.getByRole('tab', { name: /^MANGA/ })
+    expect(manga.getAttribute('aria-disabled')).toBe('false')
+    expect(manga.getAttribute('data-muted')).toBe('false')
   })
 
   it('fires onChange when a non-muted chip is clicked', () => {
@@ -62,11 +75,23 @@ describe('FilterChips', () => {
     expect(onChange).toHaveBeenCalledExactlyOnceWith('TV')
   })
 
-  it('does NOT fire onChange when a muted chip is clicked', () => {
+  it('fires onChange for ANIME + MANGA (unmuted as of Epic 8 followups)', () => {
     const onChange = vi.fn()
     render(<FilterChips active='ALL' onChange={onChange} />)
 
     screen.getByRole('tab', { name: /^ANIME/ }).click()
+    expect(onChange).toHaveBeenCalledWith('ANIME')
+
+    screen.getByRole('tab', { name: /^MANGA/ }).click()
+    expect(onChange).toHaveBeenCalledWith('MANGA')
+
+    expect(onChange).toHaveBeenCalledTimes(2)
+  })
+
+  it('does NOT fire onChange when GAMES (muted) is clicked', () => {
+    const onChange = vi.fn()
+    render(<FilterChips active='ALL' onChange={onChange} />)
+
     screen.getByRole('tab', { name: /^GAMES/ }).click()
 
     expect(onChange).not.toHaveBeenCalled()

--- a/components/organisms/GlobalSearch/GlobalSearch.tsx
+++ b/components/organisms/GlobalSearch/GlobalSearch.tsx
@@ -43,6 +43,7 @@ const TYPE_TO_API: Record<Exclude<FilterId, 'ALL'>, SearchApiType> = {
   MOVIES: 'movie',
   TV: 'tv',
   ANIME: 'anime',
+  MANGA: 'manga',
   GAMES: 'game',
 }
 

--- a/lib/api/__tests__/anilist.test.ts
+++ b/lib/api/__tests__/anilist.test.ts
@@ -116,33 +116,36 @@ describe('partialDateToDate', () => {
     const { partialDateToDate } = await import('@/lib/api/anilist')
     const d = partialDateToDate(2020, 3, 15)
     expect(d).not.toBeNull()
-    expect(d?.getFullYear()).toBe(2020)
-    expect(d?.getMonth()).toBe(2)
-    expect(d?.getDate()).toBe(15)
+    // UTC getters: ECH-8-2-1 fix anchors construction via Date.UTC(...) so
+    // assertions are TZ-independent (a developer running in Asia/Tokyo gets
+    // the same result as one running in UTC).
+    expect(d?.getUTCFullYear()).toBe(2020)
+    expect(d?.getUTCMonth()).toBe(2)
+    expect(d?.getUTCDate()).toBe(15)
   })
 
   it('falls back day to 1 when null', async () => {
     const { partialDateToDate } = await import('@/lib/api/anilist')
     const d = partialDateToDate(2020, 3, null)
-    expect(d?.getFullYear()).toBe(2020)
-    expect(d?.getMonth()).toBe(2)
-    expect(d?.getDate()).toBe(1)
+    expect(d?.getUTCFullYear()).toBe(2020)
+    expect(d?.getUTCMonth()).toBe(2)
+    expect(d?.getUTCDate()).toBe(1)
   })
 
   it('falls back month to January (index 0) when null', async () => {
     const { partialDateToDate } = await import('@/lib/api/anilist')
     const d = partialDateToDate(2020, null, 15)
-    expect(d?.getFullYear()).toBe(2020)
-    expect(d?.getMonth()).toBe(0)
-    expect(d?.getDate()).toBe(15)
+    expect(d?.getUTCFullYear()).toBe(2020)
+    expect(d?.getUTCMonth()).toBe(0)
+    expect(d?.getUTCDate()).toBe(15)
   })
 
   it('falls back to Jan 1 when month and day are both null', async () => {
     const { partialDateToDate } = await import('@/lib/api/anilist')
     const d = partialDateToDate(2020, null, null)
-    expect(d?.getFullYear()).toBe(2020)
-    expect(d?.getMonth()).toBe(0)
-    expect(d?.getDate()).toBe(1)
+    expect(d?.getUTCFullYear()).toBe(2020)
+    expect(d?.getUTCMonth()).toBe(0)
+    expect(d?.getUTCDate()).toBe(1)
   })
 
   it('returns null when year is null (no anchor)', async () => {
@@ -360,5 +363,138 @@ describe('rate limiting', () => {
     await expect(searchAnime('Frieren')).rejects.toBeInstanceOf(
       AnilistApiError,
     )
+  })
+})
+
+describe('Epic 8 retroactive followups (Pass 2)', () => {
+  it('ECH-8-1-1: a third concurrent caller is NOT contaminated by another caller`s rejection', async () => {
+    // Setup: three pending fetches via deferred promises. The first rejects,
+    // the second + third are still in flight. Pre-fix, withLimit would
+    // re-throw the first call`s rejection to the third caller awaiting
+    // Promise.race(inflight) BEFORE the third caller ran its own fetch.
+    const deferred: Array<{
+      resolve: (r: Response) => void
+      reject: (e: unknown) => void
+    }> = []
+    let i = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Promise<Response>((resolve, reject) => {
+            const slot = i
+            deferred[slot] = { resolve, reject }
+            i += 1
+          }),
+      ),
+    )
+
+    const { searchAnime, AnilistApiError } = await import('@/lib/api/anilist')
+
+    // Fire three concurrent searches. The first two saturate the limiter
+    // (concurrency cap = 2); the third waits.
+    const p1 = searchAnime('a').catch((err) => ({ kind: 'err', err }))
+    // p2 is held in-flight via deferred[1] but its result is irrelevant - it
+    // exists only to occupy the second concurrency slot so p3 has to wait
+    // on Promise.race(inflight).
+    const _p2 = searchAnime('b').catch((err) => ({ kind: 'err', err }))
+    const p3 = searchAnime('c').catch((err) => ({ kind: 'err', err }))
+
+    // Wait a microtask so the first two register in `inflight`.
+    await new Promise((r) => setTimeout(r, 0))
+
+    // Reject the first caller. The second + third should be unaffected.
+    deferred[0]!.reject(new Error('caller 1 boom'))
+
+    // p1 should reject with the boom (wrapped inside AnilistApiError.cause -
+    // the adapter's anilistFetch wraps fetch failures in AnilistApiError).
+    // p3 must NOT see "caller 1 boom" - it gets its own fetch slot and waits
+    // for deferred[2].
+    const r1 = await p1
+    expect(r1).toMatchObject({
+      kind: 'err',
+      err: expect.objectContaining({
+        name: 'AnilistApiError',
+        cause: expect.objectContaining({
+          message: expect.stringContaining('caller 1 boom'),
+        }),
+      }),
+    })
+
+    // p3 should now have its own pending fetch. Resolve it with valid data.
+    // (deferred[2] was created when p3 entered the limiter.)
+    await new Promise((r) => setTimeout(r, 0))
+    expect(deferred[2]).toBeDefined()
+    deferred[2]!.resolve(
+      new Response(JSON.stringify({ data: { Page: { media: [] } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    // Drain p2 too so the test doesn`t leak.
+    deferred[1]!.resolve(
+      new Response(JSON.stringify({ data: { Page: { media: [] } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const r3 = await p3
+    expect(r3).toEqual([])
+    // Confirm p3 was NOT contaminated by caller 1`s rejection.
+    expect(r3).not.toMatchObject({ kind: 'err' })
+    // Sanity: AnilistApiError shouldn`t even be involved.
+    expect(AnilistApiError).toBeDefined()
+  })
+
+  it('ECH-8-2-1: partialDateToDate is UTC-anchored regardless of process TZ', async () => {
+    // Stash original TZ; force to Asia/Tokyo (UTC+9) which would offset
+    // local-time Date constructor by 9 hours west. process.env.TZ is the
+    // only path to override the Node runtime TZ; this is a legit Node API
+    // (not a config value the Zod env schema should own), hence the
+    // eslint-disable below.
+    /* eslint-disable no-restricted-syntax */
+    const originalTz = process.env.TZ
+    process.env.TZ = 'Asia/Tokyo'
+    try {
+      const { partialDateToDate } = await import('@/lib/api/anilist')
+      const d = partialDateToDate(2023, 9, 29)
+      expect(d).not.toBeNull()
+      // Must serialise to midnight UTC on the requested calendar day.
+      expect(d!.toISOString()).toBe('2023-09-29T00:00:00.000Z')
+
+      const yearOnly = partialDateToDate(2020, null, null)
+      expect(yearOnly!.toISOString()).toBe('2020-01-01T00:00:00.000Z')
+    } finally {
+      if (originalTz === undefined) {
+        delete process.env.TZ
+      } else {
+        process.env.TZ = originalTz
+      }
+    }
+    /* eslint-enable no-restricted-syntax */
+  })
+
+  it('ECH-8-3-8: getMedia throws AnilistNotFoundError when AniList returns Media: null', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Response(JSON.stringify({ data: { Media: null } }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+      ),
+    )
+    const { getMedia, AnilistNotFoundError } = await import('@/lib/api/anilist')
+
+    await expect(getMedia(30002, 'ANIME')).rejects.toBeInstanceOf(
+      AnilistNotFoundError,
+    )
+    await expect(getMedia(30002, 'ANIME')).rejects.toMatchObject({
+      id: 30002,
+      format: 'ANIME',
+    })
   })
 })

--- a/lib/api/anilist.ts
+++ b/lib/api/anilist.ts
@@ -186,9 +186,26 @@ const AnilistSearchPageSchema = z.object({
   }),
 })
 
+// AniList returns `{ data: { Media: null } }` (HTTP 200) when the id-type tuple
+// does not resolve to a record - e.g. requesting `getMedia(<manga-id>, 'ANIME')`.
+// We model that as a typed `AnilistNotFoundError` so the route handler can map
+// it to 404 instead of bubbling a "parse failure" 502 through the upstream-
+// failed path. Schema accepts null so Zod does not reject the legit response.
 const AnilistGetMediaSchema = z.object({
-  Media: AnilistMediaSchema,
+  Media: AnilistMediaSchema.nullable(),
 })
+
+export class AnilistNotFoundError extends Error {
+  readonly id: number
+  readonly format: 'ANIME' | 'MANGA'
+
+  constructor(id: number, format: 'ANIME' | 'MANGA') {
+    super(`AniList Media not found for id=${id} format=${format}`)
+    this.name = 'AnilistNotFoundError'
+    this.id = id
+    this.format = format
+  }
+}
 
 const AnilistGetRelationsSchema = z.object({
   Media: z.object({
@@ -208,26 +225,46 @@ const AnilistGraphQLErrorSchema = z.object({
 // NFR14: AniList fuzzy dates may have null month or day. `new Date(year, null, null)`
 // produces "Invalid Date" silently. Always build via (month ?? 1) - 1, day ?? 1.
 // Returns null when year is null (no anchor); callers map that to a sentinel.
+//
+// IMPORTANT: build via `Date.UTC(...)` so the resulting Date represents
+// midnight UTC on that day. The pre-fix code used `new Date(year, m, d)`
+// which interprets the args in the local TZ and then writes to Postgres as
+// a UTC instant - drifting `release_date` up to one day east of UTC vs the
+// UTC-anchored TMDB normaliser at lib/normalise/release-date.ts. Caught by
+// the Epic 8 retroactive code-review sweep (ECH-8-2-1).
 export function partialDateToDate(
   year: number | null,
   month: number | null,
   day: number | null,
 ): Date | null {
   if (year === null) return null
-  return new Date(year, (month ?? 1) - 1, day ?? 1)
+  return new Date(Date.UTC(year, (month ?? 1) - 1, day ?? 1))
 }
 
+// Each promise added to `inflight` is wrapped with a `.catch` so that
+// `Promise.race(inflight)` from a future caller can settle WITHOUT re-throwing
+// a rejection that belongs to a different caller. Pre-fix code stored the
+// `fn()` promise directly: when call A 429'd while calls B + C were waiting
+// on `Promise.race`, the race rejected with A's error and B + C re-threw it
+// before ever calling fetch (ECH-8-1-1).
 const inflight = new Set<Promise<unknown>>()
 async function withLimit<T>(fn: () => Promise<T>): Promise<T> {
   while (inflight.size >= ANILIST_CONCURRENCY) {
+    // race-safe waiter: every entry in `inflight` already has its real error
+    // path handled via the `await p` below in its own `withLimit` invocation;
+    // this loop only needs to know when a slot frees up.
     await Promise.race(inflight)
   }
-  const p = (async () => fn())()
-  inflight.add(p)
+  const real = (async () => fn())()
+  // Settled-token swallows rejections so cross-caller waiters do not get
+  // contaminated. The real promise (with the real rejection) is awaited
+  // directly by the originating caller.
+  const token: Promise<unknown> = real.catch(() => undefined)
+  inflight.add(token)
   try {
-    return await p
+    return await real
   } finally {
-    inflight.delete(p)
+    inflight.delete(token)
   }
 }
 
@@ -473,6 +510,12 @@ export function getMedia(
       AnilistGetMediaSchema,
       `media/${format.toLowerCase()}/${id}`,
     )
+    // AniList responds with `Media: null` (HTTP 200) for unresolved id-type
+    // tuples. Surface as AnilistNotFoundError so the /api/media route can map
+    // to 404 instead of the 502 upstream_failed path. ECH-8-3-8.
+    if (result.Media === null) {
+      throw new AnilistNotFoundError(id, format)
+    }
     return result.Media
   })
 }

--- a/lib/normalise/__tests__/anime.test.ts
+++ b/lib/normalise/__tests__/anime.test.ts
@@ -107,9 +107,11 @@ describe('lib/normalise/anime', () => {
         anilist_id: 170942,
       })
       expect(result.release_date).toBeInstanceOf(Date)
-      expect((result.release_date as Date).getFullYear()).toBe(2023)
-      expect((result.release_date as Date).getMonth()).toBe(8) // September is 8 (0-indexed)
-      expect((result.release_date as Date).getDate()).toBe(29)
+      // UTC getters: partialDateToDate now anchors via Date.UTC so the
+      // result is TZ-independent (ECH-8-2-1 fix).
+      expect((result.release_date as Date).getUTCFullYear()).toBe(2023)
+      expect((result.release_date as Date).getUTCMonth()).toBe(8) // September is 8 (0-indexed)
+      expect((result.release_date as Date).getUTCDate()).toBe(29)
     })
   })
 
@@ -183,9 +185,9 @@ describe('lib/normalise/anime', () => {
       )
       const date = result.release_date as Date
       expect(date).toBeInstanceOf(Date)
-      expect(date.getFullYear()).toBe(2020)
-      expect(date.getMonth()).toBe(0)
-      expect(date.getDate()).toBe(1)
+      expect(date.getUTCFullYear()).toBe(2020)
+      expect(date.getUTCMonth()).toBe(0)
+      expect(date.getUTCDate()).toBe(1)
       expect(Number.isNaN(date.getTime())).toBe(false)
     })
 
@@ -195,9 +197,9 @@ describe('lib/normalise/anime', () => {
         makeAnime({ startDate: { year: 2020, month: 6, day: null } }),
       )
       const date = result.release_date as Date
-      expect(date.getFullYear()).toBe(2020)
-      expect(date.getMonth()).toBe(5) // June
-      expect(date.getDate()).toBe(1)
+      expect(date.getUTCFullYear()).toBe(2020)
+      expect(date.getUTCMonth()).toBe(5) // June
+      expect(date.getUTCDate()).toBe(1)
     })
 
     it('falls through to 1970 sentinel when year is null (all-null fuzzy date)', async () => {

--- a/lib/normalise/__tests__/manga.test.ts
+++ b/lib/normalise/__tests__/manga.test.ts
@@ -111,7 +111,8 @@ describe('lib/normalise/manga', () => {
         anilist_id: 30002,
       })
       expect(result.release_date).toBeInstanceOf(Date)
-      expect((result.release_date as Date).getFullYear()).toBe(1989)
+      // UTC getter: ECH-8-2-1 fix anchors construction via Date.UTC.
+      expect((result.release_date as Date).getUTCFullYear()).toBe(1989)
     })
   })
 
@@ -216,9 +217,9 @@ describe('lib/normalise/manga', () => {
         makeManga({ startDate: { year: 2020, month: null, day: null } }),
       )
       const date = result.release_date as Date
-      expect(date.getFullYear()).toBe(2020)
-      expect(date.getMonth()).toBe(0)
-      expect(date.getDate()).toBe(1)
+      expect(date.getUTCFullYear()).toBe(2020)
+      expect(date.getUTCMonth()).toBe(0)
+      expect(date.getUTCDate()).toBe(1)
       expect(Number.isNaN(date.getTime())).toBe(false)
     })
 

--- a/lib/normalise/anime.ts
+++ b/lib/normalise/anime.ts
@@ -3,7 +3,6 @@ import {
   AnilistMediaSchema,
   partialDateToDate,
   type AnilistMedia,
-  type AnilistStaffEdge,
 } from '@/lib/api/anilist'
 import { RELEASE_DATE_SENTINEL } from '@/lib/normalise/release-date'
 
@@ -91,9 +90,3 @@ export function normaliseAnilistAnime(
     anilist_id: source.id,
   }
 }
-
-// Exported for parity with normaliseAnilistManga and for unit-test ergonomics;
-// route handlers should depend on the exported normalisers rather than the
-// helper directly.
-export { preferredTitle as _animeTitlePreferred }
-export type { AnilistStaffEdge }

--- a/lib/search/__tests__/federation.test.ts
+++ b/lib/search/__tests__/federation.test.ts
@@ -356,4 +356,37 @@ describe('lib/search/federation: anilistAdapter (Story 8.3)', () => {
 
     expect(results[0]?.release_year).toBeUndefined()
   })
+
+  it('ECH-8-3-1: type=undefined uses Promise.allSettled internally; preserves the fulfilled half when one of anime/manga rejects', async () => {
+    // Pre-fix: Promise.all short-circuits on the first rejection, throwing
+    // away the entire successful half. The route`s outer Promise.allSettled
+    // then sees the adapter as fully failed.
+    anilistMock.searchAnime.mockRejectedValue(
+      new Error('AniList rate limited (429)'),
+    )
+    anilistMock.searchManga.mockResolvedValue([
+      anilistMedia(30002, 'MANGA', { title: 'Berserk' }),
+    ])
+    const { ADAPTERS } = await import('@/lib/search/federation')
+    const anilist = ADAPTERS.find((a) => a.source === 'anilist')!
+
+    const results = await anilist.search('mixed', undefined)
+
+    // Manga survives; anime`s rejection is swallowed (logged via partial-failure).
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject({
+      type: 'manga',
+      anilist_id: 30002,
+      primary_source: 'anilist',
+    })
+  })
+
+  it('ECH-8-3-1: throws only when BOTH inner calls reject', async () => {
+    anilistMock.searchAnime.mockRejectedValue(new Error('boom anime'))
+    anilistMock.searchManga.mockRejectedValue(new Error('boom manga'))
+    const { ADAPTERS } = await import('@/lib/search/federation')
+    const anilist = ADAPTERS.find((a) => a.source === 'anilist')!
+
+    await expect(anilist.search('both', undefined)).rejects.toThrow(/boom/)
+  })
 })

--- a/lib/search/federation.ts
+++ b/lib/search/federation.ts
@@ -4,6 +4,7 @@ import {
   searchManga,
   type AnilistMedia,
 } from '@/lib/api/anilist'
+import { logger } from '@/lib/logger'
 
 export type SearchType = 'movie' | 'tv' | 'anime' | 'manga' | 'game'
 
@@ -130,14 +131,54 @@ const anilistAdapter: AdapterCapability = {
       const manga = await searchManga(query)
       return manga.map((m) => adaptAnilistResult(m, 'manga'))
     }
-    const [anime, manga] = await Promise.all([
+    // Promise.allSettled (not Promise.all): if anime succeeds with 25 results
+    // but manga rejects (or vice versa), we must surface the half that
+    // succeeded rather than discarding both. Pre-fix code used Promise.all
+    // which short-circuited on the first rejection - the outer route's
+    // Promise.allSettled then marked the entire anilist adapter as failed,
+    // silently throwing away valid manga rows when anime's 429'd. ECH-8-3-1.
+    // If BOTH inner calls reject we still throw, so the outer route can flag
+    // partialFailure correctly.
+    const [animeResult, mangaResult] = await Promise.allSettled([
       searchAnime(query),
       searchManga(query),
     ])
-    return [
-      ...anime.map((m) => adaptAnilistResult(m, 'anime')),
-      ...manga.map((m) => adaptAnilistResult(m, 'manga')),
-    ]
+    if (
+      animeResult.status === 'rejected' &&
+      mangaResult.status === 'rejected'
+    ) {
+      // Re-throw anime's rejection (the first-listed); the route's outer
+      // Promise.allSettled will record the adapter as failed and set
+      // partialFailure: true. The specific error identity is preserved so a
+      // 429 surfaces as a 429 in the warn log.
+      throw animeResult.reason
+    }
+    const merged: UnifiedSearchResult[] = []
+    if (animeResult.status === 'fulfilled') {
+      merged.push(
+        ...animeResult.value.map((m) => adaptAnilistResult(m, 'anime')),
+      )
+    } else {
+      // Log the half-failure so partial AniList degradation is observable
+      // even though the outer route's partialFailure stays false (the adapter
+      // returned results overall). A per-source partialFailure surface in the
+      // response contract is tracked in deferred-work.md (ECH-8-3-10).
+      logger.warn(
+        { event: 'anilist.partial_failure', branch: 'anime', err: animeResult.reason },
+        'AniList anime search rejected while manga succeeded',
+      )
+    }
+    if (mangaResult.status === 'fulfilled') {
+      merged.push(
+        ...mangaResult.value.map((m) => adaptAnilistResult(m, 'manga')),
+      )
+    } else {
+      logger.warn(
+        { event: 'anilist.partial_failure', branch: 'manga', err: mangaResult.reason },
+        'AniList manga search rejected while anime succeeded',
+      )
+    }
+    return merged
   },
 }
 


### PR DESCRIPTION
## Summary

Closes #138. Applies the 7 patch-as-followup items surfaced by the BMAD code-review retroactive sweep of merged Epic 8 stories (8.1 / 8.2 / 8.3). Lower-priority defers landed in `_bmad-output/implementation-artifacts/deferred-work.md`.

## Fixes (with per-HIGH regression tests in the same commit)

### HIGH

1. **`withLimit` cross-contamination** in `lib/api/anilist.ts`. Wrap inflight entries with `.catch(() => undefined)` release tokens so `Promise.race(inflight)` from a future caller settles WITHOUT re-throwing a rejection that belongs to a different caller. Pre-fix, when calls A + B were in flight and A 429''d, caller C awaiting `Promise.race` would re-throw A''s 429 BEFORE running its own fetch. New test exercises 3 concurrent callers with deferred fetch mocks and proves C is no longer contaminated. (ECH-8-1-1)

2. **`partialDateToDate` TZ drift** in `lib/api/anilist.ts`. Replace `new Date(year, m-1, d)` (local TZ) with `new Date(Date.UTC(year, m-1, d))` (UTC anchor). Pre-fix, in any TZ east of UTC, a 2023-09-29 startDate persisted as 2023-09-28T...:00Z, drifting timeline-sort up to 1 day vs the UTC-anchored TMDB normaliser. TZ-pinned test (`process.env.TZ = ''Asia/Tokyo''`) asserts the UTC contract. Existing anime/manga normaliser tests switched from `getMonth/getDate` to `getUTCMonth/getUTCDate` for TZ-independence. (ECH-8-2-1)

3. **`anilistAdapter.search(undefined)` data loss** in `lib/search/federation.ts`. Replace internal `Promise.all` with `Promise.allSettled`, surface fulfilled buckets, throw only if BOTH inner calls reject. Pre-fix, a 429 on anime would discard 25 successful manga results. New federation test asserts partial-success preservation + the "both reject → adapter throws" path. The route-level test for `partialFailure: true` updated to require BOTH branches to reject (the new contract); a companion test documents the new single-branch-survives semantics. A `anilist.partial_failure` warn log is emitted when one branch fails so half-degradation is observable. (ECH-8-3-1)

4. **MANGA filter chip missing** in `components/molecules/FilterChips/FilterChips.tsx` + `components/organisms/GlobalSearch/GlobalSearch.tsx`. Story 8.3 extended every type map except `FilterId` and `TYPE_TO_API` — TypeScript missed it because `manga` was never in `FilterId`. Add `MANGA` chip (unmuted, alongside `ANIME` which is now also unmuted since federated search dispatches AniList for both). FilterChips tests extended. (ECH-8-3-2)

### MED

5. **`findCrossSourceCandidates` lacks type WHERE filter** in `app/api/media/route.ts`. Push `type` into the Prisma `where` clause so the 50-row take cap is spent on eligible candidates only. On saturated years (1989: hundreds of TV_EPISODE rows + a few manga), the cap could fill with TV_EPISODE rows and silently miss the real cross-merge target. The JS-side `c.type === type` filter (ECH-T7 fix in PR #136) remains as defence in depth. (ECH-8-3-6)

### LOW

6. **Wrong-type `getMedia` returns 502 instead of 404** in `lib/api/anilist.ts`. AniList responds `Media: null` for unresolved id-type tuples (e.g. `getMedia(<manga-id>, ''ANIME'')`). Pre-fix, Zod rejected null (non-nullable schema) → `AnilistApiError` → 502 `upstream_failed`. The upstream succeeded; the user''s type was wrong. Make `AnilistGetMediaSchema.Media` nullable, throw a new `AnilistNotFoundError`, route maps to 404 with a structured log. New unit test pins the contract. (ECH-8-3-8)

### Cleanup

7. **Em-dashes in `app/api/media/route.ts`** (4 sites: lines 288, 296, 365, 412) replaced with sentence-break punctuation. Workspace `CLAUDE.md` rule. **Dead exports** `_animeTitlePreferred` + `AnilistStaffEdge` re-export removed from `lib/normalise/anime.ts` (no callers per `grep`).

## Verification

```powershell
cd cuatro-tracker
corepack pnpm typecheck                                       # clean
corepack pnpm lint                                             # clean (zero warnings)
corepack pnpm vitest run lib/api lib/search lib/normalise components/molecules/FilterChips
                                                               # 144 / 144 in scope (incl. new tests)
corepack pnpm test                                             # 752 / 754 (the 2 BullMQ worker tests require Redis up; not regressed)
```

## LOC

+413 / -69 across 12 files (7 source, 5 test).

## Disposition trail

- Findings live in the Pass 2 review-findings section of `_bmad-output/implementation-artifacts/8-4-implement-anime-grid-manga-grid.md`.
- Defers logged at `_bmad-output/implementation-artifacts/deferred-work.md` under "Deferred from: code review of Epic 8 retroactive sweep (2026-05-19, Pass 2)".
- This PR is INDEPENDENT of the open Epic 8 sub-bundle (`epic-8-anilist-bundle-2`) which carries Story 8.4 and will carry Stories 8.5 + 8.6. Safe to merge either order, but landing this first lets the bundle inherit the hardening.

## Why one PR vs separate

Each fix is independent code-wise; bundling preserves the audit trail of "all Epic 8 retroactive review followups" cohesively. Easier to revert as a group if any unexpected regression surfaces in production.