### PR TITLE
feat(anime,manga): grids + /anime/[id] detail page (#137, #141)

### DIFF
--- a/app/(media)/anime/[id]/AnimeDetailControls.tsx
+++ b/app/(media)/anime/[id]/AnimeDetailControls.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+import { EpisodeChecklist } from '@/components/molecules/EpisodeChecklist'
+
+export type AnimeDetailControlsProps = {
+  mediaItemId: string
+  episodeCount: number
+  progress: number
+}
+
+async function putProgress(body: {
+  mediaItemId: string
+  progress: number
+}): Promise<void> {
+  const res = await fetch('/api/progress', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    throw new Error(`anime_progress_failed:${res.status}`)
+  }
+}
+
+export function AnimeDetailControls({
+  mediaItemId,
+  episodeCount,
+  progress,
+}: AnimeDetailControlsProps) {
+  const router = useRouter()
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation<
+    void,
+    Error,
+    { mediaItemId: string; progress: number }
+  >({
+    mutationFn: putProgress,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['library', 'anime'] })
+      void queryClient.invalidateQueries({
+        queryKey: ['animeDetail', mediaItemId],
+      })
+      router.refresh()
+    },
+    onError: () => {
+      toast.error('COULD NOT UPDATE EPISODE')
+    },
+  })
+
+  function handleToggle(n: number, nextChecked: boolean) {
+    // AC-4: check from below advances to n; uncheck from at-or-above retreats
+    // to n - 1. The server's auto-advance branch then computes max() / status
+    // transitions per AC-5.
+    const nextProgress = nextChecked ? n : n - 1
+    mutation.mutate({ mediaItemId, progress: nextProgress })
+  }
+
+  return (
+    <EpisodeChecklist
+      mediaItemId={mediaItemId}
+      episodeCount={episodeCount}
+      progress={progress}
+      onToggleEpisode={handleToggle}
+    />
+  )
+}

--- a/app/(media)/anime/[id]/not-found.tsx
+++ b/app/(media)/anime/[id]/not-found.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function AnimeNotFound() {
+  return (
+    <main className='anime-not-found'>
+      <h1>&gt; ANIME NOT IN LIBRARY</h1>
+      <p>Try adding it from the search.</p>
+      <Link href='/anime' className='crt-pixel-button'>
+        &gt; BACK TO ANIME LIBRARY
+      </Link>
+    </main>
+  )
+}

--- a/app/(media)/anime/[id]/page.tsx
+++ b/app/(media)/anime/[id]/page.tsx
@@ -21,6 +21,7 @@ import { SectionBand } from '@/components/organisms/SectionBand/SectionBand'
 import { PhosphorBar } from '@/components/atoms/PhosphorBar'
 import { RelationsList } from '@/components/organisms/RelationsList'
 import { VoiceCastList } from '@/components/organisms/VoiceCastList'
+import { stripAnilistHtml } from '@/lib/normalise/anilist-html'
 import type { MetadataItem } from '@/components/molecules/MetadataRow'
 import { AnimeDetailControls } from './AnimeDetailControls'
 
@@ -39,11 +40,7 @@ function deriveYear(d: Date): number | null {
 // strip remaining tags so the synopsis renders as plain text. Applies at
 // render time so legacy MediaItem rows that were normalised before this fix
 // still display cleanly without a backfill.
-function stripAnilistHtml(text: string): string {
-  return text
-    .replace(/<br\s*\/?\s*>/gi, '\n\n')
-    .replace(/<[^>]*>/g, '')
-}
+
 
 export async function generateMetadata({
   params,

--- a/app/(media)/anime/[id]/page.tsx
+++ b/app/(media)/anime/[id]/page.tsx
@@ -1,0 +1,256 @@
+import { notFound } from 'next/navigation'
+import { MediaType } from '@prisma/client'
+import { db } from '@/lib/db'
+import { findUserEntryByMediaItemId } from '@/lib/db/library'
+import {
+  getMedia,
+  getMediaRelations,
+  AnilistApiError,
+  AnilistNotFoundError,
+  type AnilistMedia,
+  type AnilistCharacterEdge,
+} from '@/lib/api/anilist'
+import {
+  normaliseRelations,
+  type NormalisedRelationBuckets,
+} from '@/lib/normalise/anilist-relations'
+import { logger } from '@/lib/logger'
+import { BackToLibraryLink } from '@/components/molecules/BackToLibraryLink'
+import { DetailHero } from '@/components/organisms/DetailHero'
+import { SectionBand } from '@/components/organisms/SectionBand/SectionBand'
+import { PhosphorBar } from '@/components/atoms/PhosphorBar'
+import { RelationsList } from '@/components/organisms/RelationsList'
+import { VoiceCastList } from '@/components/organisms/VoiceCastList'
+import type { MetadataItem } from '@/components/molecules/MetadataRow'
+import { AnimeDetailControls } from './AnimeDetailControls'
+
+export const dynamic = 'force-dynamic'
+
+type PageParams = Promise<{ id: string }>
+
+function deriveYear(d: Date): number | null {
+  const y = d.getUTCFullYear()
+  return y === 1970 ? null : y
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: PageParams
+}): Promise<{ title: string }> {
+  const { id } = await params
+  const entry = await findUserEntryByMediaItemId(id)
+  if (!entry) return { title: 'NOT IN LIBRARY · Cuatro Tracker' }
+  return {
+    title: `${entry.media_item.title.toUpperCase()} · Cuatro Tracker`,
+  }
+}
+
+type RelationsResolution = {
+  buckets: NormalisedRelationBuckets
+  inLibraryByAnilistId: Map<number, string>
+}
+
+async function resolveRelations(
+  anilistId: number,
+): Promise<RelationsResolution> {
+  const empty: NormalisedRelationBuckets = {
+    sequel: [],
+    prequel: [],
+    sideStory: [],
+    parent: [],
+    adaptation: [],
+  }
+  let buckets: NormalisedRelationBuckets = empty
+  try {
+    const raw = await getMediaRelations(anilistId)
+    buckets = normaliseRelations(raw)
+  } catch (err) {
+    if (err instanceof AnilistApiError || err instanceof AnilistNotFoundError) {
+      logger.warn(
+        { event: 'anime_detail.relations_unavailable', anilistId, err },
+        'AniList relations fetch failed; relations band will be omitted',
+      )
+    } else {
+      throw err
+    }
+  }
+
+  const allRelationIds = [
+    ...buckets.sequel,
+    ...buckets.prequel,
+    ...buckets.sideStory,
+    ...buckets.parent,
+    ...buckets.adaptation,
+  ].map((r) => r.id)
+
+  const inLibraryByAnilistId = new Map<number, string>()
+  if (allRelationIds.length > 0) {
+    const rows = await db.mediaItem.findMany({
+      where: { anilist_id: { in: allRelationIds } },
+      select: { id: true, anilist_id: true },
+    })
+    for (const r of rows) {
+      if (r.anilist_id !== null) inLibraryByAnilistId.set(r.anilist_id, r.id)
+    }
+  }
+
+  return { buckets, inLibraryByAnilistId }
+}
+
+async function resolveAnilistMedia(
+  anilistId: number,
+): Promise<AnilistMedia | null> {
+  try {
+    return await getMedia(anilistId, 'ANIME')
+  } catch (err) {
+    if (err instanceof AnilistApiError || err instanceof AnilistNotFoundError) {
+      logger.warn(
+        { event: 'anime_detail.media_unavailable', anilistId, err },
+        'AniList getMedia failed; voice cast band will be omitted',
+      )
+      return null
+    }
+    throw err
+  }
+}
+
+export default async function AnimeDetailPage({
+  params,
+}: {
+  params: PageParams
+}) {
+  const { id } = await params
+  if (!id) notFound()
+
+  const entry = await findUserEntryByMediaItemId(id)
+  if (!entry || entry.media_item.type !== MediaType.ANIME) notFound()
+  if (entry.media_item.anilist_id === null) {
+    logger.warn(
+      { event: 'anime_detail.missing_anilist_id', mediaItemId: id },
+      'ANIME row has no anilist_id; rendering 404',
+    )
+    notFound()
+  }
+
+  const anilistId = entry.media_item.anilist_id
+
+  const [media, relations] = await Promise.all([
+    resolveAnilistMedia(anilistId),
+    resolveRelations(anilistId),
+  ])
+
+  const year = deriveYear(entry.media_item.release_date)
+  const metadata: MetadataItem[] = []
+  if (media?.format) {
+    metadata.push({ value: media.format.replaceAll('_', ' ') })
+  }
+  if (year !== null) metadata.push({ value: String(year) })
+  if (entry.media_item.studio_name) {
+    metadata.push({ value: entry.media_item.studio_name })
+  }
+  if (entry.media_item.episode_count !== null) {
+    metadata.push({ value: `${entry.media_item.episode_count} EP` })
+  }
+  if (entry.media_item.lifecycle_status) {
+    metadata.push({
+      value: entry.media_item.lifecycle_status
+        .replaceAll('_', ' ')
+        .toUpperCase(),
+      dim: true,
+    })
+  }
+
+  const synopsisParagraphs = (entry.media_item.overview ?? '')
+    .split(/\n+/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+
+  // AniList poster paths are stored as full URLs (per the AniList normaliser).
+  // No getImageUrl() construction step like TMDB.
+  const posterUrl = entry.media_item.poster_path
+
+  const characters: AnilistCharacterEdge[] = media?.characters?.edges ?? []
+  const hasRelations =
+    relations.buckets.sequel.length > 0 ||
+    relations.buckets.prequel.length > 0 ||
+    relations.buckets.sideStory.length > 0 ||
+    relations.buckets.parent.length > 0 ||
+    relations.buckets.adaptation.length > 0
+
+  return (
+    <main className='anime-detail-page'>
+      <BackToLibraryLink medium='anime' />
+      <DetailHero
+        mediaItemId={entry.media_item_id}
+        medium='anime'
+        mediumLabel='ANIME'
+        title={entry.media_item.title}
+        originalTitle={entry.media_item.original_title}
+        posterUrl={posterUrl}
+        metadata={metadata}
+        currentStatus={entry.status}
+        imdbId={null}
+        showQbtButton={false}
+      />
+      <div className='anime-detail-rule' aria-hidden='true' />
+      {synopsisParagraphs.length > 0 ? (
+        <article className='anime-detail-synopsis'>
+          {synopsisParagraphs.map((para, idx) => (
+            <p key={idx}>{para}</p>
+          ))}
+        </article>
+      ) : null}
+      <div
+        className='anime-detail-rule anime-detail-rule-thick'
+        aria-hidden='true'
+      />
+      {entry.media_item.episode_count !== null ? (
+        <section className='anime-detail-progress' aria-label='Show progress'>
+          <p className='anime-detail-progress-label'>
+            {entry.progress} / {entry.media_item.episode_count} EPISODES WATCHED
+          </p>
+          <PhosphorBar
+            value={entry.progress}
+            max={
+              entry.media_item.episode_count > 0
+                ? entry.media_item.episode_count
+                : 1
+            }
+            label='Show progress'
+          />
+        </section>
+      ) : null}
+      <SectionBand
+        title='Episodes'
+        count={entry.media_item.episode_count ?? null}
+      >
+        <AnimeDetailControls
+          mediaItemId={entry.media_item_id}
+          episodeCount={entry.media_item.episode_count ?? 0}
+          progress={entry.progress}
+        />
+      </SectionBand>
+      {entry.media_item.studio_name ? (
+        <SectionBand title='Studios'>
+          <span className='anime-detail-studio-chip'>
+            {entry.media_item.studio_name}
+          </span>
+        </SectionBand>
+      ) : null}
+      {characters.length > 0 ? (
+        <SectionBand title='Voice Cast' count={characters.length}>
+          <VoiceCastList characters={characters} />
+        </SectionBand>
+      ) : null}
+      {hasRelations ? (
+        <SectionBand title='Relations'>
+          <RelationsList
+            buckets={relations.buckets}
+            inLibraryByAnilistId={relations.inLibraryByAnilistId}
+          />
+        </SectionBand>
+      ) : null}
+    </main>
+  )
+}

--- a/app/(media)/anime/[id]/page.tsx
+++ b/app/(media)/anime/[id]/page.tsx
@@ -33,6 +33,18 @@ function deriveYear(d: Date): number | null {
   return y === 1970 ? null : y
 }
 
+// AniList descriptions ship raw HTML (`<br>`, `<i>`, `<a>`, ...) even when the
+// query asks for `asHtml: false` — the field's "no HTML" flag normalises line
+// breaks but leaves tags. Convert `<br>` variants to paragraph breaks then
+// strip remaining tags so the synopsis renders as plain text. Applies at
+// render time so legacy MediaItem rows that were normalised before this fix
+// still display cleanly without a backfill.
+function stripAnilistHtml(text: string): string {
+  return text
+    .replace(/<br\s*\/?\s*>/gi, '\n\n')
+    .replace(/<[^>]*>/g, '')
+}
+
 export async function generateMetadata({
   params,
 }: {
@@ -161,7 +173,7 @@ export default async function AnimeDetailPage({
     })
   }
 
-  const synopsisParagraphs = (entry.media_item.overview ?? '')
+  const synopsisParagraphs = stripAnilistHtml(entry.media_item.overview ?? '')
     .split(/\n+/)
     .map((p) => p.trim())
     .filter((p) => p.length > 0)

--- a/app/(media)/anime/page.tsx
+++ b/app/(media)/anime/page.tsx
@@ -1,0 +1,123 @@
+import { MediaType, WatchStatus } from '@prisma/client'
+import { findLibraryItems, type LibrarySortKey } from '@/lib/db/library'
+import { LibraryGrid } from '@/components/organisms/LibraryGrid'
+import type { LibraryItem } from '@/lib/types/library'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata = {
+  title: 'ANIME · Cuatro Tracker',
+}
+
+const VALID_SORTS: ReadonlyArray<LibrarySortKey> = [
+  'recently_added',
+  'recently_created',
+  'release_date_desc',
+  'title_asc',
+  'status_asc',
+  'rating_desc',
+]
+
+type SearchParams = Promise<{
+  sort?: string
+  status?: string
+  search?: string
+}>
+
+function parseSort(raw: string | undefined): LibrarySortKey {
+  if (raw && (VALID_SORTS as readonly string[]).includes(raw)) {
+    return raw as LibrarySortKey
+  }
+  return 'recently_added'
+}
+
+function parseStatus(raw: string | undefined): WatchStatus | null {
+  if (!raw) return null
+  if ((Object.values(WatchStatus) as string[]).includes(raw)) {
+    return raw as WatchStatus
+  }
+  return null
+}
+
+function deriveYear(releaseDate: Date): number | null {
+  const year = releaseDate.getUTCFullYear()
+  return year === 1970 ? null : year
+}
+
+export default async function AnimePage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const params = await searchParams
+  const sort = parseSort(params.sort)
+  const status = parseStatus(params.status)
+  // Cap at 100 chars to match the LibraryQuerySchema upper bound, otherwise
+  // the client-side TanStack Query refetch would reject with 400 and flash
+  // the error state immediately after the SSR-rendered grid hydrates.
+  const search = (params.search?.trim() ?? '').slice(0, 100)
+
+  const entries = await findLibraryItems({
+    mediaType: MediaType.ANIME,
+    status: status ?? undefined,
+    search: search.length > 0 ? search : undefined,
+    sort,
+    limit: 200,
+  })
+
+  const initialItems: LibraryItem[] = entries.map((entry) => ({
+    id: entry.id,
+    mediaItemId: entry.media_item_id,
+    mediaType: entry.media_item.type,
+    status: entry.status,
+    title: entry.media_item.title,
+    posterPath: entry.media_item.poster_path,
+    year: deriveYear(entry.media_item.release_date),
+    releaseDate:
+      entry.media_item.release_date.getUTCFullYear() === 1970
+        ? null
+        : entry.media_item.release_date.toISOString(),
+    // Story 8.4 ships the minimum grid: per-episode anime progress lands in
+    // Story 8.5 (EpisodeChecklist + UserEntry.progress visualisation). For
+    // now no progress is surfaced on the grid card.
+    progressLabel: null,
+    progressPct: null,
+    sourceLabel: null,
+    tmdbId: entry.media_item.tmdb_id,
+    anilistId: entry.media_item.anilist_id,
+    igdbId: entry.media_item.igdb_id,
+    steamId: entry.media_item.steam_id,
+    createdAt: entry.created_at.toISOString(),
+    updatedAt: entry.updated_at.toISOString(),
+  }))
+
+  return (
+    <main className='movies-page'>
+      <header className='movies-page-heading'>
+        <h1 className='movies-page-title'>
+          <span className='movies-page-blocks'>
+            <span className='movies-page-block b1'>▓</span>
+            <span className='movies-page-block b2'>▓</span>
+            <span className='movies-page-block b3'>▓</span>
+          </span>
+          <span className='movies-page-noun'>ANIME</span>
+          <span className='movies-page-blocks'>
+            <span className='movies-page-block b4'>▓</span>
+            <span className='movies-page-block b5'>▓</span>
+            <span className='movies-page-block b6'>▓</span>
+          </span>
+        </h1>
+        <p className='movies-page-subtitle'>
+          {initialItems.length} ITEMS
+        </p>
+      </header>
+      <LibraryGrid
+        mediaType='anime'
+        initialItems={initialItems}
+        initialSort={sort}
+        initialStatus={status}
+        initialSearch={search}
+      />
+    </main>
+  )
+}

--- a/app/(media)/manga/page.tsx
+++ b/app/(media)/manga/page.tsx
@@ -1,0 +1,122 @@
+import { MediaType, WatchStatus } from '@prisma/client'
+import { findLibraryItems, type LibrarySortKey } from '@/lib/db/library'
+import { LibraryGrid } from '@/components/organisms/LibraryGrid'
+import type { LibraryItem } from '@/lib/types/library'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata = {
+  title: 'MANGA · Cuatro Tracker',
+}
+
+const VALID_SORTS: ReadonlyArray<LibrarySortKey> = [
+  'recently_added',
+  'recently_created',
+  'release_date_desc',
+  'title_asc',
+  'status_asc',
+  'rating_desc',
+]
+
+type SearchParams = Promise<{
+  sort?: string
+  status?: string
+  search?: string
+}>
+
+function parseSort(raw: string | undefined): LibrarySortKey {
+  if (raw && (VALID_SORTS as readonly string[]).includes(raw)) {
+    return raw as LibrarySortKey
+  }
+  return 'recently_added'
+}
+
+function parseStatus(raw: string | undefined): WatchStatus | null {
+  if (!raw) return null
+  if ((Object.values(WatchStatus) as string[]).includes(raw)) {
+    return raw as WatchStatus
+  }
+  return null
+}
+
+function deriveYear(releaseDate: Date): number | null {
+  const year = releaseDate.getUTCFullYear()
+  return year === 1970 ? null : year
+}
+
+export default async function MangaPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const params = await searchParams
+  const sort = parseSort(params.sort)
+  const status = parseStatus(params.status)
+  // Cap at 100 chars to match the LibraryQuerySchema upper bound (see
+  // /movies and /anime pages for the same rationale).
+  const search = (params.search?.trim() ?? '').slice(0, 100)
+
+  const entries = await findLibraryItems({
+    mediaType: MediaType.MANGA,
+    status: status ?? undefined,
+    search: search.length > 0 ? search : undefined,
+    sort,
+    limit: 200,
+  })
+
+  const initialItems: LibraryItem[] = entries.map((entry) => ({
+    id: entry.id,
+    mediaItemId: entry.media_item_id,
+    mediaType: entry.media_item.type,
+    status: entry.status,
+    title: entry.media_item.title,
+    posterPath: entry.media_item.poster_path,
+    year: deriveYear(entry.media_item.release_date),
+    releaseDate:
+      entry.media_item.release_date.getUTCFullYear() === 1970
+        ? null
+        : entry.media_item.release_date.toISOString(),
+    // Story 8.4 ships the minimum grid: chapter / volume progress
+    // visualisation lands in Story 8.6 (ChapterVolumeTracker molecule +
+    // UserEntry.volume_progress migration).
+    progressLabel: null,
+    progressPct: null,
+    sourceLabel: null,
+    tmdbId: entry.media_item.tmdb_id,
+    anilistId: entry.media_item.anilist_id,
+    igdbId: entry.media_item.igdb_id,
+    steamId: entry.media_item.steam_id,
+    createdAt: entry.created_at.toISOString(),
+    updatedAt: entry.updated_at.toISOString(),
+  }))
+
+  return (
+    <main className='movies-page'>
+      <header className='movies-page-heading'>
+        <h1 className='movies-page-title'>
+          <span className='movies-page-blocks'>
+            <span className='movies-page-block b1'>▓</span>
+            <span className='movies-page-block b2'>▓</span>
+            <span className='movies-page-block b3'>▓</span>
+          </span>
+          <span className='movies-page-noun'>MANGA</span>
+          <span className='movies-page-blocks'>
+            <span className='movies-page-block b4'>▓</span>
+            <span className='movies-page-block b5'>▓</span>
+            <span className='movies-page-block b6'>▓</span>
+          </span>
+        </h1>
+        <p className='movies-page-subtitle'>
+          {initialItems.length} ITEMS
+        </p>
+      </header>
+      <LibraryGrid
+        mediaType='manga'
+        initialItems={initialItems}
+        initialSort={sort}
+        initialStatus={status}
+        initialSearch={search}
+      />
+    </main>
+  )
+}

--- a/app/api/library/__tests__/route.test.ts
+++ b/app/api/library/__tests__/route.test.ts
@@ -383,4 +383,113 @@ describe('GET /api/library', () => {
       expect(res.status).toBe(400)
     })
   })
+
+  describe('Epic 8 mediaType routing (Story 8.4)', () => {
+    it('forwards type=ANIME to findLibraryItems with MediaType.ANIME', async () => {
+      dbMock.userEntry.findMany.mockResolvedValue([])
+      const { GET } = await import('@/app/api/library/route')
+
+      const res = await GET(makeRequest('/api/library?type=ANIME'))
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body).toEqual({ items: [] })
+      const call = dbMock.userEntry.findMany.mock.calls[0]?.[0]
+      expect(call.where.media_item.type).toBe(MediaType.ANIME)
+    })
+
+    it('forwards type=MANGA to findLibraryItems with MediaType.MANGA', async () => {
+      dbMock.userEntry.findMany.mockResolvedValue([])
+      const { GET } = await import('@/app/api/library/route')
+
+      const res = await GET(makeRequest('/api/library?type=MANGA'))
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body).toEqual({ items: [] })
+      const call = dbMock.userEntry.findMany.mock.calls[0]?.[0]
+      expect(call.where.media_item.type).toBe(MediaType.MANGA)
+    })
+
+    it('serializes an ANIME LibraryItem with anilist_id and a full-URL poster_path (AniList CDN)', async () => {
+      const anilistEntry = fixtureEntry({
+        id: 'anime-entry-1',
+        media_item_id: 'anime-media-1',
+        media_item: {
+          ...fixtureEntry().media_item,
+          id: 'anime-media-1',
+          type: MediaType.ANIME,
+          title: 'Sousou no Frieren',
+          release_date: new Date('2023-09-29T00:00:00Z'),
+          poster_path:
+            'https://s4.anilist.co/file/anilistcdn/media/anime/cover/large/bx170942-x.jpg',
+          tmdb_id: null,
+          anilist_id: 170942,
+          lifecycle_status: null,
+        },
+      })
+      dbMock.userEntry.findMany.mockResolvedValue([anilistEntry])
+      const { GET } = await import('@/app/api/library/route')
+
+      const res = await GET(makeRequest('/api/library?type=ANIME'))
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.items).toHaveLength(1)
+      expect(body.items[0]).toMatchObject({
+        mediaType: MediaType.ANIME,
+        title: 'Sousou no Frieren',
+        anilistId: 170942,
+        tmdbId: null,
+        igdbId: null,
+        steamId: null,
+        sourceLabel: 'From AniList',
+        progressLabel: null,
+        progressPct: null,
+        posterPath:
+          'https://s4.anilist.co/file/anilistcdn/media/anime/cover/large/bx170942-x.jpg',
+        year: 2023,
+      })
+    })
+
+    it('serializes a MANGA LibraryItem with anilist_id and AniList CDN poster_path', async () => {
+      const mangaEntry = fixtureEntry({
+        id: 'manga-entry-1',
+        media_item_id: 'manga-media-1',
+        status: WatchStatus.PLAN_TO_WATCH,
+        media_item: {
+          ...fixtureEntry().media_item,
+          id: 'manga-media-1',
+          type: MediaType.MANGA,
+          title: 'Berserk',
+          release_date: new Date('1989-08-25T00:00:00Z'),
+          poster_path:
+            'https://s4.anilist.co/file/anilistcdn/media/manga/cover/large/bx30002-x.jpg',
+          tmdb_id: null,
+          anilist_id: 30002,
+          lifecycle_status: null,
+        },
+      })
+      dbMock.userEntry.findMany.mockResolvedValue([mangaEntry])
+      const { GET } = await import('@/app/api/library/route')
+
+      const res = await GET(makeRequest('/api/library?type=MANGA'))
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.items).toHaveLength(1)
+      expect(body.items[0]).toMatchObject({
+        mediaType: MediaType.MANGA,
+        title: 'Berserk',
+        anilistId: 30002,
+        tmdbId: null,
+        igdbId: null,
+        steamId: null,
+        sourceLabel: 'From AniList',
+        progressLabel: null,
+        progressPct: null,
+        year: 1989,
+      })
+    })
+  })
 })

--- a/app/api/progress/__tests__/route.test.ts
+++ b/app/api/progress/__tests__/route.test.ts
@@ -332,3 +332,199 @@ describe('PUT /api/progress', () => {
     expect(res.status).toBe(405)
   })
 })
+
+// Story 8.5 AC-5 + AC-9: PUT /api/progress anime auto-advance branch.
+describe('PUT /api/progress (Story 8.5 anime auto-advance)', () => {
+  const animeEntry = (overrides: Record<string, unknown> = {}) => ({
+    id: 'entry-anime-1',
+    media_item_id: 'anime-1',
+    status: WatchStatus.PLAN_TO_WATCH,
+    user_rating: null,
+    progress: 0,
+    notes: null,
+    started_at: null,
+    completed_at: null,
+    created_at: new Date('2026-05-10T12:00:00Z'),
+    updated_at: new Date('2026-05-12T12:00:00Z'),
+    media_item: {
+      id: 'anime-1',
+      type: MediaType.ANIME,
+      title: 'Sousou no Frieren',
+      anilist_id: 170942,
+      episode_count: 28,
+    },
+    ...overrides,
+  })
+
+  it('advances PLAN_TO_WATCH to WATCHING on first non-zero progress', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(animeEntry())
+    dbMock.userEntry.update.mockResolvedValue(
+      animeEntry({ progress: 1, status: WatchStatus.WATCHING }),
+    )
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(putRequest({ mediaItemId: 'anime-1', progress: 1 }))
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.progress).toBe(1)
+    expect(call.data.status).toBe(WatchStatus.WATCHING)
+    expect(call.data.completed_at).toBeUndefined()
+  })
+
+  it('auto-completes when progress reaches episode_count and sets completed_at', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(
+      animeEntry({ progress: 27, status: WatchStatus.WATCHING }),
+    )
+    const fakeNow = new Date('2026-05-19T16:00:00.000Z')
+    vi.setSystemTime(fakeNow)
+    dbMock.userEntry.update.mockResolvedValue(
+      animeEntry({
+        progress: 28,
+        status: WatchStatus.COMPLETED,
+        completed_at: fakeNow,
+      }),
+    )
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(putRequest({ mediaItemId: 'anime-1', progress: 28 }))
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.progress).toBe(28)
+    expect(call.data.status).toBe(WatchStatus.COMPLETED)
+    expect(call.data.completed_at).toBeInstanceOf(Date)
+    expect((call.data.completed_at as Date).toISOString()).toBe(
+      fakeNow.toISOString(),
+    )
+    vi.useRealTimers()
+  })
+
+  it('does NOT overwrite an existing completed_at when progress stays at episode_count (idempotent)', async () => {
+    const previousCompletedAt = new Date('2026-05-17T10:00:00.000Z')
+    dbMock.userEntry.findUnique.mockResolvedValue(
+      animeEntry({
+        progress: 28,
+        status: WatchStatus.COMPLETED,
+        completed_at: previousCompletedAt,
+      }),
+    )
+    dbMock.userEntry.update.mockResolvedValue(animeEntry({ progress: 28 }))
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(putRequest({ mediaItemId: 'anime-1', progress: 28 }))
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.progress).toBe(28)
+    expect(call.data.status).toBe(WatchStatus.COMPLETED)
+    // completed_at is NOT written when an existing one is present.
+    expect(call.data.completed_at).toBeUndefined()
+  })
+
+  it('retreats on a smaller-progress decrement and preserves status when not at boundary', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(
+      animeEntry({ progress: 5, status: WatchStatus.WATCHING }),
+    )
+    dbMock.userEntry.update.mockResolvedValue(animeEntry({ progress: 3 }))
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(putRequest({ mediaItemId: 'anime-1', progress: 3 }))
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.progress).toBe(3)
+    // No status flip: not PLAN_TO_WATCH and not >= episode_count.
+    expect(call.data.status).toBeUndefined()
+  })
+
+  it('no-op on same progress: writes progress but no status flip when already WATCHING mid-show', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(
+      animeEntry({ progress: 5, status: WatchStatus.WATCHING }),
+    )
+    dbMock.userEntry.update.mockResolvedValue(animeEntry({ progress: 5 }))
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(putRequest({ mediaItemId: 'anime-1', progress: 5 }))
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.progress).toBe(5)
+    expect(call.data.status).toBeUndefined()
+  })
+
+  it('does NOT auto-complete when episode_count is null (anime with unknown total)', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(
+      animeEntry({
+        progress: 99,
+        status: WatchStatus.WATCHING,
+        media_item: {
+          id: 'anime-1',
+          type: MediaType.ANIME,
+          title: 'Long Running',
+          anilist_id: 1234,
+          episode_count: null,
+        },
+      }),
+    )
+    dbMock.userEntry.update.mockResolvedValue(animeEntry({ progress: 100 }))
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(putRequest({ mediaItemId: 'anime-1', progress: 100 }))
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.progress).toBe(100)
+    expect(call.data.status).toBeUndefined()
+    expect(call.data.completed_at).toBeUndefined()
+  })
+
+  it('does NOT auto-advance for MOVIE entries (gate preserves non-anime behaviour)', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(fixtureEntry())
+    dbMock.userEntry.update.mockResolvedValue(fixtureEntry({ progress: 1 }))
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(putRequest({ mediaItemId: 'media-1', progress: 1 }))
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.progress).toBe(1)
+    // Movie path must NOT flip status from PLAN_TO_WATCH on progress write.
+    expect(call.data.status).toBeUndefined()
+  })
+
+  it('does NOT auto-advance for TV_SHOW entries (gate preserves TV behaviour)', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(
+      fixtureEntry({
+        media_item: {
+          id: 'show-1',
+          type: MediaType.TV_SHOW,
+          title: 'Some Show',
+          tmdb_id: 999,
+          episode_count: 24,
+        },
+      }),
+    )
+    dbMock.userEntry.update.mockResolvedValue(fixtureEntry({ progress: 24 }))
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(putRequest({ mediaItemId: 'show-1', progress: 24 }))
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.progress).toBe(24)
+    // TV_SHOW must NOT auto-advance to COMPLETED via the anime branch.
+    expect(call.data.status).toBeUndefined()
+  })
+
+  it('respects an explicit body.status alongside auto-advance computation', async () => {
+    // The auto-advance branch can override status (last writer wins on `data`).
+    // If body.status is provided AND progress triggers auto-complete, the
+    // anime branch's COMPLETED takes precedence — matches AC-5's "computed
+    // status in a single update".
+    dbMock.userEntry.findUnique.mockResolvedValue(
+      animeEntry({ progress: 27, status: WatchStatus.WATCHING }),
+    )
+    const fakeNow = new Date('2026-05-19T17:00:00.000Z')
+    vi.setSystemTime(fakeNow)
+    dbMock.userEntry.update.mockResolvedValue(
+      animeEntry({ progress: 28, status: WatchStatus.COMPLETED }),
+    )
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(
+      putRequest({
+        mediaItemId: 'anime-1',
+        progress: 28,
+        status: WatchStatus.WATCHING, // client tries to keep WATCHING; server overrides.
+      }),
+    )
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.status).toBe(WatchStatus.COMPLETED)
+    vi.useRealTimers()
+  })
+})

--- a/app/api/progress/__tests__/route.test.ts
+++ b/app/api/progress/__tests__/route.test.ts
@@ -430,6 +430,21 @@ describe('PUT /api/progress (Story 8.5 anime auto-advance)', () => {
     expect(call.data.status).toBeUndefined()
   })
 
+  it('decrement to 0 preserves WATCHING status (no revert to PLAN_TO_WATCH)', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(
+      animeEntry({ progress: 1, status: WatchStatus.WATCHING }),
+    )
+    dbMock.userEntry.update.mockResolvedValue(
+      animeEntry({ progress: 0, status: WatchStatus.WATCHING }),
+    )
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(putRequest({ mediaItemId: 'anime-1', progress: 0 }))
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.progress).toBe(0)
+    expect(call.data.status).toBeUndefined()
+  })
+
   it('no-op on same progress: writes progress but no status flip when already WATCHING mid-show', async () => {
     dbMock.userEntry.findUnique.mockResolvedValue(
       animeEntry({ progress: 5, status: WatchStatus.WATCHING }),

--- a/app/api/progress/route.ts
+++ b/app/api/progress/route.ts
@@ -155,9 +155,9 @@ async function handler(req: NextRequest): Promise<NextResponse> {
     progress !== undefined
   ) {
     const existingProgress = entry.progress
-    // Client signals direction via the sent value: progress >= existing is
-    // increment (with max() guarding against stale races); progress < existing
-    // is a decrement and we trust the client. AC-5.1.
+    // Client signals direction via the sent value: progress >= existing is an
+    // increment (max() coalesces to the larger value); progress < existing is a
+    // decrement and we trust the client. AC-5.1.
     const effectiveProgress =
       progress >= existingProgress
         ? Math.max(existingProgress, progress)

--- a/app/api/progress/route.ts
+++ b/app/api/progress/route.ts
@@ -146,6 +146,45 @@ async function handler(req: NextRequest): Promise<NextResponse> {
     return jsonResponse(body, 201)
   }
 
+  // Story 8.5 AC-5: anime auto-advance. Gated on MediaType.ANIME and only
+  // fires when the client sent an explicit `progress` field. Movie / TV /
+  // episode paths are unaffected. Server-side so a buggy client cannot drive
+  // progress backwards on a check or override completed_at.
+  if (
+    entry.media_item.type === MediaType.ANIME &&
+    progress !== undefined
+  ) {
+    const existingProgress = entry.progress
+    // Client signals direction via the sent value: progress >= existing is
+    // increment (with max() guarding against stale races); progress < existing
+    // is a decrement and we trust the client. AC-5.1.
+    const effectiveProgress =
+      progress >= existingProgress
+        ? Math.max(existingProgress, progress)
+        : progress
+
+    data.progress = effectiveProgress
+
+    const episodeCount = entry.media_item.episode_count
+    if (
+      episodeCount !== null &&
+      effectiveProgress >= episodeCount
+    ) {
+      data.status = WatchStatus.COMPLETED
+      // Idempotent: don't overwrite an existing completion timestamp.
+      if (entry.completed_at === null) {
+        data.completed_at = new Date()
+      }
+      if (!fieldsApplied.includes('status')) fieldsApplied.push('status')
+    } else if (
+      entry.status === WatchStatus.PLAN_TO_WATCH &&
+      effectiveProgress >= 1
+    ) {
+      data.status = WatchStatus.WATCHING
+      if (!fieldsApplied.includes('status')) fieldsApplied.push('status')
+    }
+  }
+
   const updated = await db.userEntry.update({
     where: { id: entry.id },
     data,

--- a/app/global.css
+++ b/app/global.css
@@ -3058,3 +3058,35 @@ body {
   padding: 96px 24px;
   text-align: center;
 }
+
+/* Dashboard click-through: HorizontalCoverScroller cells + the
+ * CurrentlyActiveCarousel hero now wrap their content in <Link> elements so
+ * the entire card is clickable / keyboard-navigable to the detail route.
+ * .hcs-cell-link spans the whole cell area; .cac-screen-link is positioned
+ * as an invisible overlay on top of the carousel screen so the existing
+ * flex layout of cover + info is preserved underneath. */
+.hcs-cell-link {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+}
+.hcs-cell-link:focus-visible {
+  outline: 2px solid var(--phosphor-green, var(--rb-green));
+  outline-offset: 4px;
+}
+
+.cac-screen { position: relative; }
+.cac-screen-link {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  /* Visually invisible but focusable + clickable; covers the whole screen. */
+  display: block;
+}
+.cac-screen-link:focus-visible {
+  outline: 2px solid var(--phosphor-green, var(--rb-green));
+  outline-offset: -2px;
+}

--- a/app/global.css
+++ b/app/global.css
@@ -2754,3 +2754,307 @@ body {
   .watch-status-control-button[data-pulsing='true'] .led { animation: none; }
   .detail-hero-title { text-shadow: none; }
 }
+
+/* =========================================================================
+ * Story 8.5 — /anime/[id] detail page
+ *
+ * Mirrors the .movie-detail-page shape for the new media types. The anime
+ * detail page (and the still-WIP manga detail in Story 8.6) reuse the same
+ * outer layout / rule / synopsis primitives. Episode checklist, voice cast,
+ * and relations are new surfaces unique to AniList.
+ * ========================================================================= */
+
+.anime-detail-page,
+.tv-detail-page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 32px 24px 96px;
+}
+
+.anime-detail-rule,
+.tv-detail-rule {
+  height: 4px;
+  background: linear-gradient(
+    to right,
+    var(--rb-green) 0%, var(--rb-green) 16.66%,
+    var(--rb-yellow) 16.66%, var(--rb-yellow) 33.33%,
+    var(--rb-orange) 33.33%, var(--rb-orange) 50%,
+    var(--rb-pink) 50%, var(--rb-pink) 66.66%,
+    var(--rb-purple) 66.66%, var(--rb-purple) 83.33%,
+    var(--rb-blue) 83.33%, var(--rb-blue) 100%
+  );
+  width: 100%;
+}
+.anime-detail-rule-thick,
+.tv-detail-rule-thick { height: 6px; }
+
+.anime-detail-synopsis,
+.tv-detail-synopsis {
+  font-family: var(--font-body), 'EB Garamond', serif;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--phosphor-cream);
+  column-count: 2;
+  column-gap: 48px;
+  column-rule: 1px solid var(--phosphor-cream-ghost);
+}
+@media (max-width: 1024px) {
+  .anime-detail-synopsis,
+  .tv-detail-synopsis { column-count: 1; }
+}
+.anime-detail-synopsis p,
+.tv-detail-synopsis p { margin: 0 0 16px; break-inside: avoid; }
+
+.anime-detail-progress,
+.tv-detail-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.anime-detail-progress-label,
+.tv-detail-progress-label {
+  font-family: var(--font-mono), 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+  margin: 0;
+}
+
+.anime-detail-studio-chip {
+  display: inline-block;
+  padding: 6px 12px;
+  border: 1px solid var(--phosphor-cream-ghost);
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream);
+}
+
+/* EpisodeChecklist molecule (Story 8.5 AC-3) — flat 1..N list of episode
+ * rows with the EpisodeWatchToggle as the trailing affordance. */
+.episode-checklist {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.episode-checklist-row {
+  display: grid;
+  grid-template-columns: 56px 1fr 32px;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border: 1px solid var(--phosphor-cream-ghost);
+  background: var(--ground-card, rgba(34, 26, 48, 0.55));
+}
+.episode-checklist-row[data-checked='true'] {
+  border-color: var(--phosphor-green, var(--rb-green));
+  background: rgba(40, 80, 40, 0.18);
+}
+.episode-checklist-row-code {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream);
+}
+.episode-checklist-row-meta {
+  font-family: var(--font-body), serif;
+  font-size: 13px;
+  color: var(--phosphor-cream-dim);
+}
+
+/* Minimal styling for the EpisodeWatchToggle button so it's visible as a
+ * checkbox-like affordance. Pre-existing across the design system (used by
+ * SeasonAccordion as well) — these rules are additive and don't override
+ * any existing token-driven styling that may land later. */
+.episode-watch-toggle,
+.crt-pixel-checkbox {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--phosphor-cream);
+  color: var(--phosphor-cream);
+  font-family: var(--font-mono), monospace;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}
+.episode-watch-toggle:hover,
+.episode-watch-toggle:focus-visible {
+  border-color: var(--phosphor-green, var(--rb-green));
+  outline: none;
+}
+.episode-watch-toggle[data-checked='true'] {
+  background: var(--phosphor-green, var(--rb-green));
+  color: var(--ground-base, #1a1126);
+  border-color: var(--phosphor-green, var(--rb-green));
+}
+.episode-watch-toggle[aria-disabled='true'] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.episode-watch-toggle-mark { display: inline-block; line-height: 1; }
+
+/* VoiceCastList organism (Story 8.5 AC-8) — horizontal scroller mirroring
+ * CastList. Composition is character (top) + voice actor (bottom). */
+.voice-cast-list {
+  display: flex;
+  gap: 16px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  list-style: none;
+  padding: 0 0 8px;
+  margin: 0;
+}
+.voice-cast-list-item {
+  flex: 0 0 auto;
+  width: 112px;
+  scroll-snap-align: start;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: center;
+  text-align: center;
+}
+.voice-cast-list-portrait {
+  width: 96px;
+  height: 96px;
+  background: var(--ground-card, #221A30);
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--phosphor-cream-ghost);
+}
+.voice-cast-list-portrait-img { width: 100%; height: 100%; object-fit: cover; }
+.voice-cast-list-portrait-initials {
+  font-family: var(--font-display), serif;
+  font-size: 28px;
+  color: var(--phosphor-cream);
+}
+.voice-cast-list-role {
+  font-family: var(--font-mono), monospace;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+}
+.voice-cast-list-name {
+  font-family: var(--font-display), serif;
+  font-size: 14px;
+  line-height: 1.2;
+  color: var(--phosphor-cream);
+}
+.voice-cast-list-voiced-by {
+  font-family: var(--font-body), serif;
+  font-style: italic;
+  font-size: 12px;
+  color: var(--phosphor-cream-dim);
+}
+
+/* RelationsList organism (Story 8.5 AC-6) — 5 buckets, fixed order, with
+ * in-library Link vs out-of-library ADD-button affordance per row. */
+.relations-list {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+.relations-list-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.relations-list-section-header {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+  margin: 0;
+  font-weight: 400;
+}
+.relations-list-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.relations-list-row {
+  border: 1px solid var(--phosphor-cream-ghost);
+  background: var(--ground-card, rgba(34, 26, 48, 0.55));
+}
+.relations-list-row-link,
+.relations-list-row-out-of-library {
+  display: grid;
+  grid-template-columns: 56px 1fr auto;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 12px;
+  text-decoration: none;
+  color: inherit;
+}
+.relations-list-row-link:hover,
+.relations-list-row-link:focus-visible {
+  border-color: var(--phosphor-green, var(--rb-green));
+  outline: none;
+}
+.relations-list-row-cover { width: 56px; }
+.relations-list-row-title {
+  font-family: var(--font-display), serif;
+  font-size: 15px;
+  color: var(--phosphor-cream);
+}
+.relations-list-row-chip {
+  font-family: var(--font-mono), monospace;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+  padding: 4px 8px;
+  border: 1px solid var(--phosphor-cream-ghost);
+}
+.relations-list-row-out-of-library {
+  /* Out-of-library row has an extra trailing ADD-button column */
+  grid-template-columns: 56px 1fr auto auto;
+}
+.relations-list-row-add {
+  font-family: var(--font-mono), monospace;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 10px;
+  border: 1px solid var(--phosphor-cream);
+  color: var(--phosphor-cream);
+  text-decoration: none;
+  background: transparent;
+}
+.relations-list-row-add:hover,
+.relations-list-row-add:focus-visible {
+  border-color: var(--phosphor-green, var(--rb-green));
+  color: var(--phosphor-green, var(--rb-green));
+  outline: none;
+}
+
+.anime-not-found {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+  padding: 96px 24px;
+  text-align: center;
+}

--- a/app/global.css
+++ b/app/global.css
@@ -3250,3 +3250,171 @@ body {
   padding: 96px 24px;
   text-align: center;
 }
+
+/* =========================================================================
+ * SeasonAccordion (Story 7.5) — TV detail page episode tracker.
+ *
+ * Classes were referenced by the TV detail page but never styled. The
+ * accordion expands one season at a time, with a PhosphorBar in the header
+ * and a grid of episode rows in the panel.
+ * ========================================================================= */
+.season-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.season-accordion-section {
+  border: 1px solid var(--phosphor-cream-ghost);
+  background: var(--ground-card, rgba(34, 26, 48, 0.55));
+}
+.season-accordion-header {
+  display: grid;
+  grid-template-columns: 1fr 120px minmax(120px, 220px) 24px;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  padding: 12px 16px;
+  background: transparent;
+  border: none;
+  color: var(--phosphor-cream);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+}
+.season-accordion-header:hover,
+.season-accordion-header:focus-visible {
+  background: rgba(123, 92, 255, 0.06);
+  outline: none;
+}
+.season-accordion-header-title {
+  font-family: var(--font-display), serif;
+  font-size: 18px;
+  line-height: 1.2;
+}
+.season-accordion-header-count {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+  text-align: right;
+}
+.season-accordion-header-progress { min-width: 0; }
+.season-accordion-header-chev {
+  font-family: var(--font-mono), monospace;
+  font-size: 18px;
+  color: var(--phosphor-cream-dim);
+  transition: transform 200ms ease-out;
+  text-align: center;
+}
+.season-accordion-header-chev[data-rot='90'] { transform: rotate(90deg); }
+
+.season-accordion-panel {
+  border-top: 1px solid var(--phosphor-cream-ghost);
+  padding: 12px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.season-accordion-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+.season-accordion-mark-watched {
+  font-family: var(--font-mono), monospace;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 6px 10px;
+  background: transparent;
+  border: 1px solid var(--phosphor-cream);
+  color: var(--phosphor-cream);
+  cursor: pointer;
+}
+.season-accordion-mark-watched:hover:not(:disabled),
+.season-accordion-mark-watched:focus-visible:not(:disabled) {
+  border-color: var(--phosphor-green, var(--rb-green));
+  color: var(--phosphor-green, var(--rb-green));
+  outline: none;
+}
+.season-accordion-mark-watched:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.season-accordion-episodes {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.season-accordion-episode {
+  display: grid;
+  grid-template-columns: 56px 1fr 96px 64px 24px;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 8px;
+  border: 1px solid transparent;
+}
+.season-accordion-episode:hover { border-color: var(--phosphor-cream-ghost); }
+.season-accordion-episode[data-unaired='true'] { opacity: 0.55; }
+.season-accordion-episode-code {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--phosphor-cream);
+}
+.season-accordion-episode-title {
+  font-family: var(--font-display), serif;
+  font-size: 14px;
+  line-height: 1.3;
+  color: var(--phosphor-cream);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.season-accordion-episode-air,
+.season-accordion-episode-runtime {
+  font-family: var(--font-mono), monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--phosphor-cream-dim);
+  text-align: right;
+}
+
+@media (max-width: 768px) {
+  .season-accordion-header {
+    grid-template-columns: 1fr 80px 24px;
+  }
+  .season-accordion-header-progress { display: none; }
+  .season-accordion-episode {
+    grid-template-columns: 56px 1fr 24px;
+  }
+  .season-accordion-episode-air,
+  .season-accordion-episode-runtime { display: none; }
+}
+
+/* Shared CRT-pixel button (used by not-found pages + the relations ADD link). */
+.crt-pixel-button {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 14px;
+  background: transparent;
+  border: 1px solid var(--phosphor-cream);
+  color: var(--phosphor-cream);
+  text-decoration: none;
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.crt-pixel-button:hover,
+.crt-pixel-button:focus-visible {
+  border-color: var(--phosphor-green, var(--rb-green));
+  color: var(--phosphor-green, var(--rb-green));
+  outline: none;
+}

--- a/app/global.css
+++ b/app/global.css
@@ -2998,8 +2998,7 @@ body {
   border: 1px solid var(--phosphor-cream-ghost);
   background: var(--ground-card, rgba(34, 26, 48, 0.55));
 }
-.relations-list-row-link,
-.relations-list-row-out-of-library {
+.relations-list-row-link {
   display: grid;
   grid-template-columns: 56px 1fr auto;
   align-items: center;
@@ -3027,27 +3026,6 @@ body {
   color: var(--phosphor-cream-dim);
   padding: 4px 8px;
   border: 1px solid var(--phosphor-cream-ghost);
-}
-.relations-list-row-out-of-library {
-  /* Out-of-library row has an extra trailing ADD-button column */
-  grid-template-columns: 56px 1fr auto auto;
-}
-.relations-list-row-add {
-  font-family: var(--font-mono), monospace;
-  font-size: 10px;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  padding: 6px 10px;
-  border: 1px solid var(--phosphor-cream);
-  color: var(--phosphor-cream);
-  text-decoration: none;
-  background: transparent;
-}
-.relations-list-row-add:hover,
-.relations-list-row-add:focus-visible {
-  border-color: var(--phosphor-green, var(--rb-green));
-  color: var(--phosphor-green, var(--rb-green));
-  outline: none;
 }
 
 .anime-not-found {

--- a/app/global.css
+++ b/app/global.css
@@ -3090,3 +3090,163 @@ body {
   outline: 2px solid var(--phosphor-green, var(--rb-green));
   outline-offset: -2px;
 }
+
+/* =========================================================================
+ * /preview/[source]/[type]/[id] — Story 8.5 follow-up
+ *
+ * Source-driven preview page for search results that aren't in the user's
+ * library yet. Fetches from TMDB / AniList on-the-fly and renders a minimal
+ * detail-shaped layout with an ADD TO LIBRARY button that promotes the
+ * record into the canonical /<medium>/<MediaItem.id> detail page on success.
+ * ========================================================================= */
+.preview-page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 32px 24px 96px;
+}
+
+.preview-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--phosphor-cream-dim);
+  text-decoration: none;
+  font-family: var(--font-mono), 'IBM Plex Mono', monospace;
+  font-size: 12px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  align-self: flex-start;
+}
+.preview-back-link:hover,
+.preview-back-link:focus-visible {
+  color: var(--phosphor-cream);
+  outline: none;
+}
+
+.preview-hero {
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) 1fr;
+  gap: 32px;
+  align-items: flex-start;
+}
+@media (max-width: 768px) {
+  .preview-hero { grid-template-columns: 1fr; gap: 24px; }
+}
+
+.preview-hero-cover {
+  width: 100%;
+  max-width: 320px;
+  justify-self: center;
+  border: 1px solid var(--phosphor-cream-ghost);
+  background: var(--ground-card, #221A30);
+  aspect-ratio: 2 / 3;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.preview-hero-poster {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.preview-hero-poster-fallback {
+  font-family: var(--font-display), serif;
+  font-size: 64px;
+  color: var(--phosphor-cream-dim);
+}
+
+.preview-hero-text {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+.preview-hero-medium {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream-dim);
+  margin: 0;
+}
+.preview-hero-title {
+  font-family: var(--font-display), 'PP Editorial New', 'Cormorant Garamond', serif;
+  font-size: clamp(32px, 4vw, 56px);
+  line-height: 1.05;
+  color: var(--phosphor-cream);
+  margin: 0;
+  font-weight: 400;
+}
+.preview-hero-original-title {
+  font-family: var(--font-body), 'EB Garamond', serif;
+  font-style: italic;
+  font-size: 16px;
+  color: var(--phosphor-cream-dim);
+  margin: 0;
+}
+.preview-hero-meta {
+  font-family: var(--font-mono), monospace;
+  font-size: 12px;
+  letter-spacing: 0.15em;
+  color: var(--phosphor-cream-dim);
+  margin: 0;
+}
+.preview-hero-source {
+  font-family: var(--font-mono), monospace;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--phosphor-cream-ghost);
+  margin: 0;
+}
+
+.preview-add-button {
+  align-self: flex-start;
+  font-family: var(--font-mono), monospace;
+  font-size: 12px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  padding: 10px 16px;
+  margin-top: 8px;
+  background: transparent;
+  border: 1px solid var(--phosphor-cream);
+  color: var(--phosphor-cream);
+  cursor: pointer;
+}
+.preview-add-button:hover:not(:disabled),
+.preview-add-button:focus-visible:not(:disabled) {
+  border-color: var(--phosphor-green, var(--rb-green));
+  color: var(--phosphor-green, var(--rb-green));
+  outline: none;
+}
+.preview-add-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.preview-synopsis {
+  font-family: var(--font-body), 'EB Garamond', serif;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--phosphor-cream);
+  column-count: 2;
+  column-gap: 48px;
+  column-rule: 1px solid var(--phosphor-cream-ghost);
+}
+@media (max-width: 1024px) {
+  .preview-synopsis { column-count: 1; }
+}
+.preview-synopsis p { margin: 0 0 16px; break-inside: avoid; }
+
+.preview-not-found {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+  padding: 96px 24px;
+  text-align: center;
+}

--- a/app/preview/[source]/[type]/[id]/AddToLibraryButton.tsx
+++ b/app/preview/[source]/[type]/[id]/AddToLibraryButton.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useMutation } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+import type { MediaType } from '@prisma/client'
+
+export type AddToLibraryButtonProps = {
+  source: 'tmdb' | 'anilist'
+  sourceId: number
+  type: MediaType
+  medium: 'movies' | 'tv' | 'anime' | 'manga'
+}
+
+type AddBody = {
+  source: AddToLibraryButtonProps['source']
+  sourceId: number
+  type: MediaType
+}
+
+type AddResponse = {
+  mediaItem: { id: string }
+  merged: boolean
+}
+
+async function addToLibrary(body: AddBody): Promise<AddResponse> {
+  const res = await fetch('/api/media', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const payload = (await res.json().catch(() => ({}))) as { error?: string }
+    throw new Error(payload.error ?? `add_failed:${res.status}`)
+  }
+  return (await res.json()) as AddResponse
+}
+
+export function AddToLibraryButton({
+  source,
+  sourceId,
+  type,
+  medium,
+}: AddToLibraryButtonProps) {
+  const router = useRouter()
+
+  const mutation = useMutation<AddResponse, Error, AddBody>({
+    mutationFn: addToLibrary,
+    onSuccess: (data) => {
+      toast.success('ADDED TO LIBRARY')
+      router.push(`/${medium}/${data.mediaItem.id}`)
+    },
+    onError: (err) => {
+      const reason =
+        err.message.startsWith('add_failed:5') || err.message === 'upstream_failed'
+          ? 'Upstream unavailable. Please retry.'
+          : err.message === 'unsupported_source_type'
+            ? 'This media type is not wired yet.'
+            : 'Could not add to library.'
+      toast.error('COULD NOT ADD', { description: reason })
+    },
+  })
+
+  return (
+    <button
+      type='button'
+      className='preview-add-button cpb'
+      disabled={mutation.isPending}
+      onClick={() => mutation.mutate({ source, sourceId, type })}
+    >
+      {mutation.isPending ? '> ADDING…' : '> ADD TO LIBRARY'}
+    </button>
+  )
+}

--- a/app/preview/[source]/[type]/[id]/AddToLibraryButton.tsx
+++ b/app/preview/[source]/[type]/[id]/AddToLibraryButton.tsx
@@ -49,7 +49,10 @@ export function AddToLibraryButton({
     mutationFn: addToLibrary,
     onSuccess: (data) => {
       toast.success('ADDED TO LIBRARY')
-      router.push(`/${medium}/${data.mediaItem.id}`)
+      const hasDetailPage = medium !== 'manga'
+      router.push(
+        hasDetailPage ? `/${medium}/${data.mediaItem.id}` : `/${medium}`,
+      )
     },
     onError: (err) => {
       const reason =

--- a/app/preview/[source]/[type]/[id]/AnimePreview.tsx
+++ b/app/preview/[source]/[type]/[id]/AnimePreview.tsx
@@ -1,0 +1,177 @@
+import Link from 'next/link'
+import { MediaType } from '@prisma/client'
+import {
+  getMedia,
+  getMediaRelations,
+  type AnilistCharacterEdge,
+  type AnilistMedia,
+} from '@/lib/api/anilist'
+import { db } from '@/lib/db'
+import {
+  normaliseRelations,
+  type NormalisedRelationBuckets,
+} from '@/lib/normalise/anilist-relations'
+import { DetailHero } from '@/components/organisms/DetailHero'
+import { SectionBand } from '@/components/organisms/SectionBand/SectionBand'
+import { RelationsList } from '@/components/organisms/RelationsList'
+import { VoiceCastList } from '@/components/organisms/VoiceCastList'
+import type { MetadataItem } from '@/components/molecules/MetadataRow'
+import { AddToLibraryButton } from './AddToLibraryButton'
+
+function stripAnilistHtml(text: string): string {
+  return text
+    .replace(/<br\s*\/?\s*>/gi, '\n\n')
+    .replace(/<[^>]*>/g, '')
+}
+
+function preferredTitle(t: AnilistMedia['title']): string {
+  return (
+    t.userPreferred ?? t.romaji ?? t.english ?? t.native ?? 'Untitled'
+  )
+}
+
+function pickCover(media: AnilistMedia): string | null {
+  return (
+    media.coverImage?.extraLarge ??
+    media.coverImage?.large ??
+    media.coverImage?.medium ??
+    null
+  )
+}
+
+async function resolveInLibraryByAnilistId(
+  buckets: NormalisedRelationBuckets,
+): Promise<Map<number, string>> {
+  const allIds = [
+    ...buckets.sequel,
+    ...buckets.prequel,
+    ...buckets.sideStory,
+    ...buckets.parent,
+    ...buckets.adaptation,
+  ].map((r) => r.id)
+  if (allIds.length === 0) return new Map()
+  const rows = await db.mediaItem.findMany({
+    where: { anilist_id: { in: allIds } },
+    select: { id: true, anilist_id: true },
+  })
+  const map = new Map<number, string>()
+  for (const r of rows) {
+    if (r.anilist_id !== null) map.set(r.anilist_id, r.id)
+  }
+  return map
+}
+
+export async function AnimePreview({ id }: { id: number }) {
+  const [media, rawRelations] = await Promise.all([
+    getMedia(id, 'ANIME'),
+    getMediaRelations(id).catch(() => null),
+  ])
+
+  const buckets: NormalisedRelationBuckets =
+    rawRelations !== null
+      ? normaliseRelations(rawRelations)
+      : {
+          sequel: [],
+          prequel: [],
+          sideStory: [],
+          parent: [],
+          adaptation: [],
+        }
+  const inLibraryByAnilistId = await resolveInLibraryByAnilistId(buckets)
+
+  const title = preferredTitle(media.title)
+  const native = media.title.native ?? null
+  const year = media.startDate.year
+  const posterUrl = pickCover(media)
+  const studioName =
+    media.studios?.nodes.find((n) => n.isAnimationStudio)?.name ??
+    media.studios?.nodes[0]?.name ??
+    null
+  const episodeCount = media.episodes ?? null
+
+  const metadata: MetadataItem[] = []
+  if (media.format) {
+    metadata.push({ value: media.format.replaceAll('_', ' ') })
+  }
+  if (year !== null) metadata.push({ value: String(year) })
+  if (studioName !== null) metadata.push({ value: studioName })
+  if (episodeCount !== null) metadata.push({ value: `${episodeCount} EP` })
+  if (media.status && media.status.length > 0) {
+    metadata.push({
+      value: media.status.replaceAll('_', ' ').toUpperCase(),
+      dim: true,
+    })
+  }
+
+  const synopsisParagraphs = stripAnilistHtml(media.description ?? '')
+    .split(/\n+/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+
+  const characters: AnilistCharacterEdge[] = media.characters?.edges ?? []
+  const hasRelations =
+    buckets.sequel.length > 0 ||
+    buckets.prequel.length > 0 ||
+    buckets.sideStory.length > 0 ||
+    buckets.parent.length > 0 ||
+    buckets.adaptation.length > 0
+
+  return (
+    <main className='anime-detail-page'>
+      <Link href='/search' className='back-to-library-link'>
+        <span className='back-to-library-link-arrow' aria-hidden='true'>
+          &lt;
+        </span>{' '}
+        BACK TO SEARCH
+      </Link>
+      <DetailHero
+        medium='anime'
+        mediumLabel='ANIME · PREVIEW'
+        title={title}
+        originalTitle={native !== title ? native : null}
+        posterUrl={posterUrl}
+        metadata={metadata}
+        imdbId={null}
+        showQbtButton={false}
+        actionsOverride={
+          <AddToLibraryButton
+            source='anilist'
+            sourceId={id}
+            type={MediaType.ANIME}
+            medium='anime'
+          />
+        }
+      />
+      <div className='anime-detail-rule' aria-hidden='true' />
+      {synopsisParagraphs.length > 0 ? (
+        <article className='anime-detail-synopsis'>
+          {synopsisParagraphs.map((para, idx) => (
+            <p key={idx}>{para}</p>
+          ))}
+        </article>
+      ) : null}
+      <div
+        className='anime-detail-rule anime-detail-rule-thick'
+        aria-hidden='true'
+      />
+      {studioName !== null ? (
+        <SectionBand title='Studios'>
+          <span className='anime-detail-studio-chip'>{studioName}</span>
+        </SectionBand>
+      ) : null}
+      {characters.length > 0 ? (
+        <SectionBand title='Voice Cast' count={characters.length}>
+          <VoiceCastList characters={characters} />
+        </SectionBand>
+      ) : null}
+      {hasRelations ? (
+        <SectionBand title='Relations'>
+          <RelationsList
+            buckets={buckets}
+            inLibraryByAnilistId={inLibraryByAnilistId}
+          />
+        </SectionBand>
+      ) : null}
+    </main>
+  )
+}

--- a/app/preview/[source]/[type]/[id]/AnimePreview.tsx
+++ b/app/preview/[source]/[type]/[id]/AnimePreview.tsx
@@ -16,13 +16,8 @@ import { SectionBand } from '@/components/organisms/SectionBand/SectionBand'
 import { RelationsList } from '@/components/organisms/RelationsList'
 import { VoiceCastList } from '@/components/organisms/VoiceCastList'
 import type { MetadataItem } from '@/components/molecules/MetadataRow'
+import { stripAnilistHtml } from '@/lib/normalise/anilist-html'
 import { AddToLibraryButton } from './AddToLibraryButton'
-
-function stripAnilistHtml(text: string): string {
-  return text
-    .replace(/<br\s*\/?\s*>/gi, '\n\n')
-    .replace(/<[^>]*>/g, '')
-}
 
 function preferredTitle(t: AnilistMedia['title']): string {
   return (

--- a/app/preview/[source]/[type]/[id]/MangaPreview.tsx
+++ b/app/preview/[source]/[type]/[id]/MangaPreview.tsx
@@ -1,0 +1,161 @@
+import Link from 'next/link'
+import { MediaType } from '@prisma/client'
+import {
+  getMedia,
+  getMediaRelations,
+  type AnilistMedia,
+} from '@/lib/api/anilist'
+import { db } from '@/lib/db'
+import {
+  normaliseRelations,
+  type NormalisedRelationBuckets,
+} from '@/lib/normalise/anilist-relations'
+import { DetailHero } from '@/components/organisms/DetailHero'
+import { SectionBand } from '@/components/organisms/SectionBand/SectionBand'
+import { RelationsList } from '@/components/organisms/RelationsList'
+import type { MetadataItem } from '@/components/molecules/MetadataRow'
+import { AddToLibraryButton } from './AddToLibraryButton'
+
+function stripAnilistHtml(text: string): string {
+  return text
+    .replace(/<br\s*\/?\s*>/gi, '\n\n')
+    .replace(/<[^>]*>/g, '')
+}
+
+function preferredTitle(t: AnilistMedia['title']): string {
+  return (
+    t.userPreferred ?? t.romaji ?? t.english ?? t.native ?? 'Untitled'
+  )
+}
+
+function pickCover(media: AnilistMedia): string | null {
+  return (
+    media.coverImage?.extraLarge ??
+    media.coverImage?.large ??
+    media.coverImage?.medium ??
+    null
+  )
+}
+
+async function resolveInLibraryByAnilistId(
+  buckets: NormalisedRelationBuckets,
+): Promise<Map<number, string>> {
+  const allIds = [
+    ...buckets.sequel,
+    ...buckets.prequel,
+    ...buckets.sideStory,
+    ...buckets.parent,
+    ...buckets.adaptation,
+  ].map((r) => r.id)
+  if (allIds.length === 0) return new Map()
+  const rows = await db.mediaItem.findMany({
+    where: { anilist_id: { in: allIds } },
+    select: { id: true, anilist_id: true },
+  })
+  const map = new Map<number, string>()
+  for (const r of rows) {
+    if (r.anilist_id !== null) map.set(r.anilist_id, r.id)
+  }
+  return map
+}
+
+export async function MangaPreview({ id }: { id: number }) {
+  const [media, rawRelations] = await Promise.all([
+    getMedia(id, 'MANGA'),
+    getMediaRelations(id).catch(() => null),
+  ])
+
+  const buckets: NormalisedRelationBuckets =
+    rawRelations !== null
+      ? normaliseRelations(rawRelations)
+      : {
+          sequel: [],
+          prequel: [],
+          sideStory: [],
+          parent: [],
+          adaptation: [],
+        }
+  const inLibraryByAnilistId = await resolveInLibraryByAnilistId(buckets)
+
+  const title = preferredTitle(media.title)
+  const native = media.title.native ?? null
+  const year = media.startDate.year
+  const posterUrl = pickCover(media)
+  const chapterCount = media.chapters ?? null
+  const volumeCount = media.volumes ?? null
+
+  const metadata: MetadataItem[] = []
+  if (media.format) {
+    metadata.push({ value: media.format.replaceAll('_', ' ') })
+  }
+  if (year !== null) metadata.push({ value: String(year) })
+  if (chapterCount !== null) metadata.push({ value: `${chapterCount} CH` })
+  if (volumeCount !== null) metadata.push({ value: `${volumeCount} VOL` })
+  if (media.status && media.status.length > 0) {
+    metadata.push({
+      value: media.status.replaceAll('_', ' ').toUpperCase(),
+      dim: true,
+    })
+  }
+
+  const synopsisParagraphs = stripAnilistHtml(media.description ?? '')
+    .split(/\n+/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+
+  const hasRelations =
+    buckets.sequel.length > 0 ||
+    buckets.prequel.length > 0 ||
+    buckets.sideStory.length > 0 ||
+    buckets.parent.length > 0 ||
+    buckets.adaptation.length > 0
+
+  return (
+    <main className='anime-detail-page'>
+      <Link href='/search' className='back-to-library-link'>
+        <span className='back-to-library-link-arrow' aria-hidden='true'>
+          &lt;
+        </span>{' '}
+        BACK TO SEARCH
+      </Link>
+      <DetailHero
+        medium='manga'
+        mediumLabel='MANGA · PREVIEW'
+        title={title}
+        originalTitle={native !== title ? native : null}
+        posterUrl={posterUrl}
+        metadata={metadata}
+        imdbId={null}
+        showQbtButton={false}
+        actionsOverride={
+          <AddToLibraryButton
+            source='anilist'
+            sourceId={id}
+            type={MediaType.MANGA}
+            medium='manga'
+          />
+        }
+      />
+      <div className='anime-detail-rule' aria-hidden='true' />
+      {synopsisParagraphs.length > 0 ? (
+        <article className='anime-detail-synopsis'>
+          {synopsisParagraphs.map((para, idx) => (
+            <p key={idx}>{para}</p>
+          ))}
+        </article>
+      ) : null}
+      <div
+        className='anime-detail-rule anime-detail-rule-thick'
+        aria-hidden='true'
+      />
+      {hasRelations ? (
+        <SectionBand title='Relations'>
+          <RelationsList
+            buckets={buckets}
+            inLibraryByAnilistId={inLibraryByAnilistId}
+          />
+        </SectionBand>
+      ) : null}
+    </main>
+  )
+}

--- a/app/preview/[source]/[type]/[id]/MangaPreview.tsx
+++ b/app/preview/[source]/[type]/[id]/MangaPreview.tsx
@@ -14,13 +14,8 @@ import { DetailHero } from '@/components/organisms/DetailHero'
 import { SectionBand } from '@/components/organisms/SectionBand/SectionBand'
 import { RelationsList } from '@/components/organisms/RelationsList'
 import type { MetadataItem } from '@/components/molecules/MetadataRow'
+import { stripAnilistHtml } from '@/lib/normalise/anilist-html'
 import { AddToLibraryButton } from './AddToLibraryButton'
-
-function stripAnilistHtml(text: string): string {
-  return text
-    .replace(/<br\s*\/?\s*>/gi, '\n\n')
-    .replace(/<[^>]*>/g, '')
-}
 
 function preferredTitle(t: AnilistMedia['title']): string {
   return (

--- a/app/preview/[source]/[type]/[id]/MoviePreview.tsx
+++ b/app/preview/[source]/[type]/[id]/MoviePreview.tsx
@@ -1,0 +1,122 @@
+import Link from 'next/link'
+import { MediaType } from '@prisma/client'
+import { getMovie, getWatchProviders, getImageUrl } from '@/lib/api/tmdb'
+import { env } from '@/lib/env'
+import { DetailHero } from '@/components/organisms/DetailHero'
+import { CastList } from '@/components/organisms/CastList'
+import { StreamingBadges } from '@/components/organisms/StreamingBadges'
+import { SectionBand } from '@/components/organisms/SectionBand/SectionBand'
+import type { MetadataItem } from '@/components/molecules/MetadataRow'
+import { AddToLibraryButton } from './AddToLibraryButton'
+
+const CREW_JOBS_KEEP = new Set([
+  'Director',
+  'Writer',
+  'Screenplay',
+  'Producer',
+  'Novel',
+])
+
+function deriveYear(releaseDate: string): number | null {
+  const year = Number.parseInt(releaseDate.slice(0, 4), 10)
+  if (!Number.isFinite(year) || year === 1970) return null
+  return year
+}
+
+export async function MoviePreview({ id }: { id: number }) {
+  const [movieDetail, providers] = await Promise.all([
+    getMovie(id, { withCredits: true }),
+    getWatchProviders('movie', id, env.TMDB_WATCH_PROVIDER_COUNTRY),
+  ])
+
+  const cast = movieDetail.credits.cast.slice(0, 12).map((c) => ({
+    name: c.name,
+    role: c.character ?? '',
+    profilePath: c.profile_path,
+  }))
+  const crew = movieDetail.credits.crew
+    .filter((c) => CREW_JOBS_KEEP.has(c.job))
+    .map((c) => ({
+      name: c.name,
+      role: c.job,
+      profilePath: c.profile_path,
+    }))
+  const director =
+    movieDetail.credits.crew.find((c) => c.job === 'Director')?.name ?? null
+  const year = deriveYear(movieDetail.release_date)
+
+  const metadata: MetadataItem[] = []
+  if (movieDetail.runtime != null && movieDetail.runtime > 0) {
+    metadata.push({ value: `${movieDetail.runtime} MIN` })
+  }
+  if (director) metadata.push({ value: director.toUpperCase() })
+  if (year !== null) metadata.push({ value: String(year) })
+  if (movieDetail.status && movieDetail.status.trim().length > 0) {
+    metadata.push({ value: movieDetail.status.toUpperCase(), dim: true })
+  }
+  if (movieDetail.genres.length > 0) {
+    metadata.push({
+      value: movieDetail.genres.map((g) => g.name.toUpperCase()).join(' · '),
+      dim: true,
+    })
+  }
+
+  const posterUrl = getImageUrl(movieDetail.poster_path, 'w780')
+
+  const synopsisParagraphs = (movieDetail.overview ?? '')
+    .split(/\n+/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+
+  return (
+    <main className='movie-detail-page'>
+      <Link href='/search' className='back-to-library-link'>
+        <span className='back-to-library-link-arrow' aria-hidden='true'>
+          &lt;
+        </span>{' '}
+        BACK TO SEARCH
+      </Link>
+      <DetailHero
+        medium='movies'
+        mediumLabel={`MOVIE${year !== null ? ` · ${year}` : ''} · PREVIEW`}
+        title={movieDetail.title}
+        originalTitle={movieDetail.original_title ?? null}
+        posterUrl={posterUrl}
+        metadata={metadata}
+        imdbId={movieDetail.external_ids?.imdb_id ?? null}
+        showQbtButton={false}
+        actionsOverride={
+          <AddToLibraryButton
+            source='tmdb'
+            sourceId={id}
+            type={MediaType.MOVIE}
+            medium='movies'
+          />
+        }
+      />
+      <div className='movie-detail-rule' aria-hidden='true' />
+      {synopsisParagraphs.length > 0 ? (
+        <article className='movie-detail-synopsis'>
+          {synopsisParagraphs.map((para, idx) => (
+            <p key={idx}>{para}</p>
+          ))}
+        </article>
+      ) : null}
+      <div
+        className='movie-detail-rule movie-detail-rule-thick'
+        aria-hidden='true'
+      />
+      <SectionBand title='Cast' count={cast.length}>
+        <CastList people={cast} />
+      </SectionBand>
+      {crew.length > 0 ? (
+        <SectionBand title='Crew' count={crew.length}>
+          <CastList people={crew} />
+        </SectionBand>
+      ) : null}
+      <SectionBand title='Streaming'>
+        <StreamingBadges providers={providers} />
+      </SectionBand>
+    </main>
+  )
+}

--- a/app/preview/[source]/[type]/[id]/TvPreview.tsx
+++ b/app/preview/[source]/[type]/[id]/TvPreview.tsx
@@ -1,0 +1,121 @@
+import Link from 'next/link'
+import { MediaType } from '@prisma/client'
+import { getTv, getImageUrl } from '@/lib/api/tmdb'
+import { DetailHero } from '@/components/organisms/DetailHero'
+import { CastList } from '@/components/organisms/CastList'
+import { StreamingBadges } from '@/components/organisms/StreamingBadges'
+import { SectionBand } from '@/components/organisms/SectionBand/SectionBand'
+import type { MetadataItem } from '@/components/molecules/MetadataRow'
+import type { TmdbCountryProviders } from '@/lib/api/tmdb'
+import { env } from '@/lib/env'
+import { AddToLibraryButton } from './AddToLibraryButton'
+
+function deriveYear(firstAirDate: string): number | null {
+  const year = Number.parseInt(firstAirDate.slice(0, 4), 10)
+  if (!Number.isFinite(year) || year === 1970) return null
+  return year
+}
+
+const EMPTY_PROVIDERS: TmdbCountryProviders = {
+  link: '',
+  flatrate: [],
+  buy: [],
+  rent: [],
+}
+
+export async function TvPreview({ id }: { id: number }) {
+  const tv = await getTv(id)
+
+  const cast = tv.credits.cast.slice(0, 12).map((c) => ({
+    name: c.name,
+    role: c.character ?? '',
+    profilePath: c.profile_path,
+  }))
+
+  const year = deriveYear(tv.first_air_date)
+  const totalSeasons = tv.number_of_seasons ?? null
+  const totalEpisodes = tv.number_of_episodes ?? null
+
+  const metadata: MetadataItem[] = []
+  if (totalEpisodes !== null && totalEpisodes > 0) {
+    metadata.push({ value: `${totalEpisodes} EPISODES` })
+  }
+  if (totalSeasons !== null && totalSeasons > 0) {
+    metadata.push({ value: `${totalSeasons} SEASONS` })
+  }
+  if (year !== null) metadata.push({ value: String(year) })
+  if (tv.status && tv.status.trim().length > 0) {
+    metadata.push({ value: tv.status.toUpperCase(), dim: true })
+  }
+  if (tv.genres.length > 0) {
+    metadata.push({
+      value: tv.genres.map((g) => g.name.toUpperCase()).join(' · '),
+      dim: true,
+    })
+  }
+
+  const posterUrl = getImageUrl(tv.poster_path, 'w780')
+
+  const synopsisParagraphs = (tv.overview ?? '')
+    .split(/\n+/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+
+  // getTv() appends watch/providers but we resolve the country slice locally
+  // (the helper getWatchProviders() does the same shape extraction). Empty
+  // slice when the country isn't represented in the response.
+  const country = env.TMDB_WATCH_PROVIDER_COUNTRY
+  const providersSlice = tv['watch/providers']?.results?.[country]
+  const providers: TmdbCountryProviders = providersSlice
+    ? {
+        link: providersSlice.link ?? '',
+        flatrate: providersSlice.flatrate ?? [],
+        buy: providersSlice.buy ?? [],
+        rent: providersSlice.rent ?? [],
+      }
+    : EMPTY_PROVIDERS
+
+  return (
+    <main className='tv-detail-page'>
+      <Link href='/search' className='back-to-library-link'>
+        <span className='back-to-library-link-arrow' aria-hidden='true'>
+          &lt;
+        </span>{' '}
+        BACK TO SEARCH
+      </Link>
+      <DetailHero
+        medium='tv'
+        mediumLabel={`TV${year !== null ? ` · ${year}` : ''} · PREVIEW`}
+        title={tv.name}
+        originalTitle={tv.original_name ?? null}
+        posterUrl={posterUrl}
+        metadata={metadata}
+        imdbId={tv.external_ids?.imdb_id ?? null}
+        showQbtButton={false}
+        actionsOverride={
+          <AddToLibraryButton
+            source='tmdb'
+            sourceId={id}
+            type={MediaType.TV_SHOW}
+            medium='tv'
+          />
+        }
+      />
+      <div className='tv-detail-rule' aria-hidden='true' />
+      {synopsisParagraphs.length > 0 ? (
+        <article className='tv-detail-synopsis'>
+          {synopsisParagraphs.map((para, idx) => (
+            <p key={idx}>{para}</p>
+          ))}
+        </article>
+      ) : null}
+      <div className='tv-detail-rule tv-detail-rule-thick' aria-hidden='true' />
+      <SectionBand title='Cast' count={cast.length}>
+        <CastList people={cast} />
+      </SectionBand>
+      <SectionBand title='Streaming'>
+        <StreamingBadges providers={providers} />
+      </SectionBand>
+    </main>
+  )
+}

--- a/app/preview/[source]/[type]/[id]/not-found.tsx
+++ b/app/preview/[source]/[type]/[id]/not-found.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function PreviewNotFound() {
+  return (
+    <main className='preview-not-found'>
+      <h1>&gt; PREVIEW UNAVAILABLE</h1>
+      <p>The source item couldn&apos;t be loaded.</p>
+      <Link href='/search' className='crt-pixel-button'>
+        &gt; BACK TO SEARCH
+      </Link>
+    </main>
+  )
+}

--- a/app/preview/[source]/[type]/[id]/page.tsx
+++ b/app/preview/[source]/[type]/[id]/page.tsx
@@ -1,19 +1,14 @@
 import { notFound } from 'next/navigation'
-import Link from 'next/link'
-import { MediaType } from '@prisma/client'
 import { z } from 'zod'
-import { getMovie, getTv, getImageUrl, TmdbApiError } from '@/lib/api/tmdb'
-import {
-  getMedia,
-  AnilistApiError,
-  AnilistNotFoundError,
-} from '@/lib/api/anilist'
+import { TmdbApiError } from '@/lib/api/tmdb'
+import { AnilistApiError, AnilistNotFoundError } from '@/lib/api/anilist'
 import { logger } from '@/lib/logger'
-import { AddToLibraryButton } from './AddToLibraryButton'
+import { MoviePreview } from './MoviePreview'
+import { TvPreview } from './TvPreview'
+import { AnimePreview } from './AnimePreview'
+import { MangaPreview } from './MangaPreview'
 
 export const dynamic = 'force-dynamic'
-
-type Medium = 'movies' | 'tv' | 'anime' | 'manga'
 
 const ParamsSchema = z.object({
   source: z.enum(['tmdb', 'anilist']),
@@ -21,124 +16,10 @@ const ParamsSchema = z.object({
   id: z.coerce.number().int().positive(),
 })
 
-type Params = z.infer<typeof ParamsSchema>
-
-const TYPE_TO_MEDIA_TYPE: Record<Params['type'], MediaType> = {
-  movie: MediaType.MOVIE,
-  tv: MediaType.TV_SHOW,
-  anime: MediaType.ANIME,
-  manga: MediaType.MANGA,
-}
-
-const TYPE_TO_MEDIUM: Record<Params['type'], Medium> = {
-  movie: 'movies',
-  tv: 'tv',
-  anime: 'anime',
-  manga: 'manga',
-}
-
-const TYPE_LABEL: Record<Params['type'], string> = {
-  movie: 'MOVIE',
-  tv: 'TV',
-  anime: 'ANIME',
-  manga: 'MANGA',
-}
-
-type PreviewData = {
-  title: string
-  originalTitle: string | null
-  year: number | null
-  overview: string | null
-  posterUrl: string | null
-}
-
-// AniList descriptions ship raw HTML even with `asHtml: false`. Same helper
-// as the anime detail page — mirror so legacy + future flows render uniformly.
-function stripAnilistHtml(text: string): string {
-  return text
-    .replace(/<br\s*\/?\s*>/gi, '\n\n')
-    .replace(/<[^>]*>/g, '')
-}
-
-function extractYear(date: string | null | undefined): number | null {
-  if (!date) return null
-  const match = /^(\d{4})/.exec(date)
-  return match ? Number.parseInt(match[1], 10) : null
-}
-
-async function loadPreview(
-  source: Params['source'],
-  type: Params['type'],
-  id: number,
-): Promise<PreviewData | null> {
-  try {
-    if (source === 'tmdb' && type === 'movie') {
-      const movie = await getMovie(id)
-      return {
-        title: movie.title,
-        originalTitle: movie.original_title ?? null,
-        year: extractYear(movie.release_date),
-        overview: movie.overview ?? null,
-        posterUrl: getImageUrl(movie.poster_path, 'w780'),
-      }
-    }
-    if (source === 'tmdb' && type === 'tv') {
-      const tv = await getTv(id)
-      return {
-        title: tv.name,
-        originalTitle: tv.original_name ?? null,
-        year: extractYear(tv.first_air_date),
-        overview: tv.overview ?? null,
-        posterUrl: getImageUrl(tv.poster_path, 'w780'),
-      }
-    }
-    if (source === 'anilist' && (type === 'anime' || type === 'manga')) {
-      const anilistType = type === 'anime' ? 'ANIME' : 'MANGA'
-      const media = await getMedia(id, anilistType)
-      const title =
-        media.title.userPreferred ??
-        media.title.romaji ??
-        media.title.english ??
-        media.title.native ??
-        'Untitled'
-      const native = media.title.native ?? null
-      const year = media.startDate.year
-      const poster =
-        media.coverImage?.extraLarge ??
-        media.coverImage?.large ??
-        media.coverImage?.medium ??
-        null
-      return {
-        title,
-        originalTitle: native !== title ? native : null,
-        year,
-        overview: media.description ? stripAnilistHtml(media.description) : null,
-        posterUrl: poster,
-      }
-    }
-    return null
-  } catch (err) {
-    if (
-      err instanceof TmdbApiError ||
-      err instanceof AnilistApiError ||
-      err instanceof AnilistNotFoundError
-    ) {
-      logger.warn(
-        { event: 'preview.upstream_failed', source, type, id, err },
-        'preview upstream fetch failed; rendering 404',
-      )
-      return null
-    }
-    throw err
-  }
-}
-
 function isValidSourceTypeCombo(
-  source: Params['source'],
-  type: Params['type'],
+  source: 'tmdb' | 'anilist',
+  type: 'movie' | 'tv' | 'anime' | 'manga',
 ): boolean {
-  // tmdb supports movie + tv; anilist supports anime + manga. Other combos
-  // (e.g. tmdb + anime) aren't wired and 404 immediately.
   if (source === 'tmdb') return type === 'movie' || type === 'tv'
   if (source === 'anilist') return type === 'anime' || type === 'manga'
   return false
@@ -152,9 +33,9 @@ export async function generateMetadata({
   const raw = await params
   const parsed = ParamsSchema.safeParse(raw)
   if (!parsed.success) return { title: 'PREVIEW · Cuatro Tracker' }
-  const data = await loadPreview(parsed.data.source, parsed.data.type, parsed.data.id)
-  if (!data) return { title: 'PREVIEW NOT FOUND · Cuatro Tracker' }
-  return { title: `${data.title.toUpperCase()} · PREVIEW · Cuatro Tracker` }
+  return {
+    title: `PREVIEW · ${parsed.data.type.toUpperCase()} · Cuatro Tracker`,
+  }
 }
 
 export default async function PreviewPage({
@@ -168,64 +49,32 @@ export default async function PreviewPage({
   const { source, type, id } = parsed.data
   if (!isValidSourceTypeCombo(source, type)) notFound()
 
-  const data = await loadPreview(source, type, id)
-  if (!data) notFound()
-
-  const mediaType = TYPE_TO_MEDIA_TYPE[type]
-  const medium = TYPE_TO_MEDIUM[type]
-  const synopsisParagraphs = (data.overview ?? '')
-    .split(/\n+/)
-    .map((p) => p.trim())
-    .filter((p) => p.length > 0)
-
-  return (
-    <main className='preview-page'>
-      <Link href='/search' className='preview-back-link'>
-        &lt; BACK TO SEARCH
-      </Link>
-      <section className='preview-hero'>
-        <div className='preview-hero-cover'>
-          {data.posterUrl ? (
-            // Plain <img> rather than next/image — the AniList URLs aren't
-            // listed in next.config.images.remotePatterns, and next/image is
-            // overkill for an ephemeral preview page.
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={data.posterUrl}
-              alt={data.title}
-              className='preview-hero-poster'
-            />
-          ) : (
-            <div className='preview-hero-poster-fallback'>?</div>
-          )}
-        </div>
-        <div className='preview-hero-text'>
-          <p className='preview-hero-medium'>{TYPE_LABEL[type]} · PREVIEW</p>
-          <h1 className='preview-hero-title'>{data.title}</h1>
-          {data.originalTitle ? (
-            <p className='preview-hero-original-title'>{data.originalTitle}</p>
-          ) : null}
-          {data.year !== null ? (
-            <p className='preview-hero-meta'>{data.year}</p>
-          ) : null}
-          <AddToLibraryButton
-            source={source}
-            sourceId={id}
-            type={mediaType}
-            medium={medium}
-          />
-          <p className='preview-hero-source'>
-            Source: {source.toUpperCase()} · ID {id}
-          </p>
-        </div>
-      </section>
-      {synopsisParagraphs.length > 0 ? (
-        <article className='preview-synopsis'>
-          {synopsisParagraphs.map((para, idx) => (
-            <p key={idx}>{para}</p>
-          ))}
-        </article>
-      ) : null}
-    </main>
-  )
+  try {
+    if (source === 'tmdb' && type === 'movie') {
+      return await MoviePreview({ id })
+    }
+    if (source === 'tmdb' && type === 'tv') {
+      return await TvPreview({ id })
+    }
+    if (source === 'anilist' && type === 'anime') {
+      return await AnimePreview({ id })
+    }
+    if (source === 'anilist' && type === 'manga') {
+      return await MangaPreview({ id })
+    }
+  } catch (err) {
+    if (
+      err instanceof TmdbApiError ||
+      err instanceof AnilistApiError ||
+      err instanceof AnilistNotFoundError
+    ) {
+      logger.warn(
+        { event: 'preview.upstream_failed', source, type, id, err },
+        'preview upstream fetch failed; rendering 404',
+      )
+      notFound()
+    }
+    throw err
+  }
+  notFound()
 }

--- a/app/preview/[source]/[type]/[id]/page.tsx
+++ b/app/preview/[source]/[type]/[id]/page.tsx
@@ -1,0 +1,231 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { MediaType } from '@prisma/client'
+import { z } from 'zod'
+import { getMovie, getTv, getImageUrl, TmdbApiError } from '@/lib/api/tmdb'
+import {
+  getMedia,
+  AnilistApiError,
+  AnilistNotFoundError,
+} from '@/lib/api/anilist'
+import { logger } from '@/lib/logger'
+import { AddToLibraryButton } from './AddToLibraryButton'
+
+export const dynamic = 'force-dynamic'
+
+type Medium = 'movies' | 'tv' | 'anime' | 'manga'
+
+const ParamsSchema = z.object({
+  source: z.enum(['tmdb', 'anilist']),
+  type: z.enum(['movie', 'tv', 'anime', 'manga']),
+  id: z.coerce.number().int().positive(),
+})
+
+type Params = z.infer<typeof ParamsSchema>
+
+const TYPE_TO_MEDIA_TYPE: Record<Params['type'], MediaType> = {
+  movie: MediaType.MOVIE,
+  tv: MediaType.TV_SHOW,
+  anime: MediaType.ANIME,
+  manga: MediaType.MANGA,
+}
+
+const TYPE_TO_MEDIUM: Record<Params['type'], Medium> = {
+  movie: 'movies',
+  tv: 'tv',
+  anime: 'anime',
+  manga: 'manga',
+}
+
+const TYPE_LABEL: Record<Params['type'], string> = {
+  movie: 'MOVIE',
+  tv: 'TV',
+  anime: 'ANIME',
+  manga: 'MANGA',
+}
+
+type PreviewData = {
+  title: string
+  originalTitle: string | null
+  year: number | null
+  overview: string | null
+  posterUrl: string | null
+}
+
+// AniList descriptions ship raw HTML even with `asHtml: false`. Same helper
+// as the anime detail page — mirror so legacy + future flows render uniformly.
+function stripAnilistHtml(text: string): string {
+  return text
+    .replace(/<br\s*\/?\s*>/gi, '\n\n')
+    .replace(/<[^>]*>/g, '')
+}
+
+function extractYear(date: string | null | undefined): number | null {
+  if (!date) return null
+  const match = /^(\d{4})/.exec(date)
+  return match ? Number.parseInt(match[1], 10) : null
+}
+
+async function loadPreview(
+  source: Params['source'],
+  type: Params['type'],
+  id: number,
+): Promise<PreviewData | null> {
+  try {
+    if (source === 'tmdb' && type === 'movie') {
+      const movie = await getMovie(id)
+      return {
+        title: movie.title,
+        originalTitle: movie.original_title ?? null,
+        year: extractYear(movie.release_date),
+        overview: movie.overview ?? null,
+        posterUrl: getImageUrl(movie.poster_path, 'w780'),
+      }
+    }
+    if (source === 'tmdb' && type === 'tv') {
+      const tv = await getTv(id)
+      return {
+        title: tv.name,
+        originalTitle: tv.original_name ?? null,
+        year: extractYear(tv.first_air_date),
+        overview: tv.overview ?? null,
+        posterUrl: getImageUrl(tv.poster_path, 'w780'),
+      }
+    }
+    if (source === 'anilist' && (type === 'anime' || type === 'manga')) {
+      const anilistType = type === 'anime' ? 'ANIME' : 'MANGA'
+      const media = await getMedia(id, anilistType)
+      const title =
+        media.title.userPreferred ??
+        media.title.romaji ??
+        media.title.english ??
+        media.title.native ??
+        'Untitled'
+      const native = media.title.native ?? null
+      const year = media.startDate.year
+      const poster =
+        media.coverImage?.extraLarge ??
+        media.coverImage?.large ??
+        media.coverImage?.medium ??
+        null
+      return {
+        title,
+        originalTitle: native !== title ? native : null,
+        year,
+        overview: media.description ? stripAnilistHtml(media.description) : null,
+        posterUrl: poster,
+      }
+    }
+    return null
+  } catch (err) {
+    if (
+      err instanceof TmdbApiError ||
+      err instanceof AnilistApiError ||
+      err instanceof AnilistNotFoundError
+    ) {
+      logger.warn(
+        { event: 'preview.upstream_failed', source, type, id, err },
+        'preview upstream fetch failed; rendering 404',
+      )
+      return null
+    }
+    throw err
+  }
+}
+
+function isValidSourceTypeCombo(
+  source: Params['source'],
+  type: Params['type'],
+): boolean {
+  // tmdb supports movie + tv; anilist supports anime + manga. Other combos
+  // (e.g. tmdb + anime) aren't wired and 404 immediately.
+  if (source === 'tmdb') return type === 'movie' || type === 'tv'
+  if (source === 'anilist') return type === 'anime' || type === 'manga'
+  return false
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ source: string; type: string; id: string }>
+}): Promise<{ title: string }> {
+  const raw = await params
+  const parsed = ParamsSchema.safeParse(raw)
+  if (!parsed.success) return { title: 'PREVIEW · Cuatro Tracker' }
+  const data = await loadPreview(parsed.data.source, parsed.data.type, parsed.data.id)
+  if (!data) return { title: 'PREVIEW NOT FOUND · Cuatro Tracker' }
+  return { title: `${data.title.toUpperCase()} · PREVIEW · Cuatro Tracker` }
+}
+
+export default async function PreviewPage({
+  params,
+}: {
+  params: Promise<{ source: string; type: string; id: string }>
+}) {
+  const raw = await params
+  const parsed = ParamsSchema.safeParse(raw)
+  if (!parsed.success) notFound()
+  const { source, type, id } = parsed.data
+  if (!isValidSourceTypeCombo(source, type)) notFound()
+
+  const data = await loadPreview(source, type, id)
+  if (!data) notFound()
+
+  const mediaType = TYPE_TO_MEDIA_TYPE[type]
+  const medium = TYPE_TO_MEDIUM[type]
+  const synopsisParagraphs = (data.overview ?? '')
+    .split(/\n+/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+
+  return (
+    <main className='preview-page'>
+      <Link href='/search' className='preview-back-link'>
+        &lt; BACK TO SEARCH
+      </Link>
+      <section className='preview-hero'>
+        <div className='preview-hero-cover'>
+          {data.posterUrl ? (
+            // Plain <img> rather than next/image — the AniList URLs aren't
+            // listed in next.config.images.remotePatterns, and next/image is
+            // overkill for an ephemeral preview page.
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={data.posterUrl}
+              alt={data.title}
+              className='preview-hero-poster'
+            />
+          ) : (
+            <div className='preview-hero-poster-fallback'>?</div>
+          )}
+        </div>
+        <div className='preview-hero-text'>
+          <p className='preview-hero-medium'>{TYPE_LABEL[type]} · PREVIEW</p>
+          <h1 className='preview-hero-title'>{data.title}</h1>
+          {data.originalTitle ? (
+            <p className='preview-hero-original-title'>{data.originalTitle}</p>
+          ) : null}
+          {data.year !== null ? (
+            <p className='preview-hero-meta'>{data.year}</p>
+          ) : null}
+          <AddToLibraryButton
+            source={source}
+            sourceId={id}
+            type={mediaType}
+            medium={medium}
+          />
+          <p className='preview-hero-source'>
+            Source: {source.toUpperCase()} · ID {id}
+          </p>
+        </div>
+      </section>
+      {synopsisParagraphs.length > 0 ? (
+        <article className='preview-synopsis'>
+          {synopsisParagraphs.map((para, idx) => (
+            <p key={idx}>{para}</p>
+          ))}
+        </article>
+      ) : null}
+    </main>
+  )
+}

--- a/components/molecules/EpisodeChecklist/EpisodeChecklist.tsx
+++ b/components/molecules/EpisodeChecklist/EpisodeChecklist.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { EpisodeWatchToggle } from '@/components/molecules/EpisodeWatchToggle'
+
+export type EpisodeChecklistProps = {
+  mediaItemId: string
+  episodeCount: number
+  progress: number
+  onToggleEpisode: (episodeNumber: number, nextChecked: boolean) => void
+}
+
+export function EpisodeChecklist({
+  mediaItemId,
+  episodeCount,
+  progress,
+  onToggleEpisode,
+}: EpisodeChecklistProps) {
+  if (episodeCount <= 0) return null
+
+  const rows = Array.from({ length: episodeCount }, (_, idx) => idx + 1)
+
+  return (
+    <ul
+      className='episode-checklist'
+      data-media-item-id={mediaItemId}
+      aria-label='Episode checklist'
+    >
+      {rows.map((n) => {
+        const isWatched = n <= progress
+        return (
+          <li
+            key={n}
+            className='episode-checklist-row'
+            data-checked={isWatched ? 'true' : 'false'}
+          >
+            <span className='episode-checklist-row-code'>EP {n}</span>
+            <span className='episode-checklist-row-meta' aria-hidden='true' />
+            <EpisodeWatchToggle
+              checked={isWatched}
+              label={`Mark episode ${n} watched`}
+              onToggle={() => onToggleEpisode(n, !isWatched)}
+            />
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/components/molecules/EpisodeChecklist/__tests__/EpisodeChecklist.test.tsx
+++ b/components/molecules/EpisodeChecklist/__tests__/EpisodeChecklist.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { EpisodeChecklist } from '@/components/molecules/EpisodeChecklist'
+
+describe('EpisodeChecklist', () => {
+  it('renders 1..N rows for the given episodeCount', () => {
+    render(
+      <EpisodeChecklist
+        mediaItemId='anime-1'
+        episodeCount={4}
+        progress={0}
+        onToggleEpisode={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('EP 1')).toBeInTheDocument()
+    expect(screen.getByText('EP 2')).toBeInTheDocument()
+    expect(screen.getByText('EP 3')).toBeInTheDocument()
+    expect(screen.getByText('EP 4')).toBeInTheDocument()
+    expect(screen.queryByText('EP 5')).not.toBeInTheDocument()
+  })
+
+  it('marks rows where n <= progress as checked, rows where n > progress as unchecked', () => {
+    render(
+      <EpisodeChecklist
+        mediaItemId='anime-1'
+        episodeCount={5}
+        progress={3}
+        onToggleEpisode={vi.fn()}
+      />,
+    )
+    const toggles = screen.getAllByRole('checkbox')
+    expect(toggles).toHaveLength(5)
+    expect(toggles[0]?.getAttribute('aria-checked')).toBe('true') // EP 1
+    expect(toggles[1]?.getAttribute('aria-checked')).toBe('true') // EP 2
+    expect(toggles[2]?.getAttribute('aria-checked')).toBe('true') // EP 3
+    expect(toggles[3]?.getAttribute('aria-checked')).toBe('false') // EP 4
+    expect(toggles[4]?.getAttribute('aria-checked')).toBe('false') // EP 5
+  })
+
+  it('fires onToggleEpisode with n and nextChecked=true when clicking an unwatched row', () => {
+    const onToggle = vi.fn()
+    render(
+      <EpisodeChecklist
+        mediaItemId='anime-1'
+        episodeCount={3}
+        progress={1}
+        onToggleEpisode={onToggle}
+      />,
+    )
+    // Click EP 3 (currently unwatched).
+    const ep3 = screen.getByRole('checkbox', { name: 'Mark episode 3 watched' })
+    fireEvent.click(ep3)
+    expect(onToggle).toHaveBeenCalledTimes(1)
+    expect(onToggle).toHaveBeenCalledWith(3, true)
+  })
+
+  it('fires onToggleEpisode with n and nextChecked=false when clicking a watched row', () => {
+    const onToggle = vi.fn()
+    render(
+      <EpisodeChecklist
+        mediaItemId='anime-1'
+        episodeCount={5}
+        progress={5}
+        onToggleEpisode={onToggle}
+      />,
+    )
+    // Click EP 5 (currently watched).
+    const ep5 = screen.getByRole('checkbox', { name: 'Mark episode 5 watched' })
+    fireEvent.click(ep5)
+    expect(onToggle).toHaveBeenCalledTimes(1)
+    expect(onToggle).toHaveBeenCalledWith(5, false)
+  })
+
+  it('renders nothing when episodeCount is 0', () => {
+    const { container } = render(
+      <EpisodeChecklist
+        mediaItemId='anime-1'
+        episodeCount={0}
+        progress={0}
+        onToggleEpisode={vi.fn()}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('exposes mediaItemId via a data attribute (for e2e + analytics selectors)', () => {
+    render(
+      <EpisodeChecklist
+        mediaItemId='anime-frieren'
+        episodeCount={2}
+        progress={1}
+        onToggleEpisode={vi.fn()}
+      />,
+    )
+    const list = screen.getByRole('list')
+    expect(list.getAttribute('data-media-item-id')).toBe('anime-frieren')
+  })
+})

--- a/components/molecules/EpisodeChecklist/index.ts
+++ b/components/molecules/EpisodeChecklist/index.ts
@@ -1,0 +1,4 @@
+export {
+  EpisodeChecklist,
+  type EpisodeChecklistProps,
+} from './EpisodeChecklist'

--- a/components/molecules/SearchResultRow/SearchResultRow.tsx
+++ b/components/molecules/SearchResultRow/SearchResultRow.tsx
@@ -1,6 +1,12 @@
 'use client'
 
-import { type KeyboardEvent, useMemo, useRef, useEffect } from 'react'
+import {
+  type KeyboardEvent,
+  type MouseEvent,
+  useMemo,
+  useRef,
+  useEffect,
+} from 'react'
 import { CRTPixelButton } from '@/components/atoms/CRTPixelButton'
 import { PhosphorLED, type PhosphorLEDStatus } from '@/components/atoms/PhosphorLED'
 import { FramedCover } from '@/components/molecules/FramedCover'
@@ -82,6 +88,14 @@ export function SearchResultRow({
     }
   }
 
+  function handleRowClick(event: MouseEvent<HTMLLIElement>) {
+    // The action button has its own onClick; let it handle clicks landing
+    // inside `.sr-action` so we don't double-fire on the same press.
+    const target = event.target as HTMLElement | null
+    if (target?.closest('.sr-action')) return
+    onOpenDetail()
+  }
+
   const actionLabel = addingPending
     ? '> ADDING…'
     : inLibrary
@@ -98,6 +112,7 @@ export function SearchResultRow({
       aria-selected={isFocused}
       tabIndex={isFocused ? 0 : -1}
       onKeyDown={handleKeyDown}
+      onClick={handleRowClick}
     >
       <div className='sr-cover'>
         {posterUrl ? (

--- a/components/molecules/SearchResultRow/__tests__/SearchResultRow.test.tsx
+++ b/components/molecules/SearchResultRow/__tests__/SearchResultRow.test.tsx
@@ -213,4 +213,45 @@ describe('SearchResultRow', () => {
     )
     expect(container.querySelector('.sr-cover-fallback')?.textContent).toBe('?')
   })
+
+  it('fires onOpenDetail when the row body is clicked (outside the action button)', () => {
+    const onOpenDetail = vi.fn()
+    const { container } = render(
+      <SearchResultRow
+        result={makeResult()}
+        inLibrary={true}
+        watchStatus='PLAN_TO_WATCH'
+        isFocused={false}
+        addingPending={false}
+        onAdd={() => {}}
+        onOpenDetail={onOpenDetail}
+      />,
+    )
+    const title = container.querySelector('.sr-title') as HTMLElement
+    fireEvent.click(title)
+    expect(onOpenDetail).toHaveBeenCalledOnce()
+  })
+
+  it('does NOT double-fire onOpenDetail when the action button is clicked (only the button handler runs)', () => {
+    const onOpenDetail = vi.fn()
+    const onAdd = vi.fn()
+    render(
+      <SearchResultRow
+        result={makeResult()}
+        inLibrary={true}
+        watchStatus='PLAN_TO_WATCH'
+        isFocused={false}
+        addingPending={false}
+        onAdd={onAdd}
+        onOpenDetail={onOpenDetail}
+      />,
+    )
+    const button = screen.getByRole('button', { name: /IN LIBRARY/ })
+    fireEvent.click(button)
+    // Button click bubbles to the <li>, but the row-click handler exits early
+    // when the click target is inside `.sr-action`. So onOpenDetail fires
+    // exactly once (from the button handler), not twice.
+    expect(onOpenDetail).toHaveBeenCalledOnce()
+    expect(onAdd).not.toHaveBeenCalled()
+  })
 })

--- a/components/organisms/CurrentlyActiveCarousel/CurrentlyActiveCarousel.tsx
+++ b/components/organisms/CurrentlyActiveCarousel/CurrentlyActiveCarousel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
 import { MediaType } from '@prisma/client'
 import { CRTBezel } from '@/components/molecules/CRTBezel'
 import { EmptyStateCard } from '@/components/molecules/EmptyStateCard'
@@ -33,6 +34,24 @@ const MEDIA_TYPE_LABEL: Record<MediaType, string> = {
   ANIME: 'ANIME',
   MANGA: 'MANGA',
   GAME: 'GAME',
+}
+
+function detailRouteFor(mediaType: MediaType, mediaItemId: string): string | null {
+  switch (mediaType) {
+    case MediaType.MOVIE:
+      return `/movies/${mediaItemId}`
+    case MediaType.TV_SHOW:
+      return `/tv/${mediaItemId}`
+    case MediaType.ANIME:
+      return `/anime/${mediaItemId}`
+    case MediaType.MANGA:
+      return `/manga/${mediaItemId}`
+    case MediaType.GAME:
+      return `/games/${mediaItemId}`
+    case MediaType.TV_EPISODE:
+    default:
+      return null
+  }
 }
 
 function usePrefersReducedMotion(): boolean {
@@ -111,6 +130,7 @@ export function CurrentlyActiveCarousel({
   const posterUrl =
     getImageUrl(active.posterPath, 'w342') ??
     'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>'
+  const detailRoute = detailRouteFor(active.mediaType, active.mediaItemId)
 
   return (
     <section className='dash-hero cac' aria-label='Currently active'>
@@ -127,6 +147,13 @@ export function CurrentlyActiveCarousel({
             }
           }}
         >
+          {detailRoute !== null ? (
+            <Link
+              href={detailRoute}
+              className='cac-screen-link'
+              aria-label={`Open ${active.title} detail`}
+            />
+          ) : null}
           <div className='cac-cover'>
             <FramedCover
               medium={medium}

--- a/components/organisms/CurrentlyActiveCarousel/CurrentlyActiveCarousel.tsx
+++ b/components/organisms/CurrentlyActiveCarousel/CurrentlyActiveCarousel.tsx
@@ -9,6 +9,7 @@ import { FramedCover } from '@/components/molecules/FramedCover'
 import type { Medium } from '@/components/molecules/FramedCover/media-registry'
 import { useChannelFlipNavigate } from '@/components/molecules/ChannelFlipTransition'
 import { getImageUrl } from '@/lib/api/tmdb-images'
+import { detailRouteFor } from '@/lib/detail-route'
 import type { LibraryItem } from '@/lib/types/library'
 
 export type CurrentlyActiveCarouselProps = {
@@ -36,23 +37,6 @@ const MEDIA_TYPE_LABEL: Record<MediaType, string> = {
   GAME: 'GAME',
 }
 
-function detailRouteFor(mediaType: MediaType, mediaItemId: string): string | null {
-  switch (mediaType) {
-    case MediaType.MOVIE:
-      return `/movies/${mediaItemId}`
-    case MediaType.TV_SHOW:
-      return `/tv/${mediaItemId}`
-    case MediaType.ANIME:
-      return `/anime/${mediaItemId}`
-    case MediaType.MANGA:
-      return `/manga/${mediaItemId}`
-    case MediaType.GAME:
-      return `/games/${mediaItemId}`
-    case MediaType.TV_EPISODE:
-    default:
-      return null
-  }
-}
 
 function usePrefersReducedMotion(): boolean {
   const [reduced, setReduced] = useState(false)
@@ -130,7 +114,7 @@ export function CurrentlyActiveCarousel({
   const posterUrl =
     getImageUrl(active.posterPath, 'w342') ??
     'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>'
-  const detailRoute = detailRouteFor(active.mediaType, active.mediaItemId)
+  const detailRoute = detailRouteFor(active)
 
   return (
     <section className='dash-hero cac' aria-label='Currently active'>

--- a/components/organisms/DetailHero/DetailHero.tsx
+++ b/components/organisms/DetailHero/DetailHero.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import type { WatchStatus } from '@prisma/client'
 import { FramedCover } from '@/components/molecules/FramedCover/FramedCover'
 import { BitmapText } from '@/components/atoms/BitmapText/BitmapText'
@@ -10,14 +11,20 @@ import { SendToQbtButton } from '@/components/molecules/SendToQbtButton'
 import { WatchOnImdbButton } from '@/components/molecules/WatchOnImdbButton'
 
 export type DetailHeroProps = {
-  mediaItemId: string
+  // Library-state props. Both optional so preview pages (which have no
+  // MediaItem row yet) can render the same hero shell with an
+  // `actionsOverride` slot instead.
+  mediaItemId?: string
+  currentStatus?: WatchStatus
+  // When provided, replaces the default WatchStatusControl in the actions
+  // row. Used by /preview/... to render an ADD TO LIBRARY button.
+  actionsOverride?: ReactNode
   medium: 'movies' | 'tv' | 'anime' | 'manga' | 'games'
   mediumLabel: string
   title: string
   originalTitle: string | null
   posterUrl: string | null
   metadata: MetadataItem[]
-  currentStatus: WatchStatus
   imdbId: string | null
   showQbtButton: boolean
 }
@@ -31,9 +38,21 @@ export function DetailHero({
   posterUrl,
   metadata,
   currentStatus,
+  actionsOverride,
   imdbId,
   showQbtButton,
 }: DetailHeroProps) {
+  // Preview pages pass actionsOverride; detail pages pass currentStatus +
+  // mediaItemId. Both shapes converge on the same hero layout below.
+  const primaryAction =
+    actionsOverride ??
+    (mediaItemId !== undefined && currentStatus !== undefined ? (
+      <WatchStatusControl
+        mediaItemId={mediaItemId}
+        currentStatus={currentStatus}
+      />
+    ) : null)
+
   return (
     <section className='detail-hero' aria-label='Item header'>
       <div className='detail-hero-cover'>
@@ -54,10 +73,7 @@ export function DetailHero({
         ) : null}
         <MetadataRow items={metadata} />
         <div className='detail-hero-actions'>
-          <WatchStatusControl
-            mediaItemId={mediaItemId}
-            currentStatus={currentStatus}
-          />
+          {primaryAction}
           <div className='detail-hero-action-buttons'>
             {showQbtButton ? <SendToQbtButton /> : null}
             <WatchOnImdbButton imdbId={imdbId} />

--- a/components/organisms/GlobalSearch/GlobalSearch.tsx
+++ b/components/organisms/GlobalSearch/GlobalSearch.tsx
@@ -138,6 +138,24 @@ function buildLibraryKeySet(items: readonly LibraryItem[]): Set<string> {
   return set
 }
 
+/* Map "<source>:<sourceId>" → MediaItem.id for the same library snapshot.
+ * Detail-page routes are keyed by MediaItem.id (the Prisma row), NOT the
+ * external source id. handleOpenDetail uses this to navigate correctly for
+ * in-library results; absence from the map means "not in library, no detail
+ * page to open". */
+function buildLibraryMediaItemMap(
+  items: readonly LibraryItem[],
+): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const it of items) {
+    if (it.tmdbId !== null) map.set(`tmdb:${it.tmdbId}`, it.mediaItemId)
+    if (it.anilistId !== null) map.set(`anilist:${it.anilistId}`, it.mediaItemId)
+    if (it.igdbId !== null) map.set(`igdb:${it.igdbId}`, it.mediaItemId)
+    if (it.steamId !== null) map.set(`steam:${it.steamId}`, it.mediaItemId)
+  }
+  return map
+}
+
 async function addToLibrary(body: AddBody): Promise<unknown> {
   const res = await fetch('/api/media', {
     method: 'POST',
@@ -182,6 +200,11 @@ export function GlobalSearch() {
 
   const libraryKeys = useMemo(
     () => buildLibraryKeySet(libraryQuery.data?.items ?? []),
+    [libraryQuery.data?.items],
+  )
+
+  const libraryMediaItemMap = useMemo(
+    () => buildLibraryMediaItemMap(libraryQuery.data?.items ?? []),
     [libraryQuery.data?.items],
   )
 
@@ -287,10 +310,18 @@ export function GlobalSearch() {
     (result: UnifiedSearchResult) => {
       const sourceId = getSourceId(result)
       if (sourceId === undefined) return
-      const path = `/${COVER_PATH_PREFIX[result.type]}/${sourceId}`
+      // Detail pages route by MediaItem.id (Prisma row), not by the external
+      // source id. Resolve via the in-memory library map; for results that
+      // aren't in the library yet there's no detail page to open, so the
+      // action is a no-op (the row's CRTPixelButton handles the explicit ADD).
+      const mediaItemId = libraryMediaItemMap.get(
+        `${result.primary_source}:${sourceId}`,
+      )
+      if (mediaItemId === undefined) return
+      const path = `/${COVER_PATH_PREFIX[result.type]}/${mediaItemId}`
       router.push(path)
     },
-    [router],
+    [router, libraryMediaItemMap],
   )
 
   const handleRetry = useCallback(() => {

--- a/components/organisms/GlobalSearch/GlobalSearch.tsx
+++ b/components/organisms/GlobalSearch/GlobalSearch.tsx
@@ -310,16 +310,28 @@ export function GlobalSearch() {
     (result: UnifiedSearchResult) => {
       const sourceId = getSourceId(result)
       if (sourceId === undefined) return
-      // Detail pages route by MediaItem.id (Prisma row), not by the external
-      // source id. Resolve via the in-memory library map; for results that
-      // aren't in the library yet there's no detail page to open, so the
-      // action is a no-op (the row's CRTPixelButton handles the explicit ADD).
+      // In-library: navigate to the canonical detail page (routes by
+      // MediaItem.id). Not-in-library: navigate to a preview page that
+      // fetches the source data on-the-fly + offers an ADD button. The
+      // preview accepts only TMDB + AniList for now (IGDB / Steam adapters
+      // exist but lack a getById fetch path; those become no-ops).
       const mediaItemId = libraryMediaItemMap.get(
         `${result.primary_source}:${sourceId}`,
       )
-      if (mediaItemId === undefined) return
-      const path = `/${COVER_PATH_PREFIX[result.type]}/${mediaItemId}`
-      router.push(path)
+      if (mediaItemId !== undefined) {
+        router.push(`/${COVER_PATH_PREFIX[result.type]}/${mediaItemId}`)
+        return
+      }
+      if (
+        (result.primary_source === 'tmdb' &&
+          (result.type === 'movie' || result.type === 'tv')) ||
+        (result.primary_source === 'anilist' &&
+          (result.type === 'anime' || result.type === 'manga'))
+      ) {
+        router.push(
+          `/preview/${result.primary_source}/${result.type}/${sourceId}`,
+        )
+      }
     },
     [router, libraryMediaItemMap],
   )

--- a/components/organisms/GlobalSearch/__tests__/GlobalSearch.test.tsx
+++ b/components/organisms/GlobalSearch/__tests__/GlobalSearch.test.tsx
@@ -480,9 +480,10 @@ describe('GlobalSearch', () => {
     expect(pushMock).toHaveBeenCalledWith('/movies/m-fightclub')
   })
 
-  it('Enter on a focused NOT-in-library row does not navigate (no detail page yet)', async () => {
-    // For results that aren't in the library, there's no MediaItem.id to route
-    // to. handleOpenDetail returns early; the add button is the explicit path.
+  it('Enter on a focused NOT-in-library row navigates to /preview/<source>/<type>/<sourceId>', async () => {
+    // For results that aren't in the library, the canonical detail page
+    // doesn't exist (it requires a MediaItem.id). The preview route fetches
+    // the source data on-the-fly and offers an ADD button.
     vi.stubGlobal(
       'fetch',
       routedFetchMock({
@@ -505,6 +506,7 @@ describe('GlobalSearch', () => {
     fireEvent.keyDown(root, { key: 'ArrowDown' })
     fireEvent.keyDown(root, { key: 'Enter' })
 
-    expect(pushMock).not.toHaveBeenCalled()
+    // fightResults() puts Fight Club first: source=tmdb, type=movie, tmdb_id=550.
+    expect(pushMock).toHaveBeenCalledWith('/preview/tmdb/movie/550')
   })
 })

--- a/components/organisms/GlobalSearch/__tests__/GlobalSearch.test.tsx
+++ b/components/organisms/GlobalSearch/__tests__/GlobalSearch.test.tsx
@@ -419,7 +419,70 @@ describe('GlobalSearch', () => {
     expect(addButtons).toHaveLength(1)
   })
 
-  it('Enter on a focused row navigates to the detail route stub', async () => {
+  it('Enter on a focused in-library row navigates to /<medium>/<MediaItem.id>', async () => {
+    // Detail pages route by MediaItem.id, not by the external source id. The
+    // library subscription provides the mapping; the bundle-2 hotfix uses that
+    // map to construct the correct URL.
+    vi.stubGlobal(
+      'fetch',
+      routedFetchMock({
+        library: () =>
+          new Response(
+            JSON.stringify({
+              items: [
+                {
+                  id: 'entry-1',
+                  mediaItemId: 'm-fightclub',
+                  mediaType: 'MOVIE',
+                  status: 'PLAN_TO_WATCH',
+                  title: 'Fight Club',
+                  posterPath: '/poster.jpg',
+                  year: 1999,
+                  releaseDate: '1999-10-15T00:00:00.000Z',
+                  progressLabel: null,
+                  progressPct: null,
+                  sourceLabel: 'From TMDB',
+                  tmdbId: 550,
+                  anilistId: null,
+                  igdbId: null,
+                  steamId: null,
+                  createdAt: '2026-05-10T00:00:00.000Z',
+                  updatedAt: '2026-05-10T00:00:00.000Z',
+                },
+              ],
+            }),
+            { status: 200 },
+          ),
+        search: () =>
+          new Response(
+            JSON.stringify({ results: fightResults(), partialFailure: false }),
+            { status: 200 },
+          ),
+      }),
+    )
+    const { container } = renderGS()
+    flushQuery('fight')
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { name: 'Fight Club' }),
+      ).toBeInTheDocument(),
+    )
+    // Wait for the library subscription to populate before pressing Enter,
+    // otherwise handleOpenDetail no-ops as if Fight Club weren't in the lib.
+    await waitFor(() => {
+      expect(screen.getByText('✓ IN LIBRARY')).toBeInTheDocument()
+    })
+
+    const root = container.querySelector('.gs')!
+    fireEvent.keyDown(root, { key: 'ArrowDown' })
+    fireEvent.keyDown(root, { key: 'Enter' })
+
+    expect(pushMock).toHaveBeenCalledWith('/movies/m-fightclub')
+  })
+
+  it('Enter on a focused NOT-in-library row does not navigate (no detail page yet)', async () => {
+    // For results that aren't in the library, there's no MediaItem.id to route
+    // to. handleOpenDetail returns early; the add button is the explicit path.
     vi.stubGlobal(
       'fetch',
       routedFetchMock({
@@ -442,6 +505,6 @@ describe('GlobalSearch', () => {
     fireEvent.keyDown(root, { key: 'ArrowDown' })
     fireEvent.keyDown(root, { key: 'Enter' })
 
-    expect(pushMock).toHaveBeenCalledWith('/movies/550')
+    expect(pushMock).not.toHaveBeenCalled()
   })
 })

--- a/components/organisms/HorizontalCoverScroller/HorizontalCoverScroller.tsx
+++ b/components/organisms/HorizontalCoverScroller/HorizontalCoverScroller.tsx
@@ -7,28 +7,8 @@ import { EmptyStateCard } from '@/components/molecules/EmptyStateCard'
 import { FramedCover } from '@/components/molecules/FramedCover'
 import type { Medium } from '@/components/molecules/FramedCover/media-registry'
 import { getImageUrl } from '@/lib/api/tmdb-images'
+import { detailRouteFor } from '@/lib/detail-route'
 import type { LibraryItem } from '@/lib/types/library'
-
-function detailRouteFor(item: LibraryItem): string | null {
-  // TV episodes have no per-episode detail page; they're traversed via the
-  // parent show's /tv/[id] page. The dashboard rarely shows episode rows,
-  // but when it does we render the cell without a navigation target.
-  switch (item.mediaType) {
-    case MediaType.MOVIE:
-      return `/movies/${item.mediaItemId}`
-    case MediaType.TV_SHOW:
-      return `/tv/${item.mediaItemId}`
-    case MediaType.ANIME:
-      return `/anime/${item.mediaItemId}`
-    case MediaType.MANGA:
-      return `/manga/${item.mediaItemId}`
-    case MediaType.GAME:
-      return `/games/${item.mediaItemId}`
-    case MediaType.TV_EPISODE:
-    default:
-      return null
-  }
-}
 
 export type HorizontalCoverScrollerProps = {
   items: LibraryItem[]

--- a/components/organisms/HorizontalCoverScroller/HorizontalCoverScroller.tsx
+++ b/components/organisms/HorizontalCoverScroller/HorizontalCoverScroller.tsx
@@ -1,12 +1,34 @@
 'use client'
 
-import { useCallback, useRef, type KeyboardEvent } from 'react'
+import { useCallback, useRef, type KeyboardEvent, type ReactNode } from 'react'
+import Link from 'next/link'
 import { MediaType } from '@prisma/client'
 import { EmptyStateCard } from '@/components/molecules/EmptyStateCard'
 import { FramedCover } from '@/components/molecules/FramedCover'
 import type { Medium } from '@/components/molecules/FramedCover/media-registry'
 import { getImageUrl } from '@/lib/api/tmdb-images'
 import type { LibraryItem } from '@/lib/types/library'
+
+function detailRouteFor(item: LibraryItem): string | null {
+  // TV episodes have no per-episode detail page; they're traversed via the
+  // parent show's /tv/[id] page. The dashboard rarely shows episode rows,
+  // but when it does we render the cell without a navigation target.
+  switch (item.mediaType) {
+    case MediaType.MOVIE:
+      return `/movies/${item.mediaItemId}`
+    case MediaType.TV_SHOW:
+      return `/tv/${item.mediaItemId}`
+    case MediaType.ANIME:
+      return `/anime/${item.mediaItemId}`
+    case MediaType.MANGA:
+      return `/manga/${item.mediaItemId}`
+    case MediaType.GAME:
+      return `/games/${item.mediaItemId}`
+    case MediaType.TV_EPISODE:
+    default:
+      return null
+  }
+}
 
 export type HorizontalCoverScrollerProps = {
   items: LibraryItem[]
@@ -54,7 +76,11 @@ export function HorizontalCoverScroller({
   const focusCardAt = useCallback((idx: number) => {
     const list = listRef.current
     if (list === null) return
-    const cards = list.querySelectorAll<HTMLLIElement>('li.hcs-cell')
+    // Focusable element is now the inner .hcs-cell-link (a Link for routable
+    // media types; a div for TV_EPISODE which has no detail page).
+    const cards = list.querySelectorAll<HTMLElement>(
+      'li.hcs-cell > .hcs-cell-link',
+    )
     const target = cards.item(idx)
     if (target === null) return
     target.focus()
@@ -67,7 +93,9 @@ export function HorizontalCoverScroller({
       if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
       const list = listRef.current
       if (list === null) return
-      const cards = Array.from(list.querySelectorAll<HTMLLIElement>('li.hcs-cell'))
+      const cards = Array.from(
+        list.querySelectorAll<HTMLElement>('li.hcs-cell > .hcs-cell-link'),
+      )
       const currentIdx = cards.findIndex((c) => c === document.activeElement)
 
       // Entry case: keyboard nav reached the band from outside via Tab, then
@@ -115,12 +143,9 @@ export function HorizontalCoverScroller({
         {items.map((item, i) => {
           const medium = MEDIA_TYPE_TO_MEDIUM[item.mediaType]
           const posterUrl = getImageUrl(item.posterPath, 'w342') ?? POSTER_PLACEHOLDER
-          return (
-            <li
-              key={item.id}
-              className='hcs-cell'
-              tabIndex={i === 0 ? 0 : -1}
-            >
+          const route = detailRouteFor(item)
+          const inner: ReactNode = (
+            <>
               <div className='hcs-cell-frame'>
                 <FramedCover
                   medium={medium}
@@ -131,6 +156,23 @@ export function HorizontalCoverScroller({
               </div>
               <p className='hcs-cell-title'>{item.title}</p>
               <p className='hcs-cell-meta'>{metaLine(item)}</p>
+            </>
+          )
+          return (
+            <li key={item.id} className='hcs-cell'>
+              {route !== null ? (
+                <Link
+                  href={route}
+                  className='hcs-cell-link'
+                  tabIndex={i === 0 ? 0 : -1}
+                >
+                  {inner}
+                </Link>
+              ) : (
+                <div className='hcs-cell-link' tabIndex={i === 0 ? 0 : -1}>
+                  {inner}
+                </div>
+              )}
             </li>
           )
         })}

--- a/components/organisms/HorizontalCoverScroller/__tests__/HorizontalCoverScroller.test.tsx
+++ b/components/organisms/HorizontalCoverScroller/__tests__/HorizontalCoverScroller.test.tsx
@@ -25,6 +25,15 @@ const baseItem = (overrides: Partial<LibraryItem> = {}): LibraryItem => ({
   ...overrides,
 })
 
+// Returns the focusable inner link (or non-link content div for media types
+// without a detail route, e.g. TV_EPISODE) inside the i-th listitem. The
+// roving tabindex + arrow-key nav target this element, not the outer <li>.
+function cellLinks(list: HTMLElement): HTMLElement[] {
+  return Array.from(
+    list.querySelectorAll<HTMLElement>('li.hcs-cell > .hcs-cell-link'),
+  )
+}
+
 describe('HorizontalCoverScroller', () => {
   it('renders one cell per item with title + meta', () => {
     const items: LibraryItem[] = [
@@ -74,7 +83,7 @@ describe('HorizontalCoverScroller', () => {
     expect(screen.getByText('Items you add appear here.')).toBeInTheDocument()
   })
 
-  it('only the first cell is tab-focusable initially (roving tabindex)', () => {
+  it('only the first cell-link is tab-focusable initially (roving tabindex)', () => {
     const items: LibraryItem[] = [
       baseItem({ id: 'a' }),
       baseItem({ id: 'b' }),
@@ -88,13 +97,13 @@ describe('HorizontalCoverScroller', () => {
       />,
     )
     const list = screen.getByRole('list')
-    const cells = within(list).getAllByRole('listitem')
-    expect(cells[0]).toHaveAttribute('tabindex', '0')
-    expect(cells[1]).toHaveAttribute('tabindex', '-1')
-    expect(cells[2]).toHaveAttribute('tabindex', '-1')
+    const links = cellLinks(list)
+    expect(links[0]).toHaveAttribute('tabindex', '0')
+    expect(links[1]).toHaveAttribute('tabindex', '-1')
+    expect(links[2]).toHaveAttribute('tabindex', '-1')
   })
 
-  it('ArrowRight on the first cell moves focus to the second cell', () => {
+  it('ArrowRight on the first cell moves focus to the second cell-link', () => {
     const items: LibraryItem[] = [
       baseItem({ id: 'a' }),
       baseItem({ id: 'b' }),
@@ -108,14 +117,14 @@ describe('HorizontalCoverScroller', () => {
       />,
     )
     const list = screen.getByRole('list')
-    const cells = within(list).getAllByRole('listitem')
-    cells[0].focus()
-    expect(cells[0]).toHaveFocus()
+    const links = cellLinks(list)
+    links[0].focus()
+    expect(links[0]).toHaveFocus()
     fireEvent.keyDown(list, { key: 'ArrowRight' })
-    expect(cells[1]).toHaveFocus()
+    expect(links[1]).toHaveFocus()
   })
 
-  it('ArrowLeft on the second cell moves focus back to the first', () => {
+  it('ArrowLeft on the second cell-link moves focus back to the first', () => {
     const items: LibraryItem[] = [
       baseItem({ id: 'a' }),
       baseItem({ id: 'b' }),
@@ -128,13 +137,13 @@ describe('HorizontalCoverScroller', () => {
       />,
     )
     const list = screen.getByRole('list')
-    const cells = within(list).getAllByRole('listitem')
-    cells[1].focus()
+    const links = cellLinks(list)
+    links[1].focus()
     fireEvent.keyDown(list, { key: 'ArrowLeft' })
-    expect(cells[0]).toHaveFocus()
+    expect(links[0]).toHaveFocus()
   })
 
-  it('ArrowRight at last cell does nothing (no wrap)', () => {
+  it('ArrowRight at last cell-link does nothing (no wrap)', () => {
     const items: LibraryItem[] = [baseItem({ id: 'a' }), baseItem({ id: 'b' })]
     render(
       <HorizontalCoverScroller
@@ -144,13 +153,13 @@ describe('HorizontalCoverScroller', () => {
       />,
     )
     const list = screen.getByRole('list')
-    const cells = within(list).getAllByRole('listitem')
-    cells[1].focus()
+    const links = cellLinks(list)
+    links[1].focus()
     fireEvent.keyDown(list, { key: 'ArrowRight' })
-    expect(cells[1]).toHaveFocus()
+    expect(links[1]).toHaveFocus()
   })
 
-  it('ArrowRight with focus outside (currentIdx === -1) lands focus on the first cell', () => {
+  it('ArrowRight with focus outside (currentIdx === -1) lands focus on the first cell-link', () => {
     const items: LibraryItem[] = [
       baseItem({ id: 'a' }),
       baseItem({ id: 'b' }),
@@ -164,10 +173,10 @@ describe('HorizontalCoverScroller', () => {
       />,
     )
     const list = screen.getByRole('list')
-    const cells = within(list).getAllByRole('listitem')
+    const links = cellLinks(list)
     // Note: nothing is focused yet; fire arrow event directly on the ul.
     fireEvent.keyDown(list, { key: 'ArrowRight' })
-    expect(cells[0]).toHaveFocus()
+    expect(links[0]).toHaveFocus()
   })
 
   it('boundary ArrowKey calls preventDefault so the overflow-x container does not scroll', () => {
@@ -180,10 +189,45 @@ describe('HorizontalCoverScroller', () => {
       />,
     )
     const list = screen.getByRole('list')
-    const cells = within(list).getAllByRole('listitem')
-    cells[1].focus()
+    const links = cellLinks(list)
+    links[1].focus()
     const evt = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true })
     list.dispatchEvent(evt)
     expect(evt.defaultPrevented).toBe(true)
+  })
+
+  it('cell-link is a <Link> targeting /<medium>/<mediaItemId> for routable media types', () => {
+    const items: LibraryItem[] = [
+      baseItem({ id: 'a', mediaItemId: 'm-movie', mediaType: MediaType.MOVIE }),
+      baseItem({ id: 'b', mediaItemId: 'm-tv', mediaType: MediaType.TV_SHOW }),
+      baseItem({ id: 'c', mediaItemId: 'm-anime', mediaType: MediaType.ANIME }),
+    ]
+    render(
+      <HorizontalCoverScroller items={items} emptyMessage='X' ariaLabel='X' />,
+    )
+    const list = screen.getByRole('list')
+    const links = cellLinks(list)
+    expect(links[0].getAttribute('href')).toBe('/movies/m-movie')
+    expect(links[1].getAttribute('href')).toBe('/tv/m-tv')
+    expect(links[2].getAttribute('href')).toBe('/anime/m-anime')
+  })
+
+  it('renders a non-link content div for TV_EPISODE (no per-episode detail route)', () => {
+    const items: LibraryItem[] = [
+      baseItem({
+        id: 'ep-1',
+        mediaItemId: 'm-ep',
+        mediaType: MediaType.TV_EPISODE,
+      }),
+    ]
+    render(
+      <HorizontalCoverScroller items={items} emptyMessage='X' ariaLabel='X' />,
+    )
+    const list = screen.getByRole('list')
+    const links = cellLinks(list)
+    expect(links).toHaveLength(1)
+    // Element is the focusable .hcs-cell-link wrapper but NOT an anchor.
+    expect(links[0].tagName.toLowerCase()).not.toBe('a')
+    expect(links[0].getAttribute('href')).toBeNull()
   })
 })

--- a/components/organisms/RelationsList/RelationsList.tsx
+++ b/components/organisms/RelationsList/RelationsList.tsx
@@ -1,0 +1,126 @@
+import Link from 'next/link'
+import { FramedCover } from '@/components/molecules/FramedCover'
+import type { NormalisedRelation, NormalisedRelationBuckets } from '@/lib/normalise/anilist-relations'
+
+export type RelationsListProps = {
+  buckets: NormalisedRelationBuckets
+  // Presence in the map = in-library; value = MediaItem.id for the detail
+  // route. Absence = out-of-library; row renders an ADD TO LIBRARY button
+  // targeting /search?type=anime|manga&prefill=anilist:<id>. The Story 8.5a
+  // follow-up will teach GlobalSearch to consume `prefill` (per OI #1); until
+  // then the link target is correct but the search-route prefill is a no-op.
+  inLibraryByAnilistId: Map<number, string>
+}
+
+type Section = {
+  key: keyof NormalisedRelationBuckets
+  header: string
+  rows: NormalisedRelation[]
+}
+
+function buildSections(buckets: NormalisedRelationBuckets): Section[] {
+  // AC-6: fixed order SEQUELS → PREQUELS → SIDE STORIES → ADAPTATIONS → PARENT.
+  return [
+    { key: 'sequel', header: 'SEQUELS', rows: buckets.sequel },
+    { key: 'prequel', header: 'PREQUELS', rows: buckets.prequel },
+    { key: 'sideStory', header: 'SIDE STORIES', rows: buckets.sideStory },
+    { key: 'adaptation', header: 'ADAPTATIONS', rows: buckets.adaptation },
+    { key: 'parent', header: 'PARENT', rows: buckets.parent },
+  ]
+}
+
+function relationChipLabel(relationType: string): string {
+  return relationType.replaceAll('_', ' ')
+}
+
+function detailRouteFor(type: 'ANIME' | 'MANGA', mediaItemId: string): string {
+  return type === 'ANIME'
+    ? `/anime/${mediaItemId}`
+    : `/manga/${mediaItemId}`
+}
+
+function searchPrefillUrl(type: 'ANIME' | 'MANGA', anilistId: number): string {
+  const t = type === 'ANIME' ? 'anime' : 'manga'
+  return `/search?type=${t}&prefill=anilist:${anilistId}`
+}
+
+function coverMedium(type: 'ANIME' | 'MANGA'): 'anime' | 'manga' {
+  return type === 'ANIME' ? 'anime' : 'manga'
+}
+
+export function RelationsList({
+  buckets,
+  inLibraryByAnilistId,
+}: RelationsListProps) {
+  const sections = buildSections(buckets).filter((s) => s.rows.length > 0)
+  if (sections.length === 0) return null
+
+  return (
+    <div className='relations-list'>
+      {sections.map((section) => (
+        <section
+          key={section.key}
+          className='relations-list-section'
+          aria-labelledby={`relations-${section.key}-header`}
+        >
+          <h3
+            id={`relations-${section.key}-header`}
+            className='relations-list-section-header'
+          >
+            {section.header}
+          </h3>
+          <ul className='relations-list-rows'>
+            {section.rows.map((row) => {
+              const mediaItemId = inLibraryByAnilistId.get(row.id)
+              const isInLibrary = mediaItemId !== undefined
+              const chip = relationChipLabel(row.relationType)
+              const medium = coverMedium(row.type)
+              const cover = (
+                <FramedCover
+                  medium={medium}
+                  size='thumb'
+                  src={row.cover_path ?? '/placeholder-cover.png'}
+                  alt={row.title}
+                />
+              )
+              return (
+                <li
+                  key={`${row.relationType}-${row.id}`}
+                  className='relations-list-row'
+                  data-in-library={isInLibrary ? 'true' : 'false'}
+                >
+                  {isInLibrary ? (
+                    <Link
+                      href={detailRouteFor(row.type, mediaItemId)}
+                      className='relations-list-row-link'
+                    >
+                      <span className='relations-list-row-cover'>{cover}</span>
+                      <span className='relations-list-row-title'>
+                        {row.title}
+                      </span>
+                      <span className='relations-list-row-chip'>{chip}</span>
+                    </Link>
+                  ) : (
+                    <div className='relations-list-row-out-of-library'>
+                      <span className='relations-list-row-cover'>{cover}</span>
+                      <span className='relations-list-row-title'>
+                        {row.title}
+                      </span>
+                      <span className='relations-list-row-chip'>{chip}</span>
+                      <Link
+                        href={searchPrefillUrl(row.type, row.id)}
+                        className='relations-list-row-add cpb'
+                      >
+                        &gt; ADD TO LIBRARY
+                      </Link>
+                    </div>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/components/organisms/RelationsList/RelationsList.tsx
+++ b/components/organisms/RelationsList/RelationsList.tsx
@@ -5,10 +5,11 @@ import type { NormalisedRelation, NormalisedRelationBuckets } from '@/lib/normal
 export type RelationsListProps = {
   buckets: NormalisedRelationBuckets
   // Presence in the map = in-library; value = MediaItem.id for the detail
-  // route. Absence = out-of-library; row renders an ADD TO LIBRARY button
-  // targeting /search?type=anime|manga&prefill=anilist:<id>. The Story 8.5a
-  // follow-up will teach GlobalSearch to consume `prefill` (per OI #1); until
-  // then the link target is correct but the search-route prefill is a no-op.
+  // route. Absence = out-of-library; row renders a VIEW INFO button targeting
+  // /preview/anilist/<type>/<id> — the preview page fetches the AniList row
+  // on-the-fly and offers an ADD TO LIBRARY action. Replaces the original
+  // /search?prefill=anilist:<id> URL from AC-6 (which would have required a
+  // Story 8.5a follow-up to teach GlobalSearch to consume the prefill).
   inLibraryByAnilistId: Map<number, string>
 }
 
@@ -39,9 +40,9 @@ function detailRouteFor(type: 'ANIME' | 'MANGA', mediaItemId: string): string {
     : `/manga/${mediaItemId}`
 }
 
-function searchPrefillUrl(type: 'ANIME' | 'MANGA', anilistId: number): string {
+function previewUrl(type: 'ANIME' | 'MANGA', anilistId: number): string {
   const t = type === 'ANIME' ? 'anime' : 'manga'
-  return `/search?type=${t}&prefill=anilist:${anilistId}`
+  return `/preview/anilist/${t}/${anilistId}`
 }
 
 function coverMedium(type: 'ANIME' | 'MANGA'): 'anime' | 'manga' {
@@ -101,19 +102,19 @@ export function RelationsList({
                       <span className='relations-list-row-chip'>{chip}</span>
                     </Link>
                   ) : (
-                    <div className='relations-list-row-out-of-library'>
+                    <Link
+                      href={previewUrl(row.type, row.id)}
+                      className='relations-list-row-link'
+                    >
                       <span className='relations-list-row-cover'>{cover}</span>
                       <span className='relations-list-row-title'>
                         {row.title}
                       </span>
                       <span className='relations-list-row-chip'>{chip}</span>
-                      <Link
-                        href={searchPrefillUrl(row.type, row.id)}
-                        className='relations-list-row-add cpb'
-                      >
-                        &gt; ADD TO LIBRARY
-                      </Link>
-                    </div>
+                      <span className='relations-list-row-add cpb' aria-hidden='true'>
+                        &gt; VIEW INFO
+                      </span>
+                    </Link>
                   )}
                 </li>
               )

--- a/components/organisms/RelationsList/RelationsList.tsx
+++ b/components/organisms/RelationsList/RelationsList.tsx
@@ -5,11 +5,7 @@ import type { NormalisedRelation, NormalisedRelationBuckets } from '@/lib/normal
 export type RelationsListProps = {
   buckets: NormalisedRelationBuckets
   // Presence in the map = in-library; value = MediaItem.id for the detail
-  // route. Absence = out-of-library; row renders a VIEW INFO button targeting
-  // /preview/anilist/<type>/<id> — the preview page fetches the AniList row
-  // on-the-fly and offers an ADD TO LIBRARY action. Replaces the original
-  // /search?prefill=anilist:<id> URL from AC-6 (which would have required a
-  // Story 8.5a follow-up to teach GlobalSearch to consume the prefill).
+  // route. Absence = out-of-library; row links to /preview/anilist/<type>/<id>.
   inLibraryByAnilistId: Map<number, string>
 }
 
@@ -90,32 +86,20 @@ export function RelationsList({
                   className='relations-list-row'
                   data-in-library={isInLibrary ? 'true' : 'false'}
                 >
-                  {isInLibrary ? (
-                    <Link
-                      href={detailRouteFor(row.type, mediaItemId)}
-                      className='relations-list-row-link'
-                    >
-                      <span className='relations-list-row-cover'>{cover}</span>
-                      <span className='relations-list-row-title'>
-                        {row.title}
-                      </span>
-                      <span className='relations-list-row-chip'>{chip}</span>
-                    </Link>
-                  ) : (
-                    <Link
-                      href={previewUrl(row.type, row.id)}
-                      className='relations-list-row-link'
-                    >
-                      <span className='relations-list-row-cover'>{cover}</span>
-                      <span className='relations-list-row-title'>
-                        {row.title}
-                      </span>
-                      <span className='relations-list-row-chip'>{chip}</span>
-                      <span className='relations-list-row-add cpb' aria-hidden='true'>
-                        &gt; VIEW INFO
-                      </span>
-                    </Link>
-                  )}
+                  <Link
+                    href={
+                      isInLibrary
+                        ? detailRouteFor(row.type, mediaItemId)
+                        : previewUrl(row.type, row.id)
+                    }
+                    className='relations-list-row-link'
+                  >
+                    <span className='relations-list-row-cover'>{cover}</span>
+                    <span className='relations-list-row-title'>
+                      {row.title}
+                    </span>
+                    <span className='relations-list-row-chip'>{chip}</span>
+                  </Link>
                 </li>
               )
             })}

--- a/components/organisms/RelationsList/__tests__/RelationsList.test.tsx
+++ b/components/organisms/RelationsList/__tests__/RelationsList.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { RelationsList } from '@/components/organisms/RelationsList'
+import type { NormalisedRelation } from '@/lib/normalise/anilist-relations'
+
+function row(
+  overrides: Partial<NormalisedRelation> & { id: number },
+): NormalisedRelation {
+  return {
+    type: 'ANIME',
+    title: `Title ${overrides.id}`,
+    format: 'TV',
+    cover_path: `https://cdn.example/${overrides.id}.jpg`,
+    relationType: 'SEQUEL',
+    ...overrides,
+  }
+}
+
+describe('RelationsList', () => {
+  it('renders nothing when every bucket is empty', () => {
+    const { container } = render(
+      <RelationsList
+        buckets={{
+          sequel: [],
+          prequel: [],
+          sideStory: [],
+          parent: [],
+          adaptation: [],
+        }}
+        inLibraryByAnilistId={new Map()}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders sections in the fixed order SEQUELS → PREQUELS → SIDE STORIES → ADAPTATIONS → PARENT', () => {
+    render(
+      <RelationsList
+        buckets={{
+          sequel: [row({ id: 1, relationType: 'SEQUEL' })],
+          prequel: [row({ id: 2, relationType: 'PREQUEL' })],
+          sideStory: [row({ id: 3, relationType: 'SIDE_STORY' })],
+          parent: [row({ id: 4, relationType: 'PARENT' })],
+          adaptation: [row({ id: 5, type: 'MANGA', relationType: 'ADAPTATION' })],
+        }}
+        inLibraryByAnilistId={new Map()}
+      />,
+    )
+    const headers = screen
+      .getAllByRole('heading', { level: 3 })
+      .map((h) => h.textContent)
+    expect(headers).toEqual([
+      'SEQUELS',
+      'PREQUELS',
+      'SIDE STORIES',
+      'ADAPTATIONS',
+      'PARENT',
+    ])
+  })
+
+  it('omits an empty bucket entirely (no header rendered)', () => {
+    render(
+      <RelationsList
+        buckets={{
+          sequel: [row({ id: 1, relationType: 'SEQUEL' })],
+          prequel: [],
+          sideStory: [],
+          parent: [],
+          adaptation: [row({ id: 2, type: 'MANGA', relationType: 'ADAPTATION' })],
+        }}
+        inLibraryByAnilistId={new Map()}
+      />,
+    )
+    expect(screen.getByText('SEQUELS')).toBeInTheDocument()
+    expect(screen.getByText('ADAPTATIONS')).toBeInTheDocument()
+    expect(screen.queryByText('PREQUELS')).not.toBeInTheDocument()
+    expect(screen.queryByText('SIDE STORIES')).not.toBeInTheDocument()
+    expect(screen.queryByText('PARENT')).not.toBeInTheDocument()
+  })
+
+  it('renders in-library ANIME rows as a Link to /anime/[mediaItemId]', () => {
+    render(
+      <RelationsList
+        buckets={{
+          sequel: [row({ id: 100, title: 'Frieren S2', relationType: 'SEQUEL' })],
+          prequel: [],
+          sideStory: [],
+          parent: [],
+          adaptation: [],
+        }}
+        inLibraryByAnilistId={new Map([[100, 'media-item-abc']])}
+      />,
+    )
+    const link = screen.getByRole('link', { name: /Frieren S2/ })
+    expect(link.getAttribute('href')).toBe('/anime/media-item-abc')
+  })
+
+  it('renders in-library MANGA rows as a Link to /manga/[mediaItemId]', () => {
+    render(
+      <RelationsList
+        buckets={{
+          sequel: [],
+          prequel: [],
+          sideStory: [],
+          parent: [],
+          adaptation: [
+            row({
+              id: 200,
+              type: 'MANGA',
+              title: 'Berserk',
+              relationType: 'ADAPTATION',
+            }),
+          ],
+        }}
+        inLibraryByAnilistId={new Map([[200, 'media-item-berserk']])}
+      />,
+    )
+    const link = screen.getByRole('link', { name: /Berserk/ })
+    expect(link.getAttribute('href')).toBe('/manga/media-item-berserk')
+  })
+
+  it('renders out-of-library ANIME rows with an ADD TO LIBRARY link targeting /search?type=anime&prefill=anilist:<id>', () => {
+    render(
+      <RelationsList
+        buckets={{
+          sequel: [row({ id: 777, title: 'Not in Library', relationType: 'SEQUEL' })],
+          prequel: [],
+          sideStory: [],
+          parent: [],
+          adaptation: [],
+        }}
+        inLibraryByAnilistId={new Map()}
+      />,
+    )
+    const add = screen.getByRole('link', { name: /ADD TO LIBRARY/ })
+    expect(add.getAttribute('href')).toBe('/search?type=anime&prefill=anilist:777')
+  })
+
+  it('renders out-of-library MANGA rows targeting /search?type=manga&prefill=anilist:<id>', () => {
+    render(
+      <RelationsList
+        buckets={{
+          sequel: [],
+          prequel: [],
+          sideStory: [],
+          parent: [],
+          adaptation: [
+            row({
+              id: 888,
+              type: 'MANGA',
+              title: 'Out of Library Manga',
+              relationType: 'ADAPTATION',
+            }),
+          ],
+        }}
+        inLibraryByAnilistId={new Map()}
+      />,
+    )
+    const add = screen.getByRole('link', { name: /ADD TO LIBRARY/ })
+    expect(add.getAttribute('href')).toBe('/search?type=manga&prefill=anilist:888')
+  })
+
+  it('renders the relation-type chip with underscores replaced by spaces', () => {
+    render(
+      <RelationsList
+        buckets={{
+          sequel: [],
+          prequel: [],
+          sideStory: [row({ id: 1, relationType: 'SIDE_STORY' })],
+          parent: [],
+          adaptation: [],
+        }}
+        inLibraryByAnilistId={new Map()}
+      />,
+    )
+    // Chip label is the same as the section header in this case, but the
+    // chip lives inside the row, not as the section heading.
+    const section = screen.getByRole('heading', { level: 3, name: 'SIDE STORIES' })
+      .parentElement
+    expect(section).not.toBeNull()
+    expect(within(section as HTMLElement).getAllByText('SIDE STORY').length).toBe(1)
+  })
+
+  it('marks the row with data-in-library reflecting library presence', () => {
+    render(
+      <RelationsList
+        buckets={{
+          sequel: [
+            row({ id: 100, title: 'In Library', relationType: 'SEQUEL' }),
+            row({ id: 101, title: 'Out of Library', relationType: 'SEQUEL' }),
+          ],
+          prequel: [],
+          sideStory: [],
+          parent: [],
+          adaptation: [],
+        }}
+        inLibraryByAnilistId={new Map([[100, 'mi-100']])}
+      />,
+    )
+    const inLib = screen.getByText('In Library').closest('li')
+    const outLib = screen.getByText('Out of Library').closest('li')
+    expect(inLib?.getAttribute('data-in-library')).toBe('true')
+    expect(outLib?.getAttribute('data-in-library')).toBe('false')
+  })
+})

--- a/components/organisms/RelationsList/__tests__/RelationsList.test.tsx
+++ b/components/organisms/RelationsList/__tests__/RelationsList.test.tsx
@@ -119,7 +119,7 @@ describe('RelationsList', () => {
     expect(link.getAttribute('href')).toBe('/manga/media-item-berserk')
   })
 
-  it('renders out-of-library ANIME rows with an ADD TO LIBRARY link targeting /search?type=anime&prefill=anilist:<id>', () => {
+  it('renders out-of-library ANIME rows as a Link to /preview/anilist/anime/<id>', () => {
     render(
       <RelationsList
         buckets={{
@@ -132,11 +132,11 @@ describe('RelationsList', () => {
         inLibraryByAnilistId={new Map()}
       />,
     )
-    const add = screen.getByRole('link', { name: /ADD TO LIBRARY/ })
-    expect(add.getAttribute('href')).toBe('/search?type=anime&prefill=anilist:777')
+    const link = screen.getByRole('link', { name: /Not in Library/ })
+    expect(link.getAttribute('href')).toBe('/preview/anilist/anime/777')
   })
 
-  it('renders out-of-library MANGA rows targeting /search?type=manga&prefill=anilist:<id>', () => {
+  it('renders out-of-library MANGA rows as a Link to /preview/anilist/manga/<id>', () => {
     render(
       <RelationsList
         buckets={{
@@ -156,8 +156,8 @@ describe('RelationsList', () => {
         inLibraryByAnilistId={new Map()}
       />,
     )
-    const add = screen.getByRole('link', { name: /ADD TO LIBRARY/ })
-    expect(add.getAttribute('href')).toBe('/search?type=manga&prefill=anilist:888')
+    const link = screen.getByRole('link', { name: /Out of Library Manga/ })
+    expect(link.getAttribute('href')).toBe('/preview/anilist/manga/888')
   })
 
   it('renders the relation-type chip with underscores replaced by spaces', () => {

--- a/components/organisms/RelationsList/index.ts
+++ b/components/organisms/RelationsList/index.ts
@@ -1,0 +1,1 @@
+export { RelationsList, type RelationsListProps } from './RelationsList'

--- a/components/organisms/VoiceCastList/VoiceCastList.tsx
+++ b/components/organisms/VoiceCastList/VoiceCastList.tsx
@@ -1,0 +1,63 @@
+import Image from 'next/image'
+import type { AnilistCharacterEdge } from '@/lib/api/anilist'
+
+export type VoiceCastListProps = {
+  characters: AnilistCharacterEdge[]
+  /** Maximum visible entries. Defaults to all (the adapter already caps at 12). */
+  limit?: number
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part.charAt(0).toUpperCase())
+    .join('')
+}
+
+export function VoiceCastList({ characters, limit }: VoiceCastListProps) {
+  const visible =
+    typeof limit === 'number' ? characters.slice(0, limit) : characters
+  if (visible.length === 0) return null
+
+  return (
+    <ul className='voice-cast-list'>
+      {visible.map((edge) => {
+        const character = edge.node
+        const voice = edge.voiceActors?.[0]
+        const portrait = character.image?.medium ?? null
+        return (
+          <li
+            key={`${edge.role}-${character.id}`}
+            className='voice-cast-list-item'
+          >
+            <div className='voice-cast-list-portrait'>
+              {portrait ? (
+                <Image
+                  src={portrait}
+                  alt={character.name.full}
+                  width={96}
+                  height={96}
+                  unoptimized
+                  className='voice-cast-list-portrait-img'
+                />
+              ) : (
+                <span className='voice-cast-list-portrait-initials'>
+                  {initials(character.name.full)}
+                </span>
+              )}
+            </div>
+            <span className='voice-cast-list-role'>{edge.role}</span>
+            <span className='voice-cast-list-name'>{character.name.full}</span>
+            {voice ? (
+              <span className='voice-cast-list-voiced-by'>
+                voiced by {voice.name.full}
+              </span>
+            ) : null}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/components/organisms/VoiceCastList/__tests__/VoiceCastList.test.tsx
+++ b/components/organisms/VoiceCastList/__tests__/VoiceCastList.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { VoiceCastList } from '@/components/organisms/VoiceCastList'
+import type { AnilistCharacterEdge } from '@/lib/api/anilist'
+
+function edge(
+  id: number,
+  overrides: Partial<{
+    role: string
+    characterName: string
+    voiceActorName: string | null
+    portrait: string | null
+  }> = {},
+): AnilistCharacterEdge {
+  return {
+    role: overrides.role ?? 'MAIN',
+    voiceActors:
+      overrides.voiceActorName === null
+        ? []
+        : [
+            {
+              id: id + 1000,
+              name: {
+                full: overrides.voiceActorName ?? 'Atsumi Tanezaki',
+                native: null,
+              },
+              language: 'JAPANESE',
+            },
+          ],
+    node: {
+      id,
+      name: {
+        full: overrides.characterName ?? `Character ${id}`,
+        native: null,
+      },
+      image:
+        overrides.portrait === null
+          ? undefined
+          : {
+              medium:
+                overrides.portrait ?? `https://s4.anilist.co/c/${id}.png`,
+            },
+    },
+  }
+}
+
+describe('VoiceCastList', () => {
+  it('renders nothing when characters is empty', () => {
+    const { container } = render(<VoiceCastList characters={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders one row per character with the role chip, name, and voiced-by line', () => {
+    render(
+      <VoiceCastList
+        characters={[
+          edge(1, {
+            characterName: 'Frieren',
+            voiceActorName: 'Atsumi Tanezaki',
+          }),
+          edge(2, {
+            role: 'SUPPORTING',
+            characterName: 'Fern',
+            voiceActorName: 'Kana Ichinose',
+          }),
+        ]}
+      />,
+    )
+    expect(screen.getByText('Frieren')).toBeInTheDocument()
+    expect(screen.getByText('voiced by Atsumi Tanezaki')).toBeInTheDocument()
+    expect(screen.getByText('Fern')).toBeInTheDocument()
+    expect(screen.getByText('voiced by Kana Ichinose')).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
+  })
+
+  it('omits the voiced-by line when voiceActors is empty', () => {
+    render(
+      <VoiceCastList
+        characters={[
+          edge(1, { characterName: 'Mystery Character', voiceActorName: null }),
+        ]}
+      />,
+    )
+    expect(screen.getByText('Mystery Character')).toBeInTheDocument()
+    expect(screen.queryByText(/voiced by/)).not.toBeInTheDocument()
+  })
+
+  it('honours `limit` and caps the visible entries', () => {
+    const many = Array.from({ length: 20 }, (_, i) => edge(i + 1))
+    render(<VoiceCastList characters={many} limit={5} />)
+    expect(screen.getAllByRole('listitem')).toHaveLength(5)
+  })
+
+  it('falls back to initials when the character portrait is missing', () => {
+    render(
+      <VoiceCastList
+        characters={[
+          edge(1, { characterName: 'Spike Spiegel', portrait: null }),
+        ]}
+      />,
+    )
+    expect(screen.getByText('SS')).toBeInTheDocument()
+  })
+
+  it('renders the role chip from the AniList edge (MAIN / SUPPORTING / BACKGROUND)', () => {
+    render(
+      <VoiceCastList
+        characters={[
+          edge(1, { role: 'MAIN', characterName: 'A' }),
+          edge(2, { role: 'SUPPORTING', characterName: 'B' }),
+          edge(3, { role: 'BACKGROUND', characterName: 'C' }),
+        ]}
+      />,
+    )
+    expect(screen.getByText('MAIN')).toBeInTheDocument()
+    expect(screen.getByText('SUPPORTING')).toBeInTheDocument()
+    expect(screen.getByText('BACKGROUND')).toBeInTheDocument()
+  })
+})

--- a/components/organisms/VoiceCastList/index.ts
+++ b/components/organisms/VoiceCastList/index.ts
@@ -1,0 +1,1 @@
+export { VoiceCastList, type VoiceCastListProps } from './VoiceCastList'

--- a/e2e/anime-detail.spec.ts
+++ b/e2e/anime-detail.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+
+// Story 8.5 AC-10 canonical NFR50 flow:
+//   navigate /anime/[id] -> assert hero + checklist + Studios + Relations ->
+//   toggle ep 1 -> reload -> assert checked -> click a relation row.
+//
+// Skip-in-CI semantics match e2e/anime-grid.spec.ts: requires live AniList
+// reachability for the Server Component's getMedia + getMediaRelations calls,
+// plus at least one anime in the seeded library.
+
+const ADMIN_PASS = process.env.ADMIN_PASS
+
+async function getFirstAnimeId(api: APIRequestContext): Promise<string> {
+  const res = await api.get('/api/library?type=ANIME&limit=5')
+  expect(res.ok()).toBeTruthy()
+  const body = (await res.json()) as { items: Array<{ mediaItemId: string }> }
+  expect(body.items.length).toBeGreaterThan(0)
+  return body.items[0].mediaItemId
+}
+
+async function resetAnimeProgress(
+  api: APIRequestContext,
+  mediaItemId: string,
+): Promise<void> {
+  // Reset to progress: 0 + PLAN_TO_WATCH so the test is idempotent across runs.
+  const res = await api.fetch('/api/progress', {
+    method: 'PUT',
+    data: {
+      mediaItemId,
+      progress: 0,
+      status: 'PLAN_TO_WATCH',
+      completed_at: null,
+    },
+  })
+  expect(res.ok()).toBeTruthy()
+}
+
+test.beforeAll(async () => {
+  if (!ADMIN_PASS) {
+    throw new Error(
+      'ADMIN_PASS env is required for e2e tests. Set it in .env (local) or the CI env block.',
+    )
+  }
+})
+
+test.describe('/anime/[id] detail page (Story 8.5)', () => {
+  test('AC-10: hero + checklist + Studios + Relations render; toggle ep 1 advances progress; reload persists checked', async ({
+    page,
+  }) => {
+    test.skip(
+      process.env.TMDB_API_KEY === 'test' || !process.env.TMDB_API_KEY,
+      'Requires real TMDB key (for the auth/layout stack) + live AniList reachability + a seeded anime in the library.',
+    )
+
+    await page.goto('/login')
+    await page.getByLabel('PASSWORD').fill(ADMIN_PASS!)
+    await page.getByRole('button', { name: '> LOG IN' }).click()
+    await page.waitForURL('/', { timeout: 10_000 })
+
+    const api = page.request
+    const mediaItemId = await getFirstAnimeId(api)
+    await resetAnimeProgress(api, mediaItemId)
+
+    await page.goto(`/anime/${mediaItemId}`)
+
+    // Hero present.
+    await expect(
+      page.getByRole('link', { name: /BACK TO LIBRARY/i }),
+    ).toBeVisible()
+    // The episode checklist must render at least row EP 1.
+    await expect(page.getByText('EP 1')).toBeVisible({ timeout: 10_000 })
+
+    // Studios chip — the seeded Frieren entry sets studio_name to 'Madhouse'
+    // via the AniList normaliser. Test asserts the band exists; the exact
+    // name is library-state-dependent so we match the band header rather
+    // than the chip text.
+    await expect(
+      page.getByRole('heading', { name: 'Studios' }),
+    ).toBeVisible()
+
+    // Toggle EP 1 watched.
+    const ep1Toggle = page.getByRole('checkbox', {
+      name: 'Mark episode 1 watched',
+    })
+    await ep1Toggle.click()
+
+    // Wait for the server-side mutation + router.refresh() round trip. The
+    // EpisodeChecklist row's data-checked attribute flips to "true" once the
+    // PhosphorBar and PT-to-WATCHING status flip persist.
+    await expect(ep1Toggle).toHaveAttribute('aria-checked', 'true', {
+      timeout: 10_000,
+    })
+
+    // Hard reload to assert server-side persistence (not just React state).
+    await page.reload()
+    const ep1ReloadToggle = page.getByRole('checkbox', {
+      name: 'Mark episode 1 watched',
+    })
+    await expect(ep1ReloadToggle).toHaveAttribute('aria-checked', 'true', {
+      timeout: 10_000,
+    })
+
+    // Cleanup so the test stays idempotent.
+    await resetAnimeProgress(api, mediaItemId)
+  })
+
+  test('AC-6: a relation row navigates to either an in-library detail OR the search prefill URL', async ({
+    page,
+  }) => {
+    test.skip(
+      process.env.TMDB_API_KEY === 'test' || !process.env.TMDB_API_KEY,
+      'Requires live AniList for relations + a seeded anime with relations.',
+    )
+
+    await page.goto('/login')
+    await page.getByLabel('PASSWORD').fill(ADMIN_PASS!)
+    await page.getByRole('button', { name: '> LOG IN' }).click()
+    await page.waitForURL('/', { timeout: 10_000 })
+
+    const mediaItemId = await getFirstAnimeId(page.request)
+    await page.goto(`/anime/${mediaItemId}`)
+
+    // Skip the assertion when the seeded anime happens to have no relations
+    // — the canonical Frieren entry does, but a leaner test seed may not.
+    const relationsHeading = page.getByRole('heading', { name: 'Relations' })
+    const relationsCount = await relationsHeading.count()
+    test.skip(
+      relationsCount === 0,
+      'Seeded anime has no relations buckets to click.',
+    )
+
+    // Find the first relation row (in-library link OR out-of-library ADD).
+    const firstRelationRow = page
+      .locator('.relations-list-row a')
+      .first()
+    await expect(firstRelationRow).toBeVisible({ timeout: 5_000 })
+
+    const href = await firstRelationRow.getAttribute('href')
+    expect(href).not.toBeNull()
+    // The link target is either an in-library detail route (anime/manga) OR
+    // the search prefill URL. AC-6 only contracts the URL shape, not the
+    // GlobalSearch consumer (Story 8.5a follow-up).
+    expect(href).toMatch(
+      /^(?:\/anime\/[^/]+|\/manga\/[^/]+|\/search\?type=(?:anime|manga)&prefill=anilist:\d+)$/,
+    )
+  })
+
+  test('returns 404 for a non-existent anime id', async ({ page }) => {
+    await page.goto('/login')
+    await page.getByLabel('PASSWORD').fill(ADMIN_PASS!)
+    await page.getByRole('button', { name: '> LOG IN' }).click()
+    await page.waitForURL('/', { timeout: 10_000 })
+
+    await page.goto('/anime/this-id-does-not-exist')
+    await expect(page.getByText(/ANIME NOT IN LIBRARY/i)).toBeVisible()
+    await expect(
+      page.getByRole('link', { name: /BACK TO ANIME LIBRARY/i }),
+    ).toBeVisible()
+  })
+})

--- a/e2e/anime-detail.spec.ts
+++ b/e2e/anime-detail.spec.ts
@@ -137,11 +137,12 @@ test.describe('/anime/[id] detail page (Story 8.5)', () => {
 
     const href = await firstRelationRow.getAttribute('href')
     expect(href).not.toBeNull()
-    // The link target is either an in-library detail route (anime/manga) OR
-    // the search prefill URL. AC-6 only contracts the URL shape, not the
-    // GlobalSearch consumer (Story 8.5a follow-up).
+    // The link target is either an in-library detail route (/anime/<id> or
+    // /manga/<id>) OR the preview route (/preview/anilist/anime|manga/<id>).
+    // Replaces the original /search?prefill=anilist:<id> contract after the
+    // preview page landed.
     expect(href).toMatch(
-      /^(?:\/anime\/[^/]+|\/manga\/[^/]+|\/search\?type=(?:anime|manga)&prefill=anilist:\d+)$/,
+      /^(?:\/anime\/[^/]+|\/manga\/[^/]+|\/preview\/anilist\/(?:anime|manga)\/\d+)$/,
     )
   })
 

--- a/e2e/anime-grid.spec.ts
+++ b/e2e/anime-grid.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from '@playwright/test'
+
+// Story 8.4 AC-9 / NFR49 canonical flow:
+//   search anime -> add via federated POST /api/media -> grid renders -> keyboard nav.
+//
+// Skip-in-CI semantics match e2e/movies-detail.spec.ts: real ADMIN_PASS, real
+// TMDB_API_KEY, AND live AniList reachability are all required. The federated
+// search route calls both TMDB + AniList in parallel, so a stub TMDB key
+// would surface partialFailure and make the assertions flaky.
+
+const ADMIN_PASS = process.env.ADMIN_PASS
+
+test.beforeAll(async () => {
+  if (!ADMIN_PASS) {
+    throw new Error(
+      'ADMIN_PASS env is required for e2e tests. Set it in .env (local) or the CI env block.',
+    )
+  }
+})
+
+test.describe('/anime grid (Story 8.4)', () => {
+  test('AC-9: search Frieren -> add via federated POST -> /anime renders card -> keyboard nav lands on detail route', async ({
+    page,
+  }) => {
+    test.skip(
+      process.env.TMDB_API_KEY === 'test' || !process.env.TMDB_API_KEY,
+      'Requires real TMDB API key (federated search dispatches TMDB + AniList in parallel) and live AniList reachability.',
+    )
+
+    await page.goto('/login')
+    await page.getByLabel('PASSWORD').fill(ADMIN_PASS!)
+    await page.getByRole('button', { name: '> LOG IN' }).click()
+    await page.waitForURL('/', { timeout: 10_000 })
+
+    // Open search and type Frieren. The federated search route calls TMDB
+    // plus AniList in parallel via Story 8.3's anilistAdapter.
+    await page.goto('/search')
+    await page.getByPlaceholder(/SEARCH/i).fill('Frieren')
+
+    // Wait for at least one AniList anime result to appear. The AniList
+    // section header renders with the small-caps 'ANIME' label per the
+    // SECTION_LABELS map in GlobalSearch (Story 8.3).
+    const animeRow = page
+      .locator('[role="option"][data-medium="anime"]')
+      .first()
+    await expect(animeRow).toBeVisible({ timeout: 10_000 })
+
+    // ⌘+Enter (mac) / Ctrl+Enter (other) adds to library directly from the
+    // focused row (SearchResultRow.handleKeyDown line 75).
+    await animeRow.focus()
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control'
+    await page.keyboard.press(`${modifier}+Enter`)
+
+    // Wait for the ADD success toast (sonner). The toast description includes
+    // the source + type per GlobalSearch.onSuccess (Story 5.4 / 8.3 wiring).
+    await expect(page.getByText(/ADDED TO LIBRARY/i)).toBeVisible({
+      timeout: 10_000,
+    })
+
+    // Navigate to /anime and assert the new card renders with the 35mm slide
+    // mount chrome. `data-medium='anime'` is set on the inner card element
+    // (LibraryGrid), so we target the `<li role="gridcell">` that CONTAINS
+    // it via `:has()` rather than `[data-medium=...]` directly on the li.
+    // Filter to entries by the just-added Frieren title so the test does
+    // not depend on library order.
+    await page.goto('/anime')
+    const card = page
+      .locator('li[role="gridcell"]:has([data-medium="anime"])')
+      .filter({ hasText: /Frieren/i })
+      .first()
+    await expect(card).toBeVisible({ timeout: 5_000 })
+
+    // Keyboard nav: focus the inner `<a>` (the focusable element inside the
+    // grid cell; the outer <li> is not focusable and would not respond to
+    // Enter), press Enter, assert the router navigated to /anime/[id]. The
+    // detail page does not exist until Story 8.5, so the 404 page is the
+    // acceptable destination (AC-6 explicitly allows this).
+    await card.locator('a').first().focus()
+    await page.keyboard.press('Enter')
+    await page.waitForURL(/\/anime\/[^/]+$/, { timeout: 5_000 })
+  })
+
+  test('AC-5: empty state renders for a fresh library (anime medium)', async ({
+    page,
+  }) => {
+    // This case is hard to test against a shared dev DB (the library may
+    // already contain anime from a previous test run). Skipped unless the
+    // CI env explicitly opts in via E2E_RESET_LIBRARY.
+    test.skip(
+      process.env.E2E_RESET_LIBRARY !== '1',
+      'Empty-state test requires a freshly-reset library (set E2E_RESET_LIBRARY=1 to opt in).',
+    )
+
+    await page.goto('/login')
+    await page.getByLabel('PASSWORD').fill(ADMIN_PASS!)
+    await page.getByRole('button', { name: '> LOG IN' }).click()
+    await page.waitForURL('/', { timeout: 10_000 })
+
+    await page.goto('/anime')
+    await expect(page.getByText(/NO ANIME IN LIBRARY/i)).toBeVisible()
+    await expect(
+      page.getByRole('link', { name: /ADD AN ANIME/i }),
+    ).toBeVisible()
+  })
+})
+
+test.describe('/manga grid (Story 8.4)', () => {
+  test('manga page renders with the MANGA heading and item count', async ({
+    page,
+  }) => {
+    test.skip(
+      process.env.TMDB_API_KEY === 'test' || !process.env.TMDB_API_KEY,
+      'Requires real TMDB key for the layout providers + auth gate.',
+    )
+
+    await page.goto('/login')
+    await page.getByLabel('PASSWORD').fill(ADMIN_PASS!)
+    await page.getByRole('button', { name: '> LOG IN' }).click()
+    await page.waitForURL('/', { timeout: 10_000 })
+
+    await page.goto('/manga')
+    // Heading uses display-serif 'MANGA' noun within the ▓-block treatment.
+    await expect(
+      page.getByRole('heading', { name: /MANGA/i }).first(),
+    ).toBeVisible()
+    // The subtitle reads "{n} ITEMS" regardless of count.
+    await expect(page.getByText(/^\s*\d+\s*ITEMS/i)).toBeVisible()
+  })
+})

--- a/lib/api/__tests__/anilist.test.ts
+++ b/lib/api/__tests__/anilist.test.ts
@@ -235,6 +235,63 @@ describe('getMedia', () => {
     expect(media.startDate).toEqual({ year: 2023, month: 9, day: 29 })
   })
 
+  it('parses a Media payload that includes the characters connection (Story 8.5)', async () => {
+    mockFetchData({
+      Media: makeMedia({
+        characters: {
+          edges: [
+            {
+              role: 'MAIN',
+              voiceActors: [
+                {
+                  id: 95011,
+                  name: { full: 'Atsumi Tanezaki', native: '種崎敦美' },
+                  language: 'JAPANESE',
+                },
+              ],
+              node: {
+                id: 184884,
+                name: { full: 'Frieren', native: 'フリーレン' },
+                image: {
+                  medium:
+                    'https://s4.anilist.co/file/anilistcdn/character/medium/b184884.png',
+                },
+              },
+            },
+            {
+              role: 'SUPPORTING',
+              voiceActors: [],
+              node: {
+                id: 184885,
+                name: { full: 'Fern', native: 'フェルン' },
+                image: { medium: null },
+              },
+            },
+          ],
+        },
+      }),
+    })
+    const { getMedia } = await import('@/lib/api/anilist')
+    const media = await getMedia(170942, 'ANIME')
+    expect(media.characters).toBeDefined()
+    expect(media.characters?.edges).toHaveLength(2)
+    expect(media.characters?.edges[0]?.role).toBe('MAIN')
+    expect(media.characters?.edges[0]?.voiceActors?.[0]?.name.full).toBe(
+      'Atsumi Tanezaki',
+    )
+    expect(media.characters?.edges[1]?.voiceActors).toEqual([])
+  })
+
+  it('still parses a Media payload that omits the characters field (backward compat)', async () => {
+    // Search results use the same MEDIA_FIELDS fragment but don't surface
+    // characters in the federated-search UI. Schema must keep the field
+    // optional so existing search-row parses don't regress.
+    mockFetchData({ Media: makeMedia() })
+    const { getMedia } = await import('@/lib/api/anilist')
+    const media = await getMedia(170942, 'ANIME')
+    expect(media.characters).toBeUndefined()
+  })
+
   it('preserves partial startDate where month and day are null', async () => {
     mockFetchData({
       Media: makeMedia({ startDate: { year: 2020, month: null, day: null } }),

--- a/lib/api/__tests__/tmdb-images.test.ts
+++ b/lib/api/__tests__/tmdb-images.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { getImageUrl, TMDB_IMAGE_BASE } from '@/lib/api/tmdb-images'
+
+describe('lib/api/tmdb-images: getImageUrl', () => {
+  it('returns null when path is null', () => {
+    expect(getImageUrl(null, 'w185')).toBeNull()
+  })
+
+  it('returns null when path is the empty string (treat like null)', () => {
+    expect(getImageUrl('', 'w185')).toBeNull()
+  })
+
+  it('prefixes the TMDB CDN base + size for a path-only value', () => {
+    expect(getImageUrl('/abc.jpg', 'w185')).toBe(`${TMDB_IMAGE_BASE}/w185/abc.jpg`)
+  })
+
+  it('passes a full https URL through unchanged (Story 8.4 OI #2, AniList CDN URLs)', () => {
+    const url =
+      'https://s4.anilist.co/file/anilistcdn/media/anime/cover/large/bx170942-x.jpg'
+    expect(getImageUrl(url, 'w185')).toBe(url)
+  })
+
+  it('passes a full http URL through unchanged', () => {
+    const url = 'http://example.com/cover.jpg'
+    expect(getImageUrl(url, 'w185')).toBe(url)
+  })
+
+  it('handles mixed-case schemes (HTTPS://, HTTP://) per RFC 3986 §3.1', () => {
+    expect(getImageUrl('HTTPS://s4.anilist.co/x.jpg', 'w185')).toBe(
+      'HTTPS://s4.anilist.co/x.jpg',
+    )
+    expect(getImageUrl('Http://example.com/y.jpg', 'w185')).toBe(
+      'Http://example.com/y.jpg',
+    )
+  })
+
+  it('does NOT mistake a path that merely contains "http" for an absolute URL', () => {
+    // /http_thing.jpg is a TMDB-style path that happens to contain 'http' but
+    // is anchored at index 1; the regex requires anchor-at-start.
+    expect(getImageUrl('/http_thing.jpg', 'w185')).toBe(
+      `${TMDB_IMAGE_BASE}/w185/http_thing.jpg`,
+    )
+  })
+
+  it('still prefixes when the path is a relative path-only TMDB string with no protocol', () => {
+    expect(getImageUrl('/poster.png', 'w342')).toBe(
+      `${TMDB_IMAGE_BASE}/w342/poster.png`,
+    )
+  })
+})

--- a/lib/api/anilist.ts
+++ b/lib/api/anilist.ts
@@ -106,6 +106,44 @@ export const AnilistStaffSchema = z.object({
   edges: z.array(AnilistStaffEdgeSchema),
 })
 
+// AniList returns `role` as an enum string (MAIN / SUPPORTING / BACKGROUND) and
+// `language` as another enum (JAPANESE / ENGLISH / KOREAN / ...). We keep them
+// as `z.string()` to stay loose with future AniList enum additions; downstream
+// rendering treats them as opaque chip labels.
+export const AnilistCharacterImageSchema = z.object({
+  medium: z.string().nullable().optional(),
+})
+
+export const AnilistCharacterNameSchema = z.object({
+  full: z.string(),
+  native: z.string().nullable().optional(),
+})
+
+export const AnilistVoiceActorSchema = z.object({
+  id: z.number(),
+  name: AnilistCharacterNameSchema,
+  language: z.string().optional(),
+})
+export type AnilistVoiceActor = z.infer<typeof AnilistVoiceActorSchema>
+
+export const AnilistCharacterNodeSchema = z.object({
+  id: z.number(),
+  name: AnilistCharacterNameSchema,
+  image: AnilistCharacterImageSchema.optional(),
+})
+export type AnilistCharacterNode = z.infer<typeof AnilistCharacterNodeSchema>
+
+export const AnilistCharacterEdgeSchema = z.object({
+  role: z.string(),
+  voiceActors: z.array(AnilistVoiceActorSchema).optional(),
+  node: AnilistCharacterNodeSchema,
+})
+export type AnilistCharacterEdge = z.infer<typeof AnilistCharacterEdgeSchema>
+
+export const AnilistCharactersSchema = z.object({
+  edges: z.array(AnilistCharacterEdgeSchema),
+})
+
 export const AnilistRelationTypeSchema = z.enum([
   'ADAPTATION',
   'PREQUEL',
@@ -165,6 +203,7 @@ export const AnilistMediaSchema = z.object({
   bannerImage: z.string().nullable().optional(),
   studios: AnilistStudiosSchema.optional(),
   staff: AnilistStaffSchema.optional(),
+  characters: AnilistCharactersSchema.optional(),
   source: z.string().nullable().optional(),
   isAdult: z.boolean().optional(),
   relations: AnilistRelationsSchema.optional(),
@@ -427,6 +466,13 @@ const MEDIA_FIELDS = `
   bannerImage
   studios { nodes { id name isAnimationStudio } }
   staff(perPage: 8) { edges { role node { id name { full native } } } }
+  characters(perPage: 12, sort: ROLE) {
+    edges {
+      role
+      voiceActors(language: JAPANESE) { id name { full native } language }
+      node { id name { full native } image { medium } }
+    }
+  }
   source
   isAdult
 `

--- a/lib/api/tmdb-images.ts
+++ b/lib/api/tmdb-images.ts
@@ -22,10 +22,23 @@ export const TmdbImageSizeSchema = z.enum([
 ])
 export type TmdbImageSize = z.infer<typeof TmdbImageSizeSchema>
 
+// Recognises http://, https://, HTTP://, HTTPS:// (case-insensitive per
+// RFC 3986 §3.1 which allows mixed-case schemes). Anchored at the start of
+// the string so a path like '/http_thing.jpg' is correctly rejected.
+const ABSOLUTE_URL_RE = /^https?:\/\//i
+
 export function getImageUrl(
   path: string | null,
   size: TmdbImageSize,
 ): string | null {
-  if (path === null) return null
+  // Empty string is treated as "no image" the same way null is. Without this,
+  // a normaliser that ever wrote `''` would yield `https://image.tmdb.org/t/p/w185`
+  // (the bucket root, a 404 image request).
+  if (path === null || path.length === 0) return null
+  // AniList cover URLs (and any future absolute-URL source) come through as
+  // full https://... strings; they must not be re-prefixed with the TMDB CDN
+  // base. Story 8.4 OI #2: extend the existing helper instead of introducing
+  // a new getCoverUrl(path, source) so every call site benefits automatically.
+  if (ABSOLUTE_URL_RE.test(path)) return path
   return `${TMDB_IMAGE_BASE}/${size}${path}`
 }

--- a/lib/detail-route.ts
+++ b/lib/detail-route.ts
@@ -1,0 +1,26 @@
+import { MediaType } from '@prisma/client'
+
+type DetailRouteInput = {
+  mediaType: MediaType
+  mediaItemId: string
+  anilistId?: number | null
+}
+
+export function detailRouteFor(item: DetailRouteInput): string | null {
+  switch (item.mediaType) {
+    case MediaType.MOVIE:
+      return `/movies/${item.mediaItemId}`
+    case MediaType.TV_SHOW:
+      return `/tv/${item.mediaItemId}`
+    case MediaType.ANIME:
+      return `/anime/${item.mediaItemId}`
+    case MediaType.MANGA:
+      return item.anilistId != null
+        ? `/preview/anilist/manga/${item.anilistId}`
+        : null
+    case MediaType.TV_EPISODE:
+    case MediaType.GAME:
+    default:
+      return null
+  }
+}

--- a/lib/normalise/__tests__/anilist-relations.test.ts
+++ b/lib/normalise/__tests__/anilist-relations.test.ts
@@ -59,6 +59,7 @@ describe('lib/normalise/anilist-relations', () => {
     expect(result.sequel).toEqual([
       {
         id: 1,
+        type: 'ANIME',
         title: 'Romaji 1',
         format: 'TV',
         cover_path: 'https://cdn.example/1.jpg',
@@ -70,6 +71,7 @@ describe('lib/normalise/anilist-relations', () => {
     expect(result.parent[0]?.relationType).toBe('PARENT')
     expect(result.adaptation[0]).toMatchObject({
       id: 5,
+      type: 'MANGA',
       format: 'MANGA',
       relationType: 'ADAPTATION',
     })

--- a/lib/normalise/anilist-html.ts
+++ b/lib/normalise/anilist-html.ts
@@ -1,0 +1,5 @@
+export function stripAnilistHtml(text: string): string {
+  return text
+    .replace(/<br\s*\/?\s*>/gi, '\n\n')
+    .replace(/<[^>]*>/g, '')
+}

--- a/lib/normalise/anilist-relations.ts
+++ b/lib/normalise/anilist-relations.ts
@@ -1,4 +1,5 @@
 import type {
+  AnilistMediaType,
   AnilistRelationBuckets,
   AnilistRelationNode,
   AnilistRelationType,
@@ -9,6 +10,11 @@ import type {
 // (consistency with the rest of the unified MediaItem surface).
 export interface NormalisedRelation {
   id: number
+  // Source media type: distinguishes ANIME relations from MANGA relations on
+  // the anime detail page (an ANIME → ADAPTATION row usually points to the
+  // source MANGA). RelationsList uses this to pick the FramedCover medium
+  // and the in-library / out-of-library link target (Story 8.5 AC-6).
+  type: AnilistMediaType
   title: string
   format: string | null
   cover_path: string | null
@@ -58,6 +64,7 @@ function toRelation(
 ): NormalisedRelation {
   return {
     id: node.id,
+    type: node.type,
     title: preferredTitle(node.title),
     format: node.format ?? null,
     cover_path: pickCover(node.coverImage),


### PR DESCRIPTION
## Summary

Epic 8 bundle 2 (sub-bundle pattern from Epic 7). Two stories on `epic-8-anilist-bundle-2`:

- **Story 8.4** (commit `c4b32ae3`): /anime + /manga grids. AniList-backed library lists for the two new media types. MANGA filter chip + cross-source-merge type filter.
- **Story 8.5** (commit `55543dff`): /anime/[id] detail page with flat 1..N EpisodeChecklist, Studios + Voice Cast bands, and the new RelationsList organism. Server-side auto-advance on `PUT /api/progress` (gated on `MediaType.ANIME`) for status flips + `completed_at`. AniList adapter extended with the `characters` connection.

Cumulative diff: **+2059 / -10 across 26 files**. Story 8.6 (manga detail with chapter + volume tracking) is the next slice and will land on its own branch.

## Test plan

- [x] `pnpm typecheck` clean on the bundle.
- [x] `pnpm lint --max-warnings=0` clean on the bundle.
- [x] `pnpm test` -- 796 / 798 (the 2 BullMQ worker tests require Redis up; pre-existing env-only across all of Epic 8). New surface: **+32 test cases** across the progress route, AniList adapter, anilist-relations normaliser, EpisodeChecklist, RelationsList, VoiceCastList.
- [ ] Playwright `pnpm test:e2e e2e/anime-detail.spec.ts` -- gated on `pnpm infra` + real TMDB key + a seeded anime; not run locally during dev-story (skip-in-CI guards match `e2e/movies-detail.spec.ts`).
- [ ] Browser smoke against a seeded anime detail page -- gated on the same prereqs.

## Notes

- Bundle is rebased onto main as of #139 (`720053eb`). #140 landed after the rebase; the login-deflake fix it carries is not on the bundle head, but GitHub re-runs CI against the merged state, so #140 applies on the bundle PR merge-check.
- OIs deferred at story-author time stand: OI #1 GlobalSearch `prefill=anilist:<id>` consumer (Story 8.5a follow-up), OI #2 voice-actor language picker (currently hardcoded `JAPANESE`), OI #3 per-episode AniList metadata.
- No retroactive code-review sweep on this bundle -- PR #139 already shipped that. Story 8.5 code-review was in-flight diff only.

Closes #137
Closes #141