### PR TITLE
feat(manga): /manga/[id] detail page with chapter + volume tracking (Story 8.6)

### DIFF
--- a/app/(media)/manga/[id]/MangaDetailControls.tsx
+++ b/app/(media)/manga/[id]/MangaDetailControls.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+import { ChapterVolumeTracker } from '@/components/molecules/ChapterVolumeTracker'
+
+export type MangaDetailControlsProps = {
+  mediaItemId: string
+  chapterCount: number | null
+  volumeCount: number | null
+  progress: number
+  volumeProgress: number
+  lifecycleStatus: string | null
+}
+
+type ProgressBody = {
+  mediaItemId: string
+  progress: number
+  volumeProgress: number
+}
+
+async function putProgress(body: ProgressBody): Promise<void> {
+  const res = await fetch('/api/progress', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    throw new Error(`manga_progress_failed:${res.status}`)
+  }
+}
+
+export function MangaDetailControls({
+  mediaItemId,
+  chapterCount,
+  volumeCount,
+  progress,
+  volumeProgress,
+  lifecycleStatus,
+}: MangaDetailControlsProps) {
+  const router = useRouter()
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation<void, Error, ProgressBody>({
+    mutationFn: putProgress,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['library', 'manga'] })
+      void queryClient.invalidateQueries({
+        queryKey: ['mangaDetail', mediaItemId],
+      })
+      router.refresh()
+    },
+    onError: () => {
+      toast.error('COULD NOT UPDATE PROGRESS')
+    },
+  })
+
+  function handleUpdate(next: { progress: number; volumeProgress: number }) {
+    // Molecule owns the intent translation; island is a thin transport.
+    mutation.mutate({ mediaItemId, ...next })
+  }
+
+  return (
+    <ChapterVolumeTracker
+      chapterCount={chapterCount}
+      volumeCount={volumeCount}
+      progress={progress}
+      volumeProgress={volumeProgress}
+      lifecycleStatus={lifecycleStatus}
+      onUpdate={handleUpdate}
+      disabled={mutation.isPending}
+    />
+  )
+}

--- a/app/(media)/manga/[id]/not-found.tsx
+++ b/app/(media)/manga/[id]/not-found.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function MangaNotFound() {
+  return (
+    <main className='anime-not-found'>
+      <h1>&gt; MANGA NOT IN LIBRARY</h1>
+      <p>Try adding it from the search.</p>
+      <Link href='/manga' className='crt-pixel-button'>
+        &gt; BACK TO MANGA LIBRARY
+      </Link>
+    </main>
+  )
+}

--- a/app/(media)/manga/[id]/page.tsx
+++ b/app/(media)/manga/[id]/page.tsx
@@ -1,0 +1,252 @@
+import { notFound } from 'next/navigation'
+import { MediaType } from '@prisma/client'
+import { db } from '@/lib/db'
+import { findUserEntryByMediaItemId } from '@/lib/db/library'
+import {
+  getMedia,
+  getMediaRelations,
+  AnilistApiError,
+  AnilistNotFoundError,
+  type AnilistMedia,
+} from '@/lib/api/anilist'
+import {
+  normaliseRelations,
+  type NormalisedRelationBuckets,
+} from '@/lib/normalise/anilist-relations'
+import { logger } from '@/lib/logger'
+import { BackToLibraryLink } from '@/components/molecules/BackToLibraryLink'
+import { DetailHero } from '@/components/organisms/DetailHero'
+import { SectionBand } from '@/components/organisms/SectionBand/SectionBand'
+import { RelationsList } from '@/components/organisms/RelationsList'
+import { stripAnilistHtml } from '@/lib/normalise/anilist-html'
+import type { MetadataItem } from '@/components/molecules/MetadataRow'
+import { MangaDetailControls } from './MangaDetailControls'
+
+export const dynamic = 'force-dynamic'
+
+type PageParams = Promise<{ id: string }>
+
+function deriveYear(d: Date): number | null {
+  const y = d.getUTCFullYear()
+  return y === 1970 ? null : y
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: PageParams
+}): Promise<{ title: string }> {
+  const { id } = await params
+  const entry = await findUserEntryByMediaItemId(id)
+  if (!entry) return { title: 'NOT IN LIBRARY · Cuatro Tracker' }
+  return {
+    title: `${entry.media_item.title.toUpperCase()} · Cuatro Tracker`,
+  }
+}
+
+type RelationsResolution = {
+  buckets: NormalisedRelationBuckets
+  inLibraryByAnilistId: Map<number, string>
+}
+
+async function resolveRelations(
+  anilistId: number,
+): Promise<RelationsResolution> {
+  const empty: NormalisedRelationBuckets = {
+    sequel: [],
+    prequel: [],
+    sideStory: [],
+    parent: [],
+    adaptation: [],
+  }
+  let buckets: NormalisedRelationBuckets = empty
+  try {
+    const raw = await getMediaRelations(anilistId)
+    buckets = normaliseRelations(raw)
+  } catch (err) {
+    if (err instanceof AnilistApiError || err instanceof AnilistNotFoundError) {
+      logger.warn(
+        { event: 'manga_detail.relations_unavailable', anilistId, err },
+        'AniList relations fetch failed; relations band will be omitted',
+      )
+    } else {
+      throw err
+    }
+  }
+
+  const allRelationIds = [
+    ...buckets.sequel,
+    ...buckets.prequel,
+    ...buckets.sideStory,
+    ...buckets.parent,
+    ...buckets.adaptation,
+  ].map((r) => r.id)
+
+  const inLibraryByAnilistId = new Map<number, string>()
+  if (allRelationIds.length > 0) {
+    const rows = await db.mediaItem.findMany({
+      where: { anilist_id: { in: allRelationIds } },
+      select: { id: true, anilist_id: true },
+    })
+    for (const r of rows) {
+      if (r.anilist_id !== null) inLibraryByAnilistId.set(r.anilist_id, r.id)
+    }
+  }
+
+  return { buckets, inLibraryByAnilistId }
+}
+
+async function resolveAnilistMedia(
+  anilistId: number,
+): Promise<AnilistMedia | null> {
+  try {
+    return await getMedia(anilistId, 'MANGA')
+  } catch (err) {
+    if (err instanceof AnilistApiError || err instanceof AnilistNotFoundError) {
+      logger.warn(
+        { event: 'manga_detail.media_unavailable', anilistId, err },
+        'AniList getMedia failed; ongoing chip will be omitted',
+      )
+      return null
+    }
+    throw err
+  }
+}
+
+export default async function MangaDetailPage({
+  params,
+}: {
+  params: PageParams
+}) {
+  const { id } = await params
+  if (!id) notFound()
+
+  const entry = await findUserEntryByMediaItemId(id)
+  if (!entry || entry.media_item.type !== MediaType.MANGA) notFound()
+  if (entry.media_item.anilist_id === null) {
+    logger.warn(
+      { event: 'manga_detail.missing_anilist_id', mediaItemId: id },
+      'MANGA row has no anilist_id; rendering 404',
+    )
+    notFound()
+  }
+
+  const anilistId = entry.media_item.anilist_id
+
+  const [media, relations] = await Promise.all([
+    resolveAnilistMedia(anilistId),
+    resolveRelations(anilistId),
+  ])
+
+  const year = deriveYear(entry.media_item.release_date)
+  const upstreamStatus = media?.status ?? entry.media_item.status ?? null
+
+  const metadata: MetadataItem[] = []
+  if (media?.format) {
+    metadata.push({ value: media.format.replaceAll('_', ' ') })
+  }
+  if (year !== null) metadata.push({ value: String(year) })
+  if (entry.media_item.author_name) {
+    metadata.push({ value: entry.media_item.author_name })
+  }
+  if (entry.media_item.chapter_count !== null) {
+    metadata.push({ value: `${entry.media_item.chapter_count} CH` })
+  }
+  if (entry.media_item.volume_count !== null) {
+    metadata.push({ value: `${entry.media_item.volume_count} VOL` })
+  }
+  if (upstreamStatus) {
+    metadata.push({
+      value: upstreamStatus.replaceAll('_', ' ').toUpperCase(),
+      dim: true,
+    })
+  }
+
+  const synopsisParagraphs = stripAnilistHtml(entry.media_item.overview ?? '')
+    .split(/\n+/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+
+  const posterUrl = entry.media_item.poster_path
+
+  const hasRelations =
+    relations.buckets.sequel.length > 0 ||
+    relations.buckets.prequel.length > 0 ||
+    relations.buckets.sideStory.length > 0 ||
+    relations.buckets.parent.length > 0 ||
+    relations.buckets.adaptation.length > 0
+
+  const hasTrackingAxis =
+    entry.media_item.chapter_count !== null ||
+    entry.media_item.volume_count !== null
+
+  const genres = entry.media_item.genres ?? []
+
+  return (
+    <main className='anime-detail-page'>
+      <BackToLibraryLink medium='manga' />
+      <DetailHero
+        mediaItemId={entry.media_item_id}
+        medium='manga'
+        mediumLabel='MANGA'
+        title={entry.media_item.title}
+        originalTitle={entry.media_item.original_title}
+        posterUrl={posterUrl}
+        metadata={metadata}
+        currentStatus={entry.status}
+        imdbId={null}
+        showQbtButton={false}
+      />
+      <div className='anime-detail-rule' aria-hidden='true' />
+      {synopsisParagraphs.length > 0 ? (
+        <article className='anime-detail-synopsis'>
+          {synopsisParagraphs.map((para, idx) => (
+            <p key={idx}>{para}</p>
+          ))}
+        </article>
+      ) : null}
+      <div
+        className='anime-detail-rule anime-detail-rule-thick'
+        aria-hidden='true'
+      />
+      {hasTrackingAxis ? (
+        <SectionBand title='Chapters'>
+          <MangaDetailControls
+            mediaItemId={entry.media_item_id}
+            chapterCount={entry.media_item.chapter_count}
+            volumeCount={entry.media_item.volume_count}
+            progress={entry.progress}
+            volumeProgress={entry.volume_progress}
+            lifecycleStatus={upstreamStatus}
+          />
+        </SectionBand>
+      ) : null}
+      {entry.media_item.author_name ? (
+        <SectionBand title='Authors'>
+          <span className='anime-detail-studio-chip'>
+            {entry.media_item.author_name}
+          </span>
+        </SectionBand>
+      ) : null}
+      {genres.length > 0 ? (
+        <SectionBand title='Genres'>
+          <ul className='manga-detail-genre-list'>
+            {genres.map((g) => (
+              <li key={g} className='anime-detail-studio-chip'>
+                {g}
+              </li>
+            ))}
+          </ul>
+        </SectionBand>
+      ) : null}
+      {hasRelations ? (
+        <SectionBand title='Relations'>
+          <RelationsList
+            buckets={relations.buckets}
+            inLibraryByAnilistId={relations.inLibraryByAnilistId}
+          />
+        </SectionBand>
+      ) : null}
+    </main>
+  )
+}

--- a/app/api/progress/__tests__/route.test.ts
+++ b/app/api/progress/__tests__/route.test.ts
@@ -519,7 +519,7 @@ describe('PUT /api/progress (Story 8.5 anime auto-advance)', () => {
   it('respects an explicit body.status alongside auto-advance computation', async () => {
     // The auto-advance branch can override status (last writer wins on `data`).
     // If body.status is provided AND progress triggers auto-complete, the
-    // anime branch's COMPLETED takes precedence — matches AC-5's "computed
+    // anime branch's COMPLETED takes precedence, matches AC-5's "computed
     // status in a single update".
     dbMock.userEntry.findUnique.mockResolvedValue(
       animeEntry({ progress: 27, status: WatchStatus.WATCHING }),
@@ -541,5 +541,243 @@ describe('PUT /api/progress (Story 8.5 anime auto-advance)', () => {
     const call = dbMock.userEntry.update.mock.calls[0][0]
     expect(call.data.status).toBe(WatchStatus.COMPLETED)
     vi.useRealTimers()
+  })
+})
+
+// Story 8.6 AC-5 + AC-10 #1: PUT /api/progress manga auto-advance branch.
+describe('PUT /api/progress (Story 8.6 manga auto-advance)', () => {
+  const mangaEntry = (overrides: Record<string, unknown> = {}) => ({
+    id: 'entry-manga-1',
+    media_item_id: 'manga-1',
+    status: WatchStatus.PLAN_TO_WATCH,
+    user_rating: null,
+    progress: 0,
+    volume_progress: 0,
+    notes: null,
+    started_at: null,
+    completed_at: null,
+    created_at: new Date('2026-05-10T12:00:00Z'),
+    updated_at: new Date('2026-05-12T12:00:00Z'),
+    media_item: {
+      id: 'manga-1',
+      type: MediaType.MANGA,
+      title: 'Chainsaw Man',
+      anilist_id: 105778,
+      chapter_count: 150,
+      volume_count: 15,
+    },
+    ...overrides,
+  })
+
+  it('advances PLAN_TO_WATCH to WATCHING on first chapter progress', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(mangaEntry())
+    dbMock.userEntry.update.mockResolvedValue(
+      mangaEntry({ progress: 1, status: WatchStatus.WATCHING }),
+    )
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(
+      putRequest({ mediaItemId: 'manga-1', progress: 1, volumeProgress: 0 }),
+    )
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.progress).toBe(1)
+    expect(call.data.volume_progress).toBe(0)
+    expect(call.data.status).toBe(WatchStatus.WATCHING)
+    expect(call.data.completed_at).toBeUndefined()
+  })
+
+  it('advances PLAN_TO_WATCH to WATCHING when only volumeProgress increments', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(mangaEntry())
+    dbMock.userEntry.update.mockResolvedValue(
+      mangaEntry({ volume_progress: 1, status: WatchStatus.WATCHING }),
+    )
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(
+      putRequest({ mediaItemId: 'manga-1', volumeProgress: 1 }),
+    )
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.volume_progress).toBe(1)
+    expect(call.data.status).toBe(WatchStatus.WATCHING)
+    // progress is untouched when only volumeProgress is sent.
+    expect(call.data.progress).toBeUndefined()
+  })
+
+  it('auto-completes when chapter progress reaches chapter_count and sets completed_at', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(
+      mangaEntry({
+        progress: 149,
+        volume_progress: 14,
+        status: WatchStatus.WATCHING,
+      }),
+    )
+    const fakeNow = new Date('2026-05-20T16:00:00.000Z')
+    vi.setSystemTime(fakeNow)
+    dbMock.userEntry.update.mockResolvedValue(
+      mangaEntry({
+        progress: 150,
+        volume_progress: 15,
+        status: WatchStatus.COMPLETED,
+        completed_at: fakeNow,
+      }),
+    )
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(
+      putRequest({
+        mediaItemId: 'manga-1',
+        progress: 150,
+        volumeProgress: 15,
+      }),
+    )
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.progress).toBe(150)
+    expect(call.data.volume_progress).toBe(15)
+    expect(call.data.status).toBe(WatchStatus.COMPLETED)
+    expect(call.data.completed_at).toBeInstanceOf(Date)
+    expect((call.data.completed_at as Date).toISOString()).toBe(
+      fakeNow.toISOString(),
+    )
+    vi.useRealTimers()
+  })
+
+  it('does NOT overwrite an existing completed_at when chapter progress stays at chapter_count', async () => {
+    const previousCompletedAt = new Date('2026-05-15T10:00:00.000Z')
+    dbMock.userEntry.findUnique.mockResolvedValue(
+      mangaEntry({
+        progress: 150,
+        volume_progress: 15,
+        status: WatchStatus.COMPLETED,
+        completed_at: previousCompletedAt,
+      }),
+    )
+    dbMock.userEntry.update.mockResolvedValue(
+      mangaEntry({ progress: 150, status: WatchStatus.COMPLETED }),
+    )
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(
+      putRequest({ mediaItemId: 'manga-1', progress: 150 }),
+    )
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.status).toBe(WatchStatus.COMPLETED)
+    expect(call.data.completed_at).toBeUndefined()
+  })
+
+  it('retreats independently on chapter and volume axes', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(
+      mangaEntry({
+        progress: 50,
+        volume_progress: 5,
+        status: WatchStatus.WATCHING,
+      }),
+    )
+    dbMock.userEntry.update.mockResolvedValue(
+      mangaEntry({ progress: 40, volume_progress: 4 }),
+    )
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(
+      putRequest({ mediaItemId: 'manga-1', progress: 40, volumeProgress: 4 }),
+    )
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.progress).toBe(40)
+    expect(call.data.volume_progress).toBe(4)
+    // No status flip on retreat.
+    expect(call.data.status).toBeUndefined()
+  })
+
+  it('does NOT auto-complete when chapter_count is null (ongoing serialisation)', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(
+      mangaEntry({
+        progress: 200,
+        volume_progress: 20,
+        status: WatchStatus.WATCHING,
+        media_item: {
+          id: 'manga-1',
+          type: MediaType.MANGA,
+          title: 'One Piece',
+          anilist_id: 30013,
+          chapter_count: null,
+          volume_count: null,
+        },
+      }),
+    )
+    dbMock.userEntry.update.mockResolvedValue(
+      mangaEntry({ progress: 201 }),
+    )
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(
+      putRequest({ mediaItemId: 'manga-1', progress: 201 }),
+    )
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.progress).toBe(201)
+    expect(call.data.status).toBeUndefined()
+    expect(call.data.completed_at).toBeUndefined()
+  })
+
+  it('coalesces chapter increments to max() but trusts strict decrements', async () => {
+    dbMock.userEntry.findUnique.mockResolvedValue(
+      mangaEntry({ progress: 80, volume_progress: 8, status: WatchStatus.WATCHING }),
+    )
+    dbMock.userEntry.update.mockResolvedValue(
+      mangaEntry({ progress: 80 }),
+    )
+    const { PUT } = await import('@/app/api/progress/route')
+    // Increment-then-stale-write scenario: client sends 75 (smaller), trusted.
+    const res = await PUT(
+      putRequest({ mediaItemId: 'manga-1', progress: 75 }),
+    )
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    expect(call.data.progress).toBe(75)
+  })
+
+  it('ignores manga-specific coalesce on non-manga entries (gate preserves anime behaviour)', async () => {
+    const animeWithVolumeBody = {
+      id: 'entry-anime-2',
+      media_item_id: 'anime-2',
+      status: WatchStatus.PLAN_TO_WATCH,
+      user_rating: null,
+      progress: 0,
+      volume_progress: 0,
+      notes: null,
+      started_at: null,
+      completed_at: null,
+      created_at: new Date('2026-05-10T12:00:00Z'),
+      updated_at: new Date('2026-05-12T12:00:00Z'),
+      media_item: {
+        id: 'anime-2',
+        type: MediaType.ANIME,
+        title: 'Hunter x Hunter',
+        anilist_id: 11061,
+        episode_count: 148,
+      },
+    }
+    dbMock.userEntry.findUnique.mockResolvedValue(animeWithVolumeBody)
+    dbMock.userEntry.update.mockResolvedValue({
+      ...animeWithVolumeBody,
+      progress: 5,
+      volume_progress: 99,
+      status: WatchStatus.WATCHING,
+    })
+    const { PUT } = await import('@/app/api/progress/route')
+    const res = await PUT(
+      putRequest({
+        mediaItemId: 'anime-2',
+        progress: 5,
+        volumeProgress: 99, // sent but anime branch should not surface manga-specific coalesce
+      }),
+    )
+    expect(res.status).toBe(200)
+    const call = dbMock.userEntry.update.mock.calls[0][0]
+    // Anime branch coalesces progress per its own logic; volumeProgress is
+    // written verbatim via the body-mapping step (data.volume_progress = 99)
+    // because the column is on UserEntry for all media types. The MANGA-specific
+    // coalesce / chapter-count-driven completion is NOT applied to anime rows.
+    expect(call.data.progress).toBe(5)
+    expect(call.data.volume_progress).toBe(99)
+    expect(call.data.status).toBe(WatchStatus.WATCHING) // anime auto-advance still runs
   })
 })

--- a/app/api/progress/route.ts
+++ b/app/api/progress/route.ts
@@ -27,8 +27,12 @@ export const dynamic = 'force-dynamic'
 const ProgressBodySchema = z.object({
   mediaItemId: z.string().min(1),
   // progress: episode / chapter / achievement count. DB CHECK enforces >= 0
-  // (no upper cap — TV / games can have hundreds of episodes / achievements).
+  // (no upper cap, TV / games can have hundreds of episodes / achievements).
   progress: z.number().int().min(0).optional(),
+  // volumeProgress: manga volumes completed. Mirrors `progress` shape. Story 8.6.
+  // Only the MANGA branch reads this; non-manga types pass it through to the
+  // update unchanged (the DB column defaults to 0 for non-manga rows).
+  volumeProgress: z.number().int().min(0).optional(),
   status: z.nativeEnum(WatchStatus).optional(),
   completed_at: z.string().datetime().nullable().optional(),
 })
@@ -68,13 +72,18 @@ async function handler(req: NextRequest): Promise<NextResponse> {
     )
   }
 
-  const { mediaItemId, progress, status, completed_at } = parsed.data
+  const { mediaItemId, progress, volumeProgress, status, completed_at } =
+    parsed.data
 
   const data: Prisma.UserEntryUpdateInput = {}
   const fieldsApplied: string[] = []
   if (progress !== undefined) {
     data.progress = progress
     fieldsApplied.push('progress')
+  }
+  if (volumeProgress !== undefined) {
+    data.volume_progress = volumeProgress
+    fieldsApplied.push('volumeProgress')
   }
   if (status !== undefined) {
     data.status = status
@@ -179,6 +188,50 @@ async function handler(req: NextRequest): Promise<NextResponse> {
     } else if (
       entry.status === WatchStatus.PLAN_TO_WATCH &&
       effectiveProgress >= 1
+    ) {
+      data.status = WatchStatus.WATCHING
+      if (!fieldsApplied.includes('status')) fieldsApplied.push('status')
+    }
+  }
+
+  // Story 8.6 AC-5: manga auto-advance. Gated on MediaType.MANGA. Parallel
+  // shape to the anime branch above but applies the coalesce rule
+  // independently to chapter progress and volume progress, and uses
+  // chapter_count as the completion threshold. Anime / movie / TV / episode
+  // paths are unaffected.
+  if (
+    entry.media_item.type === MediaType.MANGA &&
+    (progress !== undefined || volumeProgress !== undefined)
+  ) {
+    let effectiveProgress = entry.progress
+    if (progress !== undefined) {
+      effectiveProgress =
+        progress >= entry.progress
+          ? Math.max(entry.progress, progress)
+          : progress
+      data.progress = effectiveProgress
+    }
+
+    const existingVolume = entry.volume_progress
+    let effectiveVolume = existingVolume
+    if (volumeProgress !== undefined) {
+      effectiveVolume =
+        volumeProgress >= existingVolume
+          ? Math.max(existingVolume, volumeProgress)
+          : volumeProgress
+      data.volume_progress = effectiveVolume
+    }
+
+    const chapterCount = entry.media_item.chapter_count
+    if (chapterCount !== null && effectiveProgress >= chapterCount) {
+      data.status = WatchStatus.COMPLETED
+      if (entry.completed_at === null) {
+        data.completed_at = new Date()
+      }
+      if (!fieldsApplied.includes('status')) fieldsApplied.push('status')
+    } else if (
+      entry.status === WatchStatus.PLAN_TO_WATCH &&
+      (effectiveProgress >= 1 || effectiveVolume >= 1)
     ) {
       data.status = WatchStatus.WATCHING
       if (!fieldsApplied.includes('status')) fieldsApplied.push('status')

--- a/app/global.css
+++ b/app/global.css
@@ -3396,3 +3396,78 @@ body {
   color: var(--phosphor-green, var(--rb-green));
   outline: none;
 }
+
+/* =========================================================================
+ * ChapterVolumeTracker (Story 8.6) — manga detail page two-axis tracker.
+ *
+ * Two stacked rows: chapter axis (always present) and volume axis (rendered
+ * only when volume_count > 0). Each row has a label, a PhosphorBar, and a
+ * controls strip with +1 / -1 buttons. The chapter row also surfaces the
+ * MARK VOLUME N COMPLETE shortcut when a next volume is available.
+ * ========================================================================= */
+.chapter-volume-tracker {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.chapter-volume-tracker-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 1px solid var(--phosphor-cream-ghost);
+  background: var(--ground-card, rgba(34, 26, 48, 0.55));
+}
+.chapter-volume-tracker-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0;
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream);
+}
+.chapter-volume-tracker-ongoing {
+  display: inline-block;
+  padding: 2px 8px;
+  border: 1px solid var(--phosphor-green, var(--rb-green));
+  color: var(--phosphor-green, var(--rb-green));
+  font-size: 10px;
+  animation: phosphor-pulse 2.4s ease-in-out infinite;
+}
+@keyframes phosphor-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .chapter-volume-tracker-ongoing { animation: none; }
+}
+.chapter-volume-tracker-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.chapter-volume-tracker-button {
+  min-width: 48px;
+}
+.chapter-volume-tracker-button-mark {
+  min-width: auto;
+  padding-left: 14px;
+  padding-right: 14px;
+}
+.chapter-volume-tracker-button[disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.manga-detail-genre-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+

--- a/app/preview/[source]/[type]/[id]/AddToLibraryButton.tsx
+++ b/app/preview/[source]/[type]/[id]/AddToLibraryButton.tsx
@@ -49,10 +49,7 @@ export function AddToLibraryButton({
     mutationFn: addToLibrary,
     onSuccess: (data) => {
       toast.success('ADDED TO LIBRARY')
-      const hasDetailPage = medium !== 'manga'
-      router.push(
-        hasDetailPage ? `/${medium}/${data.mediaItem.id}` : `/${medium}`,
-      )
+      router.push(`/${medium}/${data.mediaItem.id}`)
     },
     onError: (err) => {
       const reason =

--- a/components/molecules/ChapterVolumeTracker/ChapterVolumeTracker.tsx
+++ b/components/molecules/ChapterVolumeTracker/ChapterVolumeTracker.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { PhosphorBar } from '@/components/atoms/PhosphorBar'
+import { CHAPTERS_PER_VOLUME } from '@/lib/constants/manga'
+
+export type ChapterVolumeTrackerProps = {
+  chapterCount: number | null
+  volumeCount: number | null
+  progress: number
+  volumeProgress: number
+  lifecycleStatus: string | null
+  onUpdate: (next: { progress: number; volumeProgress: number }) => void
+  disabled?: boolean
+}
+
+export function ChapterVolumeTracker({
+  chapterCount,
+  volumeCount,
+  progress,
+  volumeProgress,
+  lifecycleStatus,
+  onUpdate,
+  disabled = false,
+}: ChapterVolumeTrackerProps) {
+  const hasVolumeAxis = volumeCount !== null && volumeCount > 0
+  const isOngoing = lifecycleStatus === 'RELEASING' || lifecycleStatus === 'releasing'
+  const chapterMax =
+    chapterCount !== null && chapterCount > 0
+      ? chapterCount
+      : Math.max(progress + 1, 1)
+  const volumeMax =
+    hasVolumeAxis && volumeCount !== null && volumeCount > 0 ? volumeCount : 0
+
+  const nextVolumeNumber = volumeProgress + 1
+  const canMarkNextVolume =
+    hasVolumeAxis &&
+    volumeCount !== null &&
+    nextVolumeNumber <= volumeCount
+
+  function decrementChapter() {
+    if (progress <= 0) return
+    onUpdate({ progress: progress - 1, volumeProgress })
+  }
+
+  function incrementChapter() {
+    onUpdate({ progress: progress + 1, volumeProgress })
+  }
+
+  function decrementVolume() {
+    if (volumeProgress <= 0) return
+    onUpdate({ progress, volumeProgress: volumeProgress - 1 })
+  }
+
+  function incrementVolume() {
+    if (volumeCount !== null && volumeProgress >= volumeCount) return
+    onUpdate({ progress, volumeProgress: volumeProgress + 1 })
+  }
+
+  function markVolumeComplete() {
+    if (!canMarkNextVolume) return
+    onUpdate({
+      progress: nextVolumeNumber * CHAPTERS_PER_VOLUME,
+      volumeProgress: nextVolumeNumber,
+    })
+  }
+
+  return (
+    <div className='chapter-volume-tracker'>
+      <section className='chapter-volume-tracker-row chapter-volume-tracker-row-chapters'>
+        <p className='chapter-volume-tracker-label'>
+          <span>
+            {progress} / {chapterCount ?? '?'} CHAPTERS
+          </span>
+          {isOngoing ? (
+            <span
+              className='chapter-volume-tracker-ongoing'
+              aria-label='Status: ongoing'
+            >
+              ONGOING
+            </span>
+          ) : null}
+        </p>
+        <PhosphorBar
+          value={progress}
+          max={chapterMax}
+          label='Chapter progress'
+        />
+        <div className='chapter-volume-tracker-controls'>
+          <button
+            type='button'
+            className='cpb chapter-volume-tracker-button'
+            onClick={decrementChapter}
+            disabled={disabled || progress <= 0}
+            aria-label='Decrement chapter progress by one'
+          >
+            -1
+          </button>
+          <button
+            type='button'
+            className='cpb chapter-volume-tracker-button'
+            onClick={incrementChapter}
+            disabled={disabled}
+            aria-label='Increment chapter progress by one'
+          >
+            +1
+          </button>
+          {canMarkNextVolume ? (
+            <button
+              type='button'
+              className='cpb chapter-volume-tracker-button chapter-volume-tracker-button-mark'
+              onClick={markVolumeComplete}
+              disabled={disabled}
+              aria-label={`Mark volume ${nextVolumeNumber} complete`}
+            >
+              MARK VOLUME {nextVolumeNumber} COMPLETE
+            </button>
+          ) : null}
+        </div>
+      </section>
+      {hasVolumeAxis ? (
+        <section className='chapter-volume-tracker-row chapter-volume-tracker-row-volumes'>
+          <p className='chapter-volume-tracker-label'>
+            {volumeProgress} / {volumeCount} VOLUMES
+          </p>
+          <PhosphorBar
+            value={volumeProgress}
+            max={volumeMax}
+            label='Volume progress'
+          />
+          <div className='chapter-volume-tracker-controls'>
+            <button
+              type='button'
+              className='cpb chapter-volume-tracker-button'
+              onClick={decrementVolume}
+              disabled={disabled || volumeProgress <= 0}
+              aria-label='Decrement volume progress by one'
+            >
+              -1
+            </button>
+            <button
+              type='button'
+              className='cpb chapter-volume-tracker-button'
+              onClick={incrementVolume}
+              disabled={
+                disabled || (volumeCount !== null && volumeProgress >= volumeCount)
+              }
+              aria-label='Increment volume progress by one'
+            >
+              +1
+            </button>
+          </div>
+        </section>
+      ) : null}
+    </div>
+  )
+}

--- a/components/molecules/ChapterVolumeTracker/__tests__/ChapterVolumeTracker.test.tsx
+++ b/components/molecules/ChapterVolumeTracker/__tests__/ChapterVolumeTracker.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ChapterVolumeTracker } from '../ChapterVolumeTracker'
+import { CHAPTERS_PER_VOLUME } from '@/lib/constants/manga'
+
+describe('ChapterVolumeTracker', () => {
+  it('renders the chapter row with progress and total', () => {
+    render(
+      <ChapterVolumeTracker
+        chapterCount={150}
+        volumeCount={15}
+        progress={42}
+        volumeProgress={4}
+        lifecycleStatus='FINISHED'
+        onUpdate={vi.fn()}
+      />,
+    )
+    expect(screen.getByLabelText('Chapter progress')).toBeTruthy()
+    expect(screen.getByText(/42 \/ 150 CHAPTERS/)).toBeTruthy()
+  })
+
+  it('renders the volume row only when volumeCount > 0', () => {
+    const { rerender } = render(
+      <ChapterVolumeTracker
+        chapterCount={150}
+        volumeCount={null}
+        progress={10}
+        volumeProgress={0}
+        lifecycleStatus={null}
+        onUpdate={vi.fn()}
+      />,
+    )
+    expect(screen.queryByLabelText('Volume progress')).toBeNull()
+
+    rerender(
+      <ChapterVolumeTracker
+        chapterCount={150}
+        volumeCount={15}
+        progress={10}
+        volumeProgress={1}
+        lifecycleStatus={null}
+        onUpdate={vi.fn()}
+      />,
+    )
+    expect(screen.getByLabelText('Volume progress')).toBeTruthy()
+    expect(screen.getByText(/1 \/ 15 VOLUMES/)).toBeTruthy()
+  })
+
+  it('+1 chapter calls onUpdate with progress + 1 and unchanged volumeProgress', () => {
+    const onUpdate = vi.fn()
+    render(
+      <ChapterVolumeTracker
+        chapterCount={150}
+        volumeCount={15}
+        progress={5}
+        volumeProgress={0}
+        lifecycleStatus={null}
+        onUpdate={onUpdate}
+      />,
+    )
+    fireEvent.click(
+      screen.getByLabelText('Increment chapter progress by one'),
+    )
+    expect(onUpdate).toHaveBeenCalledWith({ progress: 6, volumeProgress: 0 })
+  })
+
+  it('-1 chapter is disabled at progress 0', () => {
+    const onUpdate = vi.fn()
+    render(
+      <ChapterVolumeTracker
+        chapterCount={150}
+        volumeCount={15}
+        progress={0}
+        volumeProgress={0}
+        lifecycleStatus={null}
+        onUpdate={onUpdate}
+      />,
+    )
+    const dec = screen.getByLabelText(
+      'Decrement chapter progress by one',
+    ) as HTMLButtonElement
+    expect(dec.disabled).toBe(true)
+    fireEvent.click(dec)
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it('MARK VOLUME N COMPLETE jumps both axes', () => {
+    const onUpdate = vi.fn()
+    render(
+      <ChapterVolumeTracker
+        chapterCount={150}
+        volumeCount={15}
+        progress={5}
+        volumeProgress={0}
+        lifecycleStatus={null}
+        onUpdate={onUpdate}
+      />,
+    )
+    fireEvent.click(screen.getByLabelText('Mark volume 1 complete'))
+    expect(onUpdate).toHaveBeenCalledWith({
+      progress: CHAPTERS_PER_VOLUME,
+      volumeProgress: 1,
+    })
+  })
+
+  it('MARK VOLUME N COMPLETE hides when volumeProgress equals volumeCount', () => {
+    render(
+      <ChapterVolumeTracker
+        chapterCount={150}
+        volumeCount={15}
+        progress={150}
+        volumeProgress={15}
+        lifecycleStatus={null}
+        onUpdate={vi.fn()}
+      />,
+    )
+    expect(screen.queryByLabelText(/Mark volume \d+ complete/)).toBeNull()
+  })
+
+  it('shows ONGOING chip when lifecycleStatus is RELEASING', () => {
+    render(
+      <ChapterVolumeTracker
+        chapterCount={150}
+        volumeCount={15}
+        progress={5}
+        volumeProgress={0}
+        lifecycleStatus='RELEASING'
+        onUpdate={vi.fn()}
+      />,
+    )
+    expect(screen.getByLabelText('Status: ongoing')).toBeTruthy()
+  })
+
+  it('hides ONGOING chip for finished manga', () => {
+    render(
+      <ChapterVolumeTracker
+        chapterCount={150}
+        volumeCount={15}
+        progress={5}
+        volumeProgress={0}
+        lifecycleStatus='FINISHED'
+        onUpdate={vi.fn()}
+      />,
+    )
+    expect(screen.queryByLabelText('Status: ongoing')).toBeNull()
+  })
+
+  it('volume +1 calls onUpdate with progress unchanged and volumeProgress + 1', () => {
+    const onUpdate = vi.fn()
+    render(
+      <ChapterVolumeTracker
+        chapterCount={150}
+        volumeCount={15}
+        progress={42}
+        volumeProgress={3}
+        lifecycleStatus={null}
+        onUpdate={onUpdate}
+      />,
+    )
+    fireEvent.click(
+      screen.getByLabelText('Increment volume progress by one'),
+    )
+    expect(onUpdate).toHaveBeenCalledWith({ progress: 42, volumeProgress: 4 })
+  })
+
+  it('volume +1 is disabled when volumeProgress equals volumeCount', () => {
+    render(
+      <ChapterVolumeTracker
+        chapterCount={150}
+        volumeCount={15}
+        progress={150}
+        volumeProgress={15}
+        lifecycleStatus={null}
+        onUpdate={vi.fn()}
+      />,
+    )
+    const inc = screen.getByLabelText(
+      'Increment volume progress by one',
+    ) as HTMLButtonElement
+    expect(inc.disabled).toBe(true)
+  })
+})

--- a/components/molecules/ChapterVolumeTracker/index.ts
+++ b/components/molecules/ChapterVolumeTracker/index.ts
@@ -1,0 +1,2 @@
+export { ChapterVolumeTracker } from './ChapterVolumeTracker'
+export type { ChapterVolumeTrackerProps } from './ChapterVolumeTracker'

--- a/e2e/manga-detail.spec.ts
+++ b/e2e/manga-detail.spec.ts
@@ -1,0 +1,151 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+
+// Story 8.6 AC-9: navigate /manga/[id] -> assert hero + ChapterVolumeTracker
+// + Authors + Relations -> +1 chapter -> reload -> assert persisted -> MARK
+// VOLUME 1 COMPLETE -> reload -> assert chapter progress jumped to
+// CHAPTERS_PER_VOLUME and volume progress is 1.
+//
+// Skip-in-CI semantics match e2e/anime-detail.spec.ts: requires live AniList
+// reachability for the Server Component's getMedia + getMediaRelations calls,
+// plus at least one manga in the seeded library.
+
+const ADMIN_PASS = process.env.ADMIN_PASS
+const CHAPTERS_PER_VOLUME = 10
+
+async function getFirstMangaId(api: APIRequestContext): Promise<string> {
+  const res = await api.get('/api/library?type=MANGA&limit=5')
+  expect(res.ok()).toBeTruthy()
+  const body = (await res.json()) as { items: Array<{ mediaItemId: string }> }
+  expect(body.items.length).toBeGreaterThan(0)
+  return body.items[0].mediaItemId
+}
+
+async function resetMangaProgress(
+  api: APIRequestContext,
+  mediaItemId: string,
+): Promise<void> {
+  // Reset to progress: 0, volume_progress: 0, PLAN_TO_WATCH so the test is
+  // idempotent across runs.
+  const res = await api.fetch('/api/progress', {
+    method: 'PUT',
+    data: {
+      mediaItemId,
+      progress: 0,
+      volumeProgress: 0,
+      status: 'PLAN_TO_WATCH',
+      completed_at: null,
+    },
+  })
+  expect(res.ok()).toBeTruthy()
+}
+
+test.beforeAll(async () => {
+  if (!ADMIN_PASS) {
+    throw new Error(
+      'ADMIN_PASS env is required for e2e tests. Set it in .env (local) or the CI env block.',
+    )
+  }
+})
+
+test.describe('/manga/[id] detail page (Story 8.6)', () => {
+  test('AC-9: hero + tracker + Authors render; +1 chapter persists across reload', async ({
+    page,
+  }) => {
+    test.skip(
+      process.env.TMDB_API_KEY === 'test' || !process.env.TMDB_API_KEY,
+      'Requires real TMDB key (for the auth/layout stack) + live AniList reachability + a seeded manga in the library.',
+    )
+
+    await page.goto('/login')
+    await page.getByLabel('PASSWORD').fill(ADMIN_PASS!)
+    await page.getByRole('button', { name: '> LOG IN' }).click()
+    await page.waitForURL('/', { timeout: 10_000 })
+
+    const api = page.request
+    const mediaItemId = await getFirstMangaId(api)
+    await resetMangaProgress(api, mediaItemId)
+
+    await page.goto(`/manga/${mediaItemId}`)
+
+    await expect(
+      page.getByRole('link', { name: /BACK TO LIBRARY/i }),
+    ).toBeVisible()
+
+    // The chapter row of ChapterVolumeTracker must render the progress label.
+    await expect(page.getByLabel('Chapter progress').first()).toBeVisible({
+      timeout: 10_000,
+    })
+
+    // Authors band (when the seeded manga has an author_name).
+    const authorsBand = page.getByRole('heading', { name: 'Authors' })
+    if ((await authorsBand.count()) > 0) {
+      await expect(authorsBand).toBeVisible()
+    }
+
+    // +1 chapter -> progress 0 -> 1 -> WATCHING.
+    await page
+      .getByRole('button', { name: 'Increment chapter progress by one' })
+      .click()
+    await expect(page.getByText(/^1 \/ /)).toBeVisible({ timeout: 10_000 })
+
+    // Hard reload to assert server-side persistence.
+    await page.reload()
+    await expect(page.getByText(/^1 \/ /)).toBeVisible({ timeout: 10_000 })
+
+    await resetMangaProgress(api, mediaItemId)
+  })
+
+  test('AC-9: MARK VOLUME 1 COMPLETE jumps chapter to CHAPTERS_PER_VOLUME and volume to 1', async ({
+    page,
+  }) => {
+    test.skip(
+      process.env.TMDB_API_KEY === 'test' || !process.env.TMDB_API_KEY,
+      'Requires real TMDB key + live AniList + a seeded manga with volume_count > 0.',
+    )
+
+    await page.goto('/login')
+    await page.getByLabel('PASSWORD').fill(ADMIN_PASS!)
+    await page.getByRole('button', { name: '> LOG IN' }).click()
+    await page.waitForURL('/', { timeout: 10_000 })
+
+    const api = page.request
+    const mediaItemId = await getFirstMangaId(api)
+    await resetMangaProgress(api, mediaItemId)
+
+    await page.goto(`/manga/${mediaItemId}`)
+
+    const markBtn = page.getByRole('button', { name: 'Mark volume 1 complete' })
+    const hasMark = (await markBtn.count()) > 0
+    test.skip(
+      !hasMark,
+      'Seeded manga does not expose a volume axis (volume_count is null or 0).',
+    )
+
+    await markBtn.click()
+    await expect(
+      page.getByText(new RegExp(`^${CHAPTERS_PER_VOLUME} \\/ `)),
+    ).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/^1 \/ \d+ VOLUMES/)).toBeVisible()
+
+    await page.reload()
+    await expect(
+      page.getByText(new RegExp(`^${CHAPTERS_PER_VOLUME} \\/ `)),
+    ).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/^1 \/ \d+ VOLUMES/)).toBeVisible()
+
+    await resetMangaProgress(api, mediaItemId)
+  })
+
+  test('returns 404 for a non-existent manga id', async ({ page }) => {
+    await page.goto('/login')
+    await page.getByLabel('PASSWORD').fill(ADMIN_PASS!)
+    await page.getByRole('button', { name: '> LOG IN' }).click()
+    await page.waitForURL('/', { timeout: 10_000 })
+
+    await page.goto('/manga/this-id-does-not-exist')
+    await expect(page.getByText(/MANGA NOT IN LIBRARY/i)).toBeVisible()
+    await expect(
+      page.getByRole('link', { name: /BACK TO MANGA LIBRARY/i }),
+    ).toBeVisible()
+  })
+})

--- a/lib/constants/__tests__/manga.test.ts
+++ b/lib/constants/__tests__/manga.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest'
+import { CHAPTERS_PER_VOLUME } from '@/lib/constants/manga'
+
+describe('manga constants', () => {
+  it('CHAPTERS_PER_VOLUME is 10 (pinned to the migration backfill SQL)', () => {
+    expect(CHAPTERS_PER_VOLUME).toBe(10)
+  })
+})

--- a/lib/constants/manga.ts
+++ b/lib/constants/manga.ts
@@ -1,0 +1,10 @@
+// Default chapters per volume. Used by:
+// - ChapterVolumeTracker molecule (MARK VOLUME N COMPLETE math)
+// - UserEntry.volume_progress migration backfill
+// - /api/progress MANGA branch (no direct use today; reserved for future per-manga override)
+//
+// * Failure mode: drift between this constant and the migration's hardcoded
+//   10 silently corrupts new manga rows on a later migration. The
+//   migration.sql comment names this file; the test in __tests__/manga.test.ts
+//   pins the value so a regression fails CI.
+export const CHAPTERS_PER_VOLUME = 10

--- a/lib/detail-route.ts
+++ b/lib/detail-route.ts
@@ -15,9 +15,7 @@ export function detailRouteFor(item: DetailRouteInput): string | null {
     case MediaType.ANIME:
       return `/anime/${item.mediaItemId}`
     case MediaType.MANGA:
-      return item.anilistId != null
-        ? `/preview/anilist/manga/${item.anilistId}`
-        : null
+      return `/manga/${item.mediaItemId}`
     case MediaType.TV_EPISODE:
     case MediaType.GAME:
     default:

--- a/prisma/migrations/20260520150000_user_entry_volume_progress/migration.sql
+++ b/prisma/migrations/20260520150000_user_entry_volume_progress/migration.sql
@@ -1,0 +1,23 @@
+-- UserEntry.volume_progress for manga two-axis tracking (Story 8.6).
+-- Non-null with default 0 so existing rows (movies, TV, anime, games) stay
+-- valid without backfill. Existing MANGA rows backfill via the chapters-per-volume
+-- default; new MANGA rows start at 0 and advance via PUT /api/progress.
+--
+-- The IF NOT EXISTS clause and the WHERE volume_progress = 0 guard on the
+-- backfill UPDATE make the migration idempotent — re-running it (e.g. on a
+-- partially-applied dev DB) is a no-op rather than a failure.
+
+ALTER TABLE "UserEntry"
+  ADD COLUMN IF NOT EXISTS "volume_progress" INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill MANGA rows. The literal 10 mirrors CHAPTERS_PER_VOLUME in
+-- lib/constants/manga.ts. Update both together if the default ever changes.
+UPDATE "UserEntry" AS ue
+   SET "volume_progress" = FLOOR(ue."progress"::numeric / 10)
+ WHERE ue."volume_progress" = 0
+   AND EXISTS (
+     SELECT 1
+       FROM "MediaItem" mi
+      WHERE mi.id = ue.media_item_id
+        AND mi.type = 'MANGA'
+   );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -155,10 +155,11 @@ model UserEntry {
   id            String      @id @default(cuid())
   media_item_id String      @unique
   media_item    MediaItem   @relation(fields: [media_item_id], references: [id], onDelete: Cascade)
-  status        WatchStatus @default(PLAN_TO_WATCH)
-  user_rating   Float? // personal rating 1-10
-  progress      Int         @default(0) // episode / chapter / achievement count
-  notes         String?
+  status         WatchStatus @default(PLAN_TO_WATCH)
+  user_rating    Float? // personal rating 1-10
+  progress       Int         @default(0) // episode / chapter / achievement count
+  volume_progress Int        @default(0) // manga: volumes completed (default 0 for non-manga; backfilled via Math.floor(progress / CHAPTERS_PER_VOLUME) for existing MANGA rows in the 20260520 migration)
+  notes          String?
   started_at    DateTime?
   completed_at  DateTime?
   created_at    DateTime    @default(now())


### PR DESCRIPTION
Story 8.6. Implements the /manga/[id] detail page mirroring /anime/[id] in shape, adds a two-axis ChapterVolumeTracker molecule, adds UserEntry.volume_progress with an idempotent migration, and removes the two temporary manga guards that PR #142 introduced.

Closes #143.

## Summary

- New route `app/(media)/manga/[id]/page.tsx` Server Component renders hero, synopsis, Chapters band (with `ChapterVolumeTracker`), Authors band, Genres band, and Relations band.
- New `ChapterVolumeTracker` molecule: two PhosphorBar rows (chapters + optional volumes), +/-1 controls, and a `MARK VOLUME N COMPLETE` shortcut that mutates both axes in a single PUT.
- New `MangaDetailControls` client island wires the tracker to PUT /api/progress via TanStack v5.
- `UserEntry.volume_progress Int @default(0)` added by `20260520150000_user_entry_volume_progress`. Idempotent: `ADD COLUMN IF NOT EXISTS` plus a `WHERE volume_progress = 0 AND EXISTS (manga)` backfill that sets `FLOOR(progress / CHAPTERS_PER_VOLUME)` for existing manga rows.
- `lib/constants/manga.ts` exports `CHAPTERS_PER_VOLUME = 10` (pinned by a unit test; migration SQL comment names this constant).
- PUT /api/progress accepts `volumeProgress` and runs a new MANGA branch parallel to the ANIME branch (max-coalesce per axis, trust decrement, promote PLAN_TO_WATCH on either axis, auto-complete on chapter_count with idempotent completed_at).
- Cleanup commit `1b381b5a`: `lib/detail-route.ts` MANGA case returns `/manga/<id>`; `AddToLibraryButton` no longer guards the manga redirect.

## Acceptance Criteria

All 11 ACs satisfied; see [the spec](../blob/epic-8-manga-detail/_bmad-output/implementation-artifacts/8-6-implement-manga-id-detail-page-with-chapter-and-volume-tracking.md) for the full mapping. AC9 (Playwright) is gated on real AniList plus a seeded manga; not run in dev-story.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm lint --max-warnings=0` clean.
- [x] `pnpm test` 821/823 passing (only the 2 pre-existing BullMQ worker tests fail without Redis).
- [x] 8 new manga-branch cases in `app/api/progress` route tests.
- [x] 10 new cases in `ChapterVolumeTracker` molecule tests.
- [x] 1 constants test pinning CHAPTERS_PER_VOLUME.
- [ ] Playwright e2e at `e2e/manga-detail.spec.ts` (manual / CI run; requires real AniList plus a seeded manga with `volume_count > 0`).

## Commits on this branch

- `3323ab40` feat(manga): /manga/[id] detail page + ChapterVolumeTracker + volume_progress migration (#143)
- `1b381b5a` fix(manga): route manga to /manga/[id] now that detail page exists (#143)

## Manual smoke checklist (Cuatro)

- `/manga/<id>` renders for an in-library manga; chapter +1 advances progress; reload persists.
- MARK VOLUME 1 COMPLETE jumps chapter progress to 10 and volume progress to 1.
- Dashboard manga card lands on `/manga/<id>` (not preview).
- "ADD TO LIBRARY" on a manga preview navigates to `/manga/<id>` (not `/manga` grid).
- `/manga/this-id-does-not-exist` renders the 404 page.