### PR TITLE
fix(test): wrap login focus assertion in waitFor to deflake CI

### DIFF
--- a/app/(auth)/login/__tests__/page.test.tsx
+++ b/app/(auth)/login/__tests__/page.test.tsx
@@ -125,10 +125,18 @@ describe('LoginPage submit flow', () => {
     const email = screen.getByLabelText('EMAIL') as HTMLInputElement
     fireEvent.submit(email.closest('form')!)
 
+    // Focus management lives in LoginCRT's `useEffect` that runs when
+    // `error` is set AND `phase === 'idle'`. The path to `'idle'` after a
+    // failed submit goes through `'error-truncating'` -> BootSequence
+    // truncation -> `onBootTruncate` -> setError + setPhase('idle') ->
+    // effect fires -> passwordRef.current.focus(). Multiple state
+    // transitions, so both assertions must live inside waitFor; otherwise
+    // a slower CI runner can hit the focus assertion before the effect
+    // runs (caught by CI run 26116188775 on 2026-05-19).
     await waitFor(() => {
       expect(screen.getByText('> ACCESS DENIED')).toBeInTheDocument()
+      expect(document.activeElement).toBe(screen.getByLabelText('PASSWORD'))
     })
-    expect(document.activeElement).toBe(screen.getByLabelText('PASSWORD'))
   })
 
   it('on error: form values are retained (email defaultValue + typed password)', async () => {


### PR DESCRIPTION
## Summary

CI run [26116188775](https://github.com/LuigiEspinosa/cuatro-tracker/actions/runs/26116188775) on main failed in `app/(auth)/login/__tests__/page.test.tsx:131` immediately after PR #139 landed. The failure is unrelated to anything in #139''s diff — it''s a pre-existing test-robustness bug that finally tripped on a slower CI runner.

## Root cause

The test asserted `document.activeElement === password input` OUTSIDE the `waitFor` that guarded the error banner. The focus settle path is multi-step async:

```
submit → signIn rejects → phase=error-truncating →
LoginCRT BootSequence truncates → onBootTruncate →
setError + setPhase(idle) → useEffect runs → passwordRef.current.focus()
```

The `waitFor` only covered the banner; the bare `expect` at line 131 then raced the focus effect. On a slower runner the activeElement assertion fired before React ran the effect.

## Fix

One-line move: pull the focus assertion INSIDE the same `waitFor` so both conditions settle together. No production code touched.

## Verification

```powershell
cd cuatro-tracker
corepack pnpm vitest --run --testNamePattern "focus moves to the password"
# 2/2 pass (the modified test + the adjacent passing test)
```

## Why this is its own PR

Unrelated to Epic 8 stories. Lands directly on main as a `chore` so the next merged Epic 8 commit lands on green CI.