### PR TITLE
feat(games): IGDB + Steam adapters + worker processors (Bundle A)

### DIFF
--- a/lib/api/__tests__/igdb.test.ts
+++ b/lib/api/__tests__/igdb.test.ts
@@ -1,0 +1,432 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const loggerMock = vi.hoisted(() => ({
+  fatal: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+}))
+
+const redisStore = vi.hoisted(() => new Map<string, string>())
+const redisMock = vi.hoisted(() => ({
+  get: vi.fn(async (key: string) => redisStore.get(key) ?? null),
+  set: vi.fn(
+    async (
+      key: string,
+      value: string,
+      _expiryToken?: string,
+      _ttlSeconds?: number,
+    ) => {
+      redisStore.set(key, value)
+      return 'OK'
+    },
+  ),
+  del: vi.fn(async (...keys: string[]) => {
+    let removed = 0
+    for (const k of keys) {
+      if (redisStore.delete(k)) removed++
+    }
+    return removed
+  }),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: loggerMock,
+  createLogger: () => loggerMock,
+}))
+
+vi.mock('@/lib/redis', () => ({
+  redis: redisMock,
+  closeRedis: vi.fn(async () => {}),
+}))
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  ANILIST_USER_AGENT: 'cuatro-tracker/test',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  })
+}
+
+function seedFreshToken(): void {
+  redisStore.set('igdb:token', 'cached-token')
+  redisStore.set(
+    'igdb:token:expiresAt',
+    String(Date.now() + 30 * 24 * 60 * 60 * 1000),
+  )
+}
+
+function makeGame(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 1942,
+    name: 'The Witcher 3: Wild Hunt',
+    summary: 'Open-world action RPG.',
+    first_release_date: 1431993600,
+    cover: { id: 99, image_id: 'co1uii' },
+    screenshots: [{ id: 1, image_id: 'sc1' }],
+    genres: [{ id: 5, name: 'Role-playing (RPG)' }],
+    platforms: [{ id: 6, name: 'PC (Microsoft Windows)' }],
+    involved_companies: [
+      {
+        id: 1,
+        company: { id: 1, name: 'CD Projekt RED' },
+        developer: true,
+        publisher: false,
+      },
+    ],
+    release_dates: [{ id: 1, y: 2015 }],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.resetAllMocks()
+  redisStore.clear()
+  // Re-bind the mock implementations after resetAllMocks wipes them.
+  redisMock.get.mockImplementation(async (key: string) => redisStore.get(key) ?? null)
+  redisMock.set.mockImplementation(
+    async (key: string, value: string) => {
+      redisStore.set(key, value)
+      return 'OK'
+    },
+  )
+  redisMock.del.mockImplementation(async (...keys: string[]) => {
+    let removed = 0
+    for (const k of keys) {
+      if (redisStore.delete(k)) removed++
+    }
+    return removed
+  })
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('searchGames + getGame happy path', () => {
+  it('searchGames returns parsed games when token is fresh', async () => {
+    seedFreshToken()
+    const fetchSpy = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        jsonResponse([makeGame()]),
+    )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { searchGames } = await import('@/lib/api/igdb')
+    const games = await searchGames('witcher')
+
+    expect(games).toHaveLength(1)
+    expect(games[0]?.name).toBe('The Witcher 3: Wild Hunt')
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchSpy.mock.calls[0]!
+    expect(String(url)).toBe('https://api.igdb.com/v4/games')
+    expect((init as RequestInit | undefined)?.method).toBe('POST')
+    const headers = (init as RequestInit).headers as Record<string, string>
+    expect(headers['Client-ID']).toBe('igdb-id')
+    expect(headers.Authorization).toBe('Bearer cached-token')
+    expect((init as RequestInit).body).toContain('search "witcher"')
+    expect((init as RequestInit).body).toContain('limit 25')
+  })
+
+  it('getGame returns the first game when one matches', async () => {
+    seedFreshToken()
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse([makeGame()])))
+
+    const { getGame } = await import('@/lib/api/igdb')
+    const game = await getGame(1942)
+    expect(game.id).toBe(1942)
+    expect(game.cover?.image_id).toBe('co1uii')
+  })
+
+  it('getGame throws IgdbApiError with httpStatus 404 when no game matches', async () => {
+    seedFreshToken()
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse([])))
+
+    const { getGame, IgdbApiError } = await import('@/lib/api/igdb')
+    await expect(getGame(999999)).rejects.toBeInstanceOf(IgdbApiError)
+    await expect(getGame(999999)).rejects.toMatchObject({
+      httpStatus: 404,
+      endpoint: 'games/999999',
+    })
+  })
+})
+
+describe('refreshIgdbToken', () => {
+  it('POSTs to Twitch with grant_type=client_credentials and persists token + expiresAt', async () => {
+    const fetchSpy = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        jsonResponse({
+          access_token: 'fresh-token',
+          expires_in: 5184000,
+          token_type: 'bearer',
+        }),
+    )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { refreshIgdbToken } = await import('@/lib/api/igdb')
+    const before = Date.now()
+    const { token, expiresAt } = await refreshIgdbToken()
+
+    expect(token).toBe('fresh-token')
+    expect(expiresAt).toBeGreaterThanOrEqual(before + 5184000 * 1000 - 5)
+
+    const [url, init] = fetchSpy.mock.calls[0]!
+    expect(String(url)).toBe(
+      'https://id.twitch.tv/oauth2/token?client_id=igdb-id&client_secret=igdb-secret&grant_type=client_credentials',
+    )
+    expect((init as RequestInit | undefined)?.method).toBe('POST')
+
+    expect(redisMock.set).toHaveBeenCalledWith(
+      'igdb:token',
+      'fresh-token',
+      'EX',
+      5184000,
+    )
+    expect(redisMock.set).toHaveBeenCalledWith(
+      'igdb:token:expiresAt',
+      expect.stringMatching(/^\d+$/),
+    )
+  })
+
+  it('triggers a refresh when expiresAt is within the 24h threshold', async () => {
+    redisStore.set('igdb:token', 'stale-token')
+    redisStore.set(
+      'igdb:token:expiresAt',
+      String(Date.now() + 60 * 60 * 1000),
+    )
+
+    const fetchSpy = vi
+      .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+      // 1st call: Twitch token refresh
+      .mockResolvedValueOnce(
+        jsonResponse({
+          access_token: 'rotated',
+          expires_in: 5184000,
+          token_type: 'bearer',
+        }),
+      )
+      // 2nd call: actual IGDB request
+      .mockResolvedValueOnce(jsonResponse([makeGame()]))
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getGame } = await import('@/lib/api/igdb')
+    await getGame(1942)
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      'id.twitch.tv/oauth2/token',
+    )
+    expect(String(fetchSpy.mock.calls[1]![0])).toBe(
+      'https://api.igdb.com/v4/games',
+    )
+    const igdbHeaders = (fetchSpy.mock.calls[1]![1] as RequestInit)
+      .headers as Record<string, string>
+    expect(igdbHeaders.Authorization).toBe('Bearer rotated')
+  })
+
+  it('rejects with IgdbApiError when Twitch returns 401', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('unauthorized', { status: 401 })),
+    )
+
+    const { refreshIgdbToken, IgdbApiError } = await import('@/lib/api/igdb')
+    await expect(refreshIgdbToken()).rejects.toBeInstanceOf(IgdbApiError)
+    await expect(refreshIgdbToken()).rejects.toMatchObject({
+      httpStatus: 401,
+      endpoint: 'twitch/oauth2/token',
+    })
+  })
+
+  it('parse failure surfaces fieldPath in the IgdbApiError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          access_token: '',
+          expires_in: 5184000,
+          token_type: 'bearer',
+        }),
+      ),
+    )
+
+    const { refreshIgdbToken, IgdbApiError } = await import('@/lib/api/igdb')
+    try {
+      await refreshIgdbToken()
+      expect.fail('refreshIgdbToken should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(IgdbApiError)
+      const igdbErr = err as InstanceType<typeof IgdbApiError>
+      expect(igdbErr.fieldPath).toBe('access_token')
+    }
+  })
+})
+
+describe('retry + backoff on 5xx and 429', () => {
+  it('retries on 5xx with 1s, 2s, 4s backoff (3 attempts before throwing)', async () => {
+    seedFreshToken()
+    vi.useFakeTimers()
+    const fetchSpy = vi
+      .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response('boom', { status: 500 }))
+      .mockResolvedValueOnce(new Response('boom', { status: 500 }))
+      .mockResolvedValueOnce(new Response('boom', { status: 500 }))
+      .mockResolvedValueOnce(new Response('boom', { status: 500 }))
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getGame, IgdbApiError } = await import('@/lib/api/igdb')
+    const promise = getGame(1942)
+    // Catch eagerly so the unhandled-rejection guard does not fire while we
+    // crank the fake clock through the backoff schedule.
+    const rejection = promise.catch((err) => err)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.advanceTimersByTimeAsync(4000)
+    const err = await rejection
+    expect(err).toBeInstanceOf(IgdbApiError)
+    expect((err as InstanceType<typeof IgdbApiError>).httpStatus).toBe(500)
+    expect(fetchSpy).toHaveBeenCalledTimes(4)
+  })
+
+  it('429 with Retry-After honours the header when greater than the base backoff', async () => {
+    seedFreshToken()
+    vi.useFakeTimers()
+    const fetchSpy = vi
+      .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+      .mockResolvedValueOnce(
+        new Response('slow down', {
+          status: 429,
+          headers: { 'Retry-After': '2' },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse([makeGame()]))
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getGame } = await import('@/lib/api/igdb')
+    const promise = getGame(1942)
+
+    // Base attempt 0 backoff is 1000ms; Retry-After header is 2000ms; the
+    // adapter waits the larger of the two before retrying.
+    await vi.advanceTimersByTimeAsync(1500)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(700)
+    const game = await promise
+    expect(game.id).toBe(1942)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('parse failures', () => {
+  it('throws IgdbApiError with fieldPath when a games array is malformed', async () => {
+    seedFreshToken()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse([
+          {
+            ...makeGame(),
+            name: 12345,
+          },
+        ]),
+      ),
+    )
+
+    const { getGame, IgdbApiError } = await import('@/lib/api/igdb')
+    try {
+      await getGame(1942)
+      expect.fail('expected parse failure')
+    } catch (err) {
+      expect(err).toBeInstanceOf(IgdbApiError)
+      const igdbErr = err as InstanceType<typeof IgdbApiError>
+      expect(igdbErr.fieldPath).toBe('0.name')
+      expect(igdbErr.endpoint).toBe('games/1942')
+    }
+  })
+})
+
+describe('slot-limited concurrency', () => {
+  it('caps in-flight IGDB requests at 4 and queues the rest', async () => {
+    seedFreshToken()
+
+    // Each call to fetch returns a deferred Promise; we control resolution
+    // order so we can assert that fetch is invoked at most 4 times until a
+    // slot frees, then a 5th time.
+    const deferreds: Array<{
+      resolve: (r: Response) => void
+      reject: (e: unknown) => void
+    }> = []
+    const fetchSpy = vi.fn(
+      (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Promise<Response>((resolve, reject) => {
+          deferreds.push({ resolve, reject })
+        }),
+    )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getGame } = await import('@/lib/api/igdb')
+    const results = Promise.all([
+      getGame(1),
+      getGame(2),
+      getGame(3),
+      getGame(4),
+      getGame(5),
+      getGame(6),
+    ])
+    // Surface unhandled-rejection noise as a no-op for the duration of the
+    // test; the resolved games array below is the success path.
+    const settled = results.catch(() => null)
+
+    // Flush microtasks so getGame -> withIgdbLimit -> getIgdbToken ->
+    // igdbFetch -> fetch all execute up to the awaited fetch.
+    await new Promise((r) => setImmediate(r))
+    await new Promise((r) => setImmediate(r))
+
+    expect(fetchSpy).toHaveBeenCalledTimes(4)
+
+    // Resolve the first deferred — that frees one slot, releasing the queued
+    // 5th call into fetch.
+    deferreds[0]!.resolve(jsonResponse([makeGame({ id: 1 })]))
+    await new Promise((r) => setImmediate(r))
+    await new Promise((r) => setImmediate(r))
+    expect(fetchSpy).toHaveBeenCalledTimes(5)
+
+    deferreds[1]!.resolve(jsonResponse([makeGame({ id: 2 })]))
+    await new Promise((r) => setImmediate(r))
+    await new Promise((r) => setImmediate(r))
+    expect(fetchSpy).toHaveBeenCalledTimes(6)
+
+    // Drain the remaining deferreds so the test does not hang.
+    deferreds[2]!.resolve(jsonResponse([makeGame({ id: 3 })]))
+    deferreds[3]!.resolve(jsonResponse([makeGame({ id: 4 })]))
+    deferreds[4]!.resolve(jsonResponse([makeGame({ id: 5 })]))
+    deferreds[5]!.resolve(jsonResponse([makeGame({ id: 6 })]))
+    await settled
+  })
+})

--- a/lib/api/__tests__/steam.test.ts
+++ b/lib/api/__tests__/steam.test.ts
@@ -1,0 +1,343 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const loggerMock = vi.hoisted(() => ({
+  fatal: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: loggerMock,
+  createLogger: () => loggerMock,
+}))
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(32),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  ANILIST_USER_AGENT: 'cuatro-tracker/test',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  })
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.resetAllMocks()
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('getOwnedGames', () => {
+  it('returns the parsed games array', async () => {
+    const fetchSpy = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        jsonResponse({
+          response: {
+            game_count: 2,
+            games: [
+              {
+                appid: 1942,
+                name: 'The Witcher 3',
+                playtime_forever: 3000,
+                img_icon_url: 'abc',
+                rtime_last_played: 1700000000,
+              },
+              {
+                appid: 7,
+                name: 'Half-Life 2',
+                playtime_forever: 0,
+              },
+            ],
+          },
+        }),
+    )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getOwnedGames } = await import('@/lib/api/steam')
+    const games = await getOwnedGames('76561197960287930')
+
+    expect(games).toHaveLength(2)
+    expect(games[0]?.name).toBe('The Witcher 3')
+    expect(games[1]?.playtime_forever).toBe(0)
+
+    const [url] = fetchSpy.mock.calls[0]!
+    expect(String(url)).toContain('/IPlayerService/GetOwnedGames/v0001/')
+    expect(String(url)).toContain('key=steam-key')
+    expect(String(url)).toContain('steamid=76561197960287930')
+    expect(String(url)).toContain('include_appinfo=1')
+  })
+
+  it('returns empty array when response.games is missing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          jsonResponse({ response: {} }),
+      ),
+    )
+    const { getOwnedGames } = await import('@/lib/api/steam')
+    const games = await getOwnedGames('76561197960287930')
+    expect(games).toEqual([])
+  })
+})
+
+describe('getSchemaForGame', () => {
+  it('returns the achievement schema array', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          jsonResponse({
+            game: {
+              gameName: 'Witcher 3',
+              availableGameStats: {
+                achievements: [
+                  {
+                    name: 'ach_01',
+                    displayName: 'First Steps',
+                    description: 'Take your first step.',
+                    icon: 'http://icon/01.png',
+                    icongray: 'http://icon/01g.png',
+                  },
+                ],
+              },
+            },
+          }),
+      ),
+    )
+
+    const { getSchemaForGame } = await import('@/lib/api/steam')
+    const schema = await getSchemaForGame('1942')
+    expect(schema).toHaveLength(1)
+    expect(schema[0]?.displayName).toBe('First Steps')
+  })
+
+  it('returns empty array when availableGameStats is missing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          jsonResponse({ game: { gameName: 'Bare Game' } }),
+      ),
+    )
+    const { getSchemaForGame } = await import('@/lib/api/steam')
+    expect(await getSchemaForGame('1942')).toEqual([])
+  })
+})
+
+describe('getPlayerAchievements', () => {
+  it('returns private_profile on 403', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          new Response('Forbidden', { status: 403 }),
+      ),
+    )
+
+    const { getPlayerAchievements } = await import('@/lib/api/steam')
+    const result = await getPlayerAchievements('76561197960287930', '1942')
+    expect(result).toEqual({ status: 'private_profile', appId: '1942' })
+  })
+
+  it('returns ok shape with empty achievements when playerstats.success is false', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          jsonResponse({
+            playerstats: {
+              success: false,
+              error: 'Requested app has no stats',
+            },
+          }),
+      ),
+    )
+
+    const { getPlayerAchievements } = await import('@/lib/api/steam')
+    const result = await getPlayerAchievements('76561197960287930', '99999')
+    expect(result.status).toBe('ok')
+    if (result.status === 'ok') {
+      expect(result.achievements).toEqual([])
+    }
+  })
+
+  it('merges player achievements with global percentages on 200', async () => {
+    const fetchSpy = vi
+      .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+      // 1st: GetPlayerAchievements
+      .mockResolvedValueOnce(
+        jsonResponse({
+          playerstats: {
+            steamID: '76561197960287930',
+            gameName: 'Witcher 3',
+            success: true,
+            achievements: [
+              { apiname: 'ach_01', achieved: 1, unlocktime: 1700000000 },
+              { apiname: 'ach_02', achieved: 0, unlocktime: 0 },
+              { apiname: 'ach_unknown_to_global', achieved: 1, unlocktime: 1700100000 },
+            ],
+          },
+        }),
+      )
+      // 2nd: GetGlobalAchievementPercentagesForApp
+      .mockResolvedValueOnce(
+        jsonResponse({
+          achievementpercentages: {
+            achievements: [
+              { name: 'ach_01', percent: 75.5 },
+              { name: 'ach_02', percent: 30.0 },
+            ],
+          },
+        }),
+      )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getPlayerAchievements } = await import('@/lib/api/steam')
+    const result = await getPlayerAchievements('76561197960287930', '1942')
+    expect(result.status).toBe('ok')
+    if (result.status === 'ok') {
+      expect(result.achievements).toHaveLength(3)
+      expect(result.achievements[0]).toEqual({
+        steam_api_name: 'ach_01',
+        unlocked_at: new Date(1700000000 * 1000),
+        percent_global: 75.5,
+      })
+      expect(result.achievements[1]).toEqual({
+        steam_api_name: 'ach_02',
+        unlocked_at: null,
+        percent_global: 30.0,
+      })
+      // Achievement absent from the global response gets null
+      expect(result.achievements[2]?.percent_global).toBeNull()
+    }
+  })
+
+  it('returns ok shape with null percent_global when global percentages 403', async () => {
+    const fetchSpy = vi
+      .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          playerstats: {
+            success: true,
+            achievements: [
+              { apiname: 'ach_01', achieved: 1, unlocktime: 1700000000 },
+            ],
+          },
+        }),
+      )
+      .mockResolvedValueOnce(new Response('Forbidden', { status: 403 }))
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getPlayerAchievements } = await import('@/lib/api/steam')
+    const result = await getPlayerAchievements('76561197960287930', '1942')
+    expect(result.status).toBe('ok')
+    if (result.status === 'ok') {
+      expect(result.achievements[0]?.percent_global).toBeNull()
+    }
+  })
+
+  it('throws SteamApiError on 401 (invalid API key)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          new Response('Unauthorized', { status: 401 }),
+      ),
+    )
+    const { getPlayerAchievements, SteamApiError } = await import(
+      '@/lib/api/steam'
+    )
+    await expect(
+      getPlayerAchievements('76561197960287930', '1942'),
+    ).rejects.toBeInstanceOf(SteamApiError)
+    await expect(
+      getPlayerAchievements('76561197960287930', '1942'),
+    ).rejects.toMatchObject({ httpStatus: 401 })
+  })
+})
+
+describe('retry on 5xx', () => {
+  it('retries 5xx with 1s/2s/4s backoff and surfaces final error', async () => {
+    vi.useFakeTimers()
+    const fetchSpy = vi
+      .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response('err', { status: 503 }))
+      .mockResolvedValueOnce(new Response('err', { status: 503 }))
+      .mockResolvedValueOnce(new Response('err', { status: 503 }))
+      .mockResolvedValueOnce(new Response('err', { status: 503 }))
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getOwnedGames, SteamApiError } = await import('@/lib/api/steam')
+    const promise = getOwnedGames('76561197960287930')
+    const rejection = promise.catch((err) => err)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.advanceTimersByTimeAsync(4000)
+    const err = await rejection
+    expect(err).toBeInstanceOf(SteamApiError)
+    expect((err as InstanceType<typeof SteamApiError>).httpStatus).toBe(503)
+    expect(fetchSpy).toHaveBeenCalledTimes(4)
+  })
+})
+
+describe('parse failure', () => {
+  it('surfaces fieldPath on a malformed Steam payload', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          jsonResponse({
+            response: {
+              game_count: 1,
+              games: [
+                {
+                  appid: 'not-a-number',
+                  name: 'Bad Game',
+                  playtime_forever: 0,
+                },
+              ],
+            },
+          }),
+      ),
+    )
+
+    const { getOwnedGames, SteamApiError } = await import('@/lib/api/steam')
+    try {
+      await getOwnedGames('76561197960287930')
+      expect.fail('expected parse failure')
+    } catch (err) {
+      expect(err).toBeInstanceOf(SteamApiError)
+      const steamErr = err as InstanceType<typeof SteamApiError>
+      expect(steamErr.fieldPath).toBe('response.games.0.appid')
+    }
+  })
+})

--- a/lib/api/igdb.ts
+++ b/lib/api/igdb.ts
@@ -1,0 +1,471 @@
+import { z } from 'zod'
+import { env } from '@/lib/env'
+import { logger } from '@/lib/logger'
+import { redis } from '@/lib/redis'
+
+const IGDB_BASE_URL = 'https://api.igdb.com/v4'
+const TWITCH_TOKEN_URL = 'https://id.twitch.tv/oauth2/token'
+const IGDB_TIMEOUT_MS = 8000
+
+// IGDB enforces 4 req/s per client. Slot-limiter mirrors lib/api/anilist.ts
+// withLimit; race-safe via a settled-token in the inflight set.
+const IGDB_CONCURRENCY = 4
+
+// Refresh proactively when within 24h of expiry per AC-2. Twitch issues
+// ~60-day tokens so a daily cron (AC-6) keeps the cached token fresh well
+// before this threshold ever triggers an inline refresh.
+const TOKEN_REFRESH_THRESHOLD_MS = 24 * 60 * 60 * 1000
+
+// 3 attempts, then bail. Sequence is 1s, 2s, 4s (AC-4).
+const RETRY_BACKOFFS_MS = [1000, 2000, 4000] as const
+
+const TOKEN_KEY = 'igdb:token'
+const TOKEN_EXPIRES_AT_KEY = 'igdb:token:expiresAt'
+
+export class IgdbApiError extends Error {
+  readonly endpoint: string
+  readonly httpStatus?: number
+  readonly fieldPath?: string
+  readonly retryAfterMs?: number
+
+  constructor(
+    message: string,
+    opts: {
+      endpoint: string
+      httpStatus?: number
+      fieldPath?: string
+      retryAfterMs?: number
+      cause?: unknown
+    },
+  ) {
+    super(message, opts.cause ? { cause: opts.cause } : undefined)
+    this.name = 'IgdbApiError'
+    this.endpoint = opts.endpoint
+    this.httpStatus = opts.httpStatus
+    this.fieldPath = opts.fieldPath
+    this.retryAfterMs = opts.retryAfterMs
+  }
+}
+
+const TwitchTokenResponseSchema = z.object({
+  access_token: z.string().min(1),
+  expires_in: z.number().int().positive(),
+  token_type: z.literal('bearer'),
+})
+
+export const IgdbCoverSchema = z.object({
+  id: z.number(),
+  image_id: z.string(),
+})
+export type IgdbCover = z.infer<typeof IgdbCoverSchema>
+
+export const IgdbScreenshotSchema = z.object({
+  id: z.number(),
+  image_id: z.string(),
+})
+export type IgdbScreenshot = z.infer<typeof IgdbScreenshotSchema>
+
+export const IgdbGenreSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+})
+export type IgdbGenre = z.infer<typeof IgdbGenreSchema>
+
+export const IgdbPlatformSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+})
+export type IgdbPlatform = z.infer<typeof IgdbPlatformSchema>
+
+export const IgdbCompanySchema = z.object({
+  id: z.number(),
+  name: z.string(),
+})
+export type IgdbCompany = z.infer<typeof IgdbCompanySchema>
+
+export const IgdbInvolvedCompanySchema = z.object({
+  id: z.number(),
+  company: IgdbCompanySchema,
+  developer: z.boolean().optional(),
+  publisher: z.boolean().optional(),
+})
+export type IgdbInvolvedCompany = z.infer<typeof IgdbInvolvedCompanySchema>
+
+export const IgdbReleaseDateSchema = z.object({
+  id: z.number(),
+  y: z.number().int().nullable().optional(),
+})
+export type IgdbReleaseDate = z.infer<typeof IgdbReleaseDateSchema>
+
+export const IgdbGameSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  summary: z.string().nullable().optional(),
+  first_release_date: z.number().int().nullable().optional(),
+  cover: IgdbCoverSchema.nullable().optional(),
+  screenshots: z.array(IgdbScreenshotSchema).optional(),
+  genres: z.array(IgdbGenreSchema).optional(),
+  platforms: z.array(IgdbPlatformSchema).optional(),
+  involved_companies: z.array(IgdbInvolvedCompanySchema).optional(),
+  release_dates: z.array(IgdbReleaseDateSchema).optional(),
+})
+export type IgdbGame = z.infer<typeof IgdbGameSchema>
+
+const IgdbGamesArraySchema = z.array(IgdbGameSchema)
+
+// Slot limiter mirrors lib/api/anilist.ts withLimit. Each in-flight call is
+// wrapped with a settled-token whose .catch swallows rejections so
+// cross-caller Promise.race waiters do not inherit unrelated errors.
+const inflight = new Set<Promise<unknown>>()
+async function withIgdbLimit<T>(fn: () => Promise<T>): Promise<T> {
+  while (inflight.size >= IGDB_CONCURRENCY) {
+    await Promise.race(inflight)
+  }
+  const real = (async () => fn())()
+  const token: Promise<unknown> = real.catch(() => undefined)
+  inflight.add(token)
+  try {
+    return await real
+  } finally {
+    inflight.delete(token)
+  }
+}
+
+// In-process single-flight for the Twitch token refresh. Concurrent callers
+// await the same promise instead of fanning out duplicate Twitch requests.
+// Cross-process collisions (Next.js + worker each refreshing simultaneously
+// during a deploy boundary) are accepted per AC-2.
+let inflightRefresh: Promise<{ token: string; expiresAt: number }> | null =
+  null
+
+export async function refreshIgdbToken(): Promise<{
+  token: string
+  expiresAt: number
+}> {
+  if (inflightRefresh) {
+    return inflightRefresh
+  }
+  inflightRefresh = (async () => {
+    const params = new URLSearchParams({
+      client_id: env.IGDB_CLIENT_ID,
+      client_secret: env.IGDB_CLIENT_SECRET,
+      grant_type: 'client_credentials',
+    })
+
+    const startedAt = Date.now()
+    let response: Response
+    try {
+      response = await fetch(`${TWITCH_TOKEN_URL}?${params.toString()}`, {
+        method: 'POST',
+        signal: AbortSignal.timeout(IGDB_TIMEOUT_MS),
+      })
+    } catch (err) {
+      const durationMs = Date.now() - startedAt
+      const isTimeout =
+        err instanceof Error &&
+        (err.name === 'TimeoutError' || err.name === 'AbortError')
+      logger.error(
+        { event: 'igdb.token.network_error', durationMs, err },
+        isTimeout ? 'igdb_token_timeout' : 'igdb_token_network_error',
+      )
+      throw new IgdbApiError(
+        isTimeout
+          ? `Twitch token request timed out after ${IGDB_TIMEOUT_MS}ms`
+          : 'Twitch token request failed',
+        { endpoint: 'twitch/oauth2/token', cause: err },
+      )
+    }
+
+    const durationMs = Date.now() - startedAt
+
+    if (!response.ok) {
+      logger.error(
+        {
+          event: 'igdb.token.http_error',
+          status: response.status,
+          durationMs,
+        },
+        'igdb_token_http_error',
+      )
+      throw new IgdbApiError(
+        `Twitch token HTTP ${response.status}`,
+        { endpoint: 'twitch/oauth2/token', httpStatus: response.status },
+      )
+    }
+
+    let payload: unknown
+    try {
+      payload = await response.json()
+    } catch (err) {
+      logger.error(
+        { event: 'igdb.token.invalid_json', durationMs, err },
+        'igdb_token_invalid_json',
+      )
+      throw new IgdbApiError('Twitch token returned invalid JSON', {
+        endpoint: 'twitch/oauth2/token',
+        httpStatus: response.status,
+        cause: err,
+      })
+    }
+
+    const parsed = TwitchTokenResponseSchema.safeParse(payload)
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0]
+      const fieldPath = issue?.path.join('.') ?? '(root)'
+      logger.error(
+        {
+          event: 'igdb.token.parse_error',
+          fieldPath,
+          durationMs,
+          err: parsed.error,
+        },
+        'igdb_token_parse_error',
+      )
+      throw new IgdbApiError(
+        `Twitch token parse failed at "${fieldPath}"`,
+        {
+          endpoint: 'twitch/oauth2/token',
+          httpStatus: response.status,
+          fieldPath,
+          cause: parsed.error,
+        },
+      )
+    }
+
+    const expiresAt = Date.now() + parsed.data.expires_in * 1000
+    await redis.set(
+      TOKEN_KEY,
+      parsed.data.access_token,
+      'EX',
+      parsed.data.expires_in,
+    )
+    await redis.set(TOKEN_EXPIRES_AT_KEY, String(expiresAt))
+
+    logger.info(
+      { event: 'igdb.token.refreshed', expiresAt, durationMs },
+      'igdb token refreshed',
+    )
+
+    return { token: parsed.data.access_token, expiresAt }
+  })()
+
+  try {
+    return await inflightRefresh
+  } finally {
+    inflightRefresh = null
+  }
+}
+
+async function getIgdbToken(): Promise<string> {
+  const [cached, expiresAtRaw] = await Promise.all([
+    redis.get(TOKEN_KEY),
+    redis.get(TOKEN_EXPIRES_AT_KEY),
+  ])
+  const expiresAt = expiresAtRaw ? Number(expiresAtRaw) : 0
+  if (cached && expiresAt - Date.now() > TOKEN_REFRESH_THRESHOLD_MS) {
+    return cached
+  }
+  const refreshed = await refreshIgdbToken()
+  return refreshed.token
+}
+
+async function igdbFetch<T extends z.ZodType>(
+  endpoint: string,
+  body: string,
+  schema: T,
+  endpointLabel: string,
+): Promise<z.infer<T>> {
+  for (let attempt = 0; attempt <= RETRY_BACKOFFS_MS.length; attempt++) {
+    const token = await getIgdbToken()
+    const startedAt = Date.now()
+    let response: Response
+    try {
+      response = await fetch(`${IGDB_BASE_URL}/${endpoint}`, {
+        method: 'POST',
+        headers: {
+          'Client-ID': env.IGDB_CLIENT_ID,
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/json',
+        },
+        body,
+        cache: 'no-store',
+        signal: AbortSignal.timeout(IGDB_TIMEOUT_MS),
+      })
+    } catch (err) {
+      const durationMs = Date.now() - startedAt
+      const isTimeout =
+        err instanceof Error &&
+        (err.name === 'TimeoutError' || err.name === 'AbortError')
+      logger.error(
+        {
+          event: 'igdb.fetch.network_error',
+          endpoint: endpointLabel,
+          durationMs,
+          err,
+        },
+        isTimeout ? 'igdb_fetch_timeout' : 'igdb_fetch_network_error',
+      )
+      throw new IgdbApiError(
+        isTimeout
+          ? `IGDB request timed out after ${IGDB_TIMEOUT_MS}ms: ${endpointLabel}`
+          : `IGDB fetch failed: ${endpointLabel}`,
+        { endpoint: endpointLabel, cause: err },
+      )
+    }
+
+    const durationMs = Date.now() - startedAt
+
+    if (response.status === 429 || response.status >= 500) {
+      const retryAfterRaw = response.headers.get('Retry-After')
+      const retryAfterSeconds = retryAfterRaw ? Number(retryAfterRaw) : NaN
+      const retryAfterMs = Number.isFinite(retryAfterSeconds)
+        ? retryAfterSeconds * 1000
+        : undefined
+
+      if (attempt < RETRY_BACKOFFS_MS.length) {
+        const baseBackoff = RETRY_BACKOFFS_MS[attempt]!
+        const backoffMs = Math.max(baseBackoff, retryAfterMs ?? 0)
+        logger.warn(
+          {
+            event: 'igdb.fetch.retry',
+            endpoint: endpointLabel,
+            attempt: attempt + 1,
+            status: response.status,
+            retryAfterMs,
+            backoffMs,
+            durationMs,
+          },
+          'igdb_fetch_retry',
+        )
+        await new Promise((r) => setTimeout(r, backoffMs))
+        continue
+      }
+
+      logger.error(
+        {
+          event: 'igdb.fetch.exhausted',
+          endpoint: endpointLabel,
+          status: response.status,
+          durationMs,
+        },
+        'igdb_fetch_retries_exhausted',
+      )
+      throw new IgdbApiError(
+        response.status === 429
+          ? `IGDB rate limited (429) after ${RETRY_BACKOFFS_MS.length} retries: ${endpointLabel}`
+          : `IGDB HTTP ${response.status} after ${RETRY_BACKOFFS_MS.length} retries: ${endpointLabel}`,
+        {
+          endpoint: endpointLabel,
+          httpStatus: response.status,
+          retryAfterMs,
+        },
+      )
+    }
+
+    if (!response.ok) {
+      logger.error(
+        {
+          event: 'igdb.fetch.http_error',
+          endpoint: endpointLabel,
+          status: response.status,
+          durationMs,
+        },
+        'igdb_fetch_http_error',
+      )
+      throw new IgdbApiError(
+        `IGDB HTTP ${response.status}: ${endpointLabel}`,
+        { endpoint: endpointLabel, httpStatus: response.status },
+      )
+    }
+
+    let payload: unknown
+    try {
+      payload = await response.json()
+    } catch (err) {
+      logger.error(
+        {
+          event: 'igdb.fetch.invalid_json',
+          endpoint: endpointLabel,
+          durationMs,
+          err,
+        },
+        'igdb_fetch_invalid_json',
+      )
+      throw new IgdbApiError(`IGDB returned invalid JSON: ${endpointLabel}`, {
+        endpoint: endpointLabel,
+        httpStatus: response.status,
+        cause: err,
+      })
+    }
+
+    const parsed = schema.safeParse(payload)
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0]
+      const fieldPath = issue?.path.join('.') ?? '(root)'
+      logger.error(
+        {
+          event: 'igdb.fetch.parse_error',
+          endpoint: endpointLabel,
+          status: response.status,
+          durationMs,
+          fieldPath,
+          err: parsed.error,
+        },
+        'igdb_fetch_parse_error',
+      )
+      throw new IgdbApiError(
+        `IGDB response parse failed at "${fieldPath}": ${endpointLabel}`,
+        {
+          endpoint: endpointLabel,
+          httpStatus: response.status,
+          fieldPath,
+          cause: parsed.error,
+        },
+      )
+    }
+
+    return parsed.data
+  }
+
+  throw new IgdbApiError(`IGDB unreachable retry exit: ${endpointLabel}`, {
+    endpoint: endpointLabel,
+  })
+}
+
+const GAME_FIELDS =
+  'fields name,summary,first_release_date,cover.image_id,screenshots.image_id,genres.name,platforms.name,involved_companies.company.name,involved_companies.developer,involved_companies.publisher,release_dates.y;'
+
+function escapeApicalypseString(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+export function searchGames(
+  query: string,
+  opts: { limit?: number } = {},
+): Promise<IgdbGame[]> {
+  return withIgdbLimit(async () => {
+    const limit = opts.limit ?? 25
+    const body = `${GAME_FIELDS} search "${escapeApicalypseString(query)}"; limit ${limit};`
+    return igdbFetch('games', body, IgdbGamesArraySchema, `search/games`)
+  })
+}
+
+export function getGame(id: number): Promise<IgdbGame> {
+  return withIgdbLimit(async () => {
+    const body = `${GAME_FIELDS} where id = ${id};`
+    const games = await igdbFetch(
+      'games',
+      body,
+      IgdbGamesArraySchema,
+      `games/${id}`,
+    )
+    const game = games[0]
+    if (!game) {
+      throw new IgdbApiError(`IGDB game not found: ${id}`, {
+        endpoint: `games/${id}`,
+        httpStatus: 404,
+      })
+    }
+    return game
+  })
+}

--- a/lib/api/steam.ts
+++ b/lib/api/steam.ts
@@ -1,0 +1,366 @@
+import { z } from 'zod'
+import { env } from '@/lib/env'
+import { logger } from '@/lib/logger'
+
+const STEAM_BASE_URL = 'https://api.steampowered.com'
+const STEAM_TIMEOUT_MS = 8000
+
+// Steam Web API documents 100,000 calls/day with no per-second limit. The
+// sync job (lib/jobs/steamAchievementSync.ts) iterates games sequentially,
+// which is the effective rate cap. No slot limiter here.
+
+const RETRY_BACKOFFS_MS = [1000, 2000, 4000] as const
+
+export class SteamApiError extends Error {
+  readonly endpoint: string
+  readonly httpStatus?: number
+  readonly fieldPath?: string
+  readonly retryAfterMs?: number
+
+  constructor(
+    message: string,
+    opts: {
+      endpoint: string
+      httpStatus?: number
+      fieldPath?: string
+      retryAfterMs?: number
+      cause?: unknown
+    },
+  ) {
+    super(message, opts.cause ? { cause: opts.cause } : undefined)
+    this.name = 'SteamApiError'
+    this.endpoint = opts.endpoint
+    this.httpStatus = opts.httpStatus
+    this.fieldPath = opts.fieldPath
+    this.retryAfterMs = opts.retryAfterMs
+  }
+}
+
+export const SteamOwnedGameSchema = z.object({
+  appid: z.number().int(),
+  name: z.string(),
+  playtime_forever: z.number().int().default(0),
+  img_icon_url: z.string().nullable().optional(),
+  rtime_last_played: z.number().int().nullable().optional(),
+})
+export type SteamOwnedGame = z.infer<typeof SteamOwnedGameSchema>
+
+const SteamOwnedGamesResponseSchema = z.object({
+  response: z
+    .object({
+      game_count: z.number().int().optional(),
+      games: z.array(SteamOwnedGameSchema).optional(),
+    })
+    .default({}),
+})
+
+const SteamPlayerAchievementEntrySchema = z.object({
+  apiname: z.string(),
+  achieved: z.union([z.literal(0), z.literal(1)]),
+  unlocktime: z.number().int(),
+})
+
+const SteamPlayerAchievementsResponseSchema = z.object({
+  playerstats: z.object({
+    steamID: z.string().optional(),
+    gameName: z.string().optional(),
+    success: z.boolean(),
+    error: z.string().optional(),
+    achievements: z.array(SteamPlayerAchievementEntrySchema).optional(),
+  }),
+})
+
+export const SteamAchievementSchemaEntrySchema = z.object({
+  name: z.string(),
+  displayName: z.string(),
+  description: z.string().nullable().optional(),
+  icon: z.string(),
+  icongray: z.string().optional(),
+})
+export type SteamAchievementSchemaEntry = z.infer<
+  typeof SteamAchievementSchemaEntrySchema
+>
+
+const SteamGameSchemaResponseSchema = z.object({
+  game: z
+    .object({
+      availableGameStats: z
+        .object({
+          achievements: z.array(SteamAchievementSchemaEntrySchema).optional(),
+        })
+        .optional(),
+    })
+    .default({}),
+})
+
+const SteamGlobalPercentageEntrySchema = z.object({
+  name: z.string(),
+  percent: z.number(),
+})
+
+const SteamGlobalPercentagesResponseSchema = z.object({
+  achievementpercentages: z
+    .object({
+      achievements: z.array(SteamGlobalPercentageEntrySchema).optional(),
+    })
+    .default({}),
+})
+
+export type SteamAchievementSyncEntry = {
+  steam_api_name: string
+  unlocked_at: Date | null
+  percent_global: number | null
+}
+
+export type SteamPlayerAchievementsResult =
+  | { status: 'private_profile'; appId: string }
+  | {
+      status: 'ok'
+      appId: string
+      achievements: SteamAchievementSyncEntry[]
+    }
+
+async function steamFetch<T extends z.ZodType>(
+  url: string,
+  schema: T,
+  endpointLabel: string,
+): Promise<z.infer<T>> {
+  for (let attempt = 0; attempt <= RETRY_BACKOFFS_MS.length; attempt++) {
+    const startedAt = Date.now()
+    let response: Response
+    try {
+      response = await fetch(url, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        cache: 'no-store',
+        signal: AbortSignal.timeout(STEAM_TIMEOUT_MS),
+      })
+    } catch (err) {
+      const durationMs = Date.now() - startedAt
+      const isTimeout =
+        err instanceof Error &&
+        (err.name === 'TimeoutError' || err.name === 'AbortError')
+      logger.error(
+        {
+          event: 'steam.fetch.network_error',
+          endpoint: endpointLabel,
+          durationMs,
+          err,
+        },
+        isTimeout ? 'steam_fetch_timeout' : 'steam_fetch_network_error',
+      )
+      throw new SteamApiError(
+        isTimeout
+          ? `Steam request timed out after ${STEAM_TIMEOUT_MS}ms: ${endpointLabel}`
+          : `Steam fetch failed: ${endpointLabel}`,
+        { endpoint: endpointLabel, cause: err },
+      )
+    }
+
+    const durationMs = Date.now() - startedAt
+
+    if (response.status >= 500) {
+      const retryAfterRaw = response.headers.get('Retry-After')
+      const retryAfterSeconds = retryAfterRaw ? Number(retryAfterRaw) : NaN
+      const retryAfterMs = Number.isFinite(retryAfterSeconds)
+        ? retryAfterSeconds * 1000
+        : undefined
+
+      if (attempt < RETRY_BACKOFFS_MS.length) {
+        const baseBackoff = RETRY_BACKOFFS_MS[attempt]!
+        const backoffMs = Math.max(baseBackoff, retryAfterMs ?? 0)
+        logger.warn(
+          {
+            event: 'steam.fetch.retry',
+            endpoint: endpointLabel,
+            attempt: attempt + 1,
+            status: response.status,
+            retryAfterMs,
+            backoffMs,
+            durationMs,
+          },
+          'steam_fetch_retry',
+        )
+        await new Promise((r) => setTimeout(r, backoffMs))
+        continue
+      }
+
+      logger.error(
+        {
+          event: 'steam.fetch.exhausted',
+          endpoint: endpointLabel,
+          status: response.status,
+          durationMs,
+        },
+        'steam_fetch_retries_exhausted',
+      )
+      throw new SteamApiError(
+        `Steam HTTP ${response.status} after ${RETRY_BACKOFFS_MS.length} retries: ${endpointLabel}`,
+        {
+          endpoint: endpointLabel,
+          httpStatus: response.status,
+          retryAfterMs,
+        },
+      )
+    }
+
+    if (!response.ok) {
+      throw new SteamApiError(
+        `Steam HTTP ${response.status}: ${endpointLabel}`,
+        { endpoint: endpointLabel, httpStatus: response.status },
+      )
+    }
+
+    let payload: unknown
+    try {
+      payload = await response.json()
+    } catch (err) {
+      logger.error(
+        {
+          event: 'steam.fetch.invalid_json',
+          endpoint: endpointLabel,
+          durationMs,
+          err,
+        },
+        'steam_fetch_invalid_json',
+      )
+      throw new SteamApiError(`Steam returned invalid JSON: ${endpointLabel}`, {
+        endpoint: endpointLabel,
+        httpStatus: response.status,
+        cause: err,
+      })
+    }
+
+    const parsed = schema.safeParse(payload)
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0]
+      const fieldPath = issue?.path.join('.') ?? '(root)'
+      logger.error(
+        {
+          event: 'steam.fetch.parse_error',
+          endpoint: endpointLabel,
+          status: response.status,
+          durationMs,
+          fieldPath,
+          err: parsed.error,
+        },
+        'steam_fetch_parse_error',
+      )
+      throw new SteamApiError(
+        `Steam response parse failed at "${fieldPath}": ${endpointLabel}`,
+        {
+          endpoint: endpointLabel,
+          httpStatus: response.status,
+          fieldPath,
+          cause: parsed.error,
+        },
+      )
+    }
+    return parsed.data
+  }
+
+  throw new SteamApiError(`Steam unreachable retry exit: ${endpointLabel}`, {
+    endpoint: endpointLabel,
+  })
+}
+
+export async function getOwnedGames(
+  steamId: string,
+): Promise<SteamOwnedGame[]> {
+  const url = `${STEAM_BASE_URL}/IPlayerService/GetOwnedGames/v0001/?key=${encodeURIComponent(env.STEAM_API_KEY)}&steamid=${encodeURIComponent(steamId)}&include_appinfo=1&format=json`
+  const data = await steamFetch(
+    url,
+    SteamOwnedGamesResponseSchema,
+    `getOwnedGames/${steamId}`,
+  )
+  return data.response.games ?? []
+}
+
+export async function getSchemaForGame(
+  appId: string,
+): Promise<SteamAchievementSchemaEntry[]> {
+  const url = `${STEAM_BASE_URL}/ISteamUserStats/GetSchemaForGame/v2/?key=${encodeURIComponent(env.STEAM_API_KEY)}&appid=${encodeURIComponent(appId)}&format=json`
+  const data = await steamFetch(
+    url,
+    SteamGameSchemaResponseSchema,
+    `getSchemaForGame/${appId}`,
+  )
+  return data.game.availableGameStats?.achievements ?? []
+}
+
+async function getGlobalAchievementPercentages(
+  appId: string,
+): Promise<Map<string, number>> {
+  const url = `${STEAM_BASE_URL}/ISteamUserStats/GetGlobalAchievementPercentagesForApp/v0002/?gameid=${encodeURIComponent(appId)}&format=json`
+  try {
+    const data = await steamFetch(
+      url,
+      SteamGlobalPercentagesResponseSchema,
+      `getGlobalAchievementPercentages/${appId}`,
+    )
+    const map = new Map<string, number>()
+    for (const entry of data.achievementpercentages.achievements ?? []) {
+      map.set(entry.name, entry.percent)
+    }
+    return map
+  } catch (err) {
+    // Some apps (especially recent releases or games without public stats)
+    // return a non-200 here even when player achievements work. Treat as
+    // empty rather than failing the whole sync.
+    if (err instanceof SteamApiError && err.httpStatus !== undefined) {
+      logger.warn(
+        {
+          event: 'steam.fetch.global_percentages_unavailable',
+          appId,
+          status: err.httpStatus,
+        },
+        'steam_global_percentages_unavailable',
+      )
+      return new Map()
+    }
+    throw err
+  }
+}
+
+export async function getPlayerAchievements(
+  steamId: string,
+  appId: string,
+): Promise<SteamPlayerAchievementsResult> {
+  const url = `${STEAM_BASE_URL}/ISteamUserStats/GetPlayerAchievements/v0001/?key=${encodeURIComponent(env.STEAM_API_KEY)}&steamid=${encodeURIComponent(steamId)}&appid=${encodeURIComponent(appId)}`
+
+  let player: z.infer<typeof SteamPlayerAchievementsResponseSchema>
+  try {
+    player = await steamFetch(
+      url,
+      SteamPlayerAchievementsResponseSchema,
+      `getPlayerAchievements/${appId}`,
+    )
+  } catch (err) {
+    if (err instanceof SteamApiError && err.httpStatus === 403) {
+      return { status: 'private_profile', appId }
+    }
+    throw err
+  }
+
+  if (!player.playerstats.success) {
+    // Steam returns success=false for both "no achievements available" and
+    // some private cases. Either way the visible state is "nothing to render";
+    // the explicit 403 private-profile path is the discriminator above.
+    return { status: 'ok', appId, achievements: [] }
+  }
+
+  const globalPercentages = await getGlobalAchievementPercentages(appId)
+
+  const achievements: SteamAchievementSyncEntry[] = (
+    player.playerstats.achievements ?? []
+  ).map((entry) => ({
+    steam_api_name: entry.apiname,
+    unlocked_at:
+      entry.achieved === 1 && entry.unlocktime > 0
+        ? new Date(entry.unlocktime * 1000)
+        : null,
+    percent_global: globalPercentages.get(entry.apiname) ?? null,
+  }))
+
+  return { status: 'ok', appId, achievements }
+}

--- a/lib/jobs/__tests__/igdbTokenRefresh.test.ts
+++ b/lib/jobs/__tests__/igdbTokenRefresh.test.ts
@@ -1,0 +1,115 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Queue, Worker } from 'bullmq'
+import type Redis from 'ioredis'
+
+// Integration test for the igdbTokenRefresh BullMQ processor wired through
+// the queue registry from lib/jobs/queues.ts. Hits real Redis from
+// `pnpm infra` (local) or the redis service in CI; mocks Twitch via
+// vi.stubGlobal('fetch') so the processor never makes an external request.
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(64),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  ANILIST_USER_AGENT: 'cuatro-tracker/test',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+const TEST_QUEUE_NAME = `test-igdb-token-${Math.random().toString(36).slice(2, 10)}`
+
+let redis: Redis
+let processors: Record<string, (job: import('bullmq').Job) => Promise<unknown>>
+
+beforeAll(async () => {
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+  const redisMod = await import('@/lib/redis')
+  redis = redisMod.redis
+  const queuesMod = await import('@/lib/jobs/queues')
+  processors = queuesMod.processors
+})
+
+afterAll(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('igdbTokenRefresh processor (BullMQ integration)', () => {
+  let queue: Queue
+  let worker: Worker | undefined
+
+  beforeEach(async () => {
+    queue = new Queue(TEST_QUEUE_NAME, { connection: redis })
+    await queue.drain()
+    await redis.del('igdb:token', 'igdb:token:expiresAt')
+  })
+
+  afterEach(async () => {
+    if (worker) {
+      await worker.close()
+      worker = undefined
+    }
+    await queue.drain()
+    await queue.close()
+    await redis.del('igdb:token', 'igdb:token:expiresAt')
+    vi.unstubAllGlobals()
+  })
+
+  it(
+    'enqueued job runs the registered processor and persists token + expiresAt to Redis',
+    async () => {
+      // Mock the Twitch token endpoint. The processor delegates to
+      // refreshIgdbToken which calls fetch under the hood.
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(
+          async () =>
+            new Response(
+              JSON.stringify({
+                access_token: 'integration-token',
+                expires_in: 5184000,
+                token_type: 'bearer',
+              }),
+              {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+              },
+            ),
+        ),
+      )
+
+      const processor = processors.igdbTokenRefresh
+      expect(processor).toBeDefined()
+
+      worker = new Worker(
+        TEST_QUEUE_NAME,
+        async (job) => processor!(job),
+        { connection: redis },
+      )
+
+      await new Promise<void>((resolve, reject) => {
+        worker!.on('completed', () => resolve())
+        worker!.on('failed', (_job, err) => reject(err))
+        queue.add('manual', {}, { jobId: 'test-manual-refresh' })
+      })
+
+      const persistedToken = await redis.get('igdb:token')
+      const persistedExpiresAt = await redis.get('igdb:token:expiresAt')
+
+      expect(persistedToken).toBe('integration-token')
+      expect(persistedExpiresAt).not.toBeNull()
+      expect(Number(persistedExpiresAt)).toBeGreaterThan(Date.now())
+    },
+    20_000,
+  )
+})

--- a/lib/jobs/__tests__/steamAchievementSync.test.ts
+++ b/lib/jobs/__tests__/steamAchievementSync.test.ts
@@ -1,0 +1,231 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Queue, Worker } from 'bullmq'
+import { MediaType } from '@prisma/client'
+import type Redis from 'ioredis'
+
+const dbMock = vi.hoisted(() => ({
+  mediaItem: {
+    findMany: vi.fn(),
+    update: vi.fn(),
+  },
+  achievement: {
+    upsert: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/db', () => ({ db: dbMock }))
+
+const validEnv: Record<string, string> = {
+  NEXTAUTH_SECRET: 'a'.repeat(64),
+  NEXTAUTH_URL: 'http://localhost:3000',
+  DATABASE_URL: 'postgresql://tracker:password@localhost:5432/tracker',
+  REDIS_URL: 'redis://localhost:6379',
+  ADMIN_PASS: 'password123',
+  DB_PASS: 'password',
+  TMDB_API_KEY: 'tmdb-key',
+  ANILIST_USER_AGENT: 'cuatro-tracker/test',
+  IGDB_CLIENT_ID: 'igdb-id',
+  IGDB_CLIENT_SECRET: 'igdb-secret',
+  STEAM_API_KEY: 'steam-key',
+  STEAM_USER_ID: '76561197960287930',
+  QBITTORRENT_HOST: 'http://qbittorrent:8080',
+  QBITTORRENT_USER: 'admin',
+  QBITTORRENT_PASS: 'qbpass',
+  DOWNLOAD_PATH: '/downloads',
+  LOG_LEVEL: 'info',
+}
+
+const TEST_QUEUE_NAME = `test-steam-sync-${Math.random().toString(36).slice(2, 10)}`
+
+let redis: Redis
+let processors: Record<string, (job: import('bullmq').Job) => Promise<unknown>>
+
+beforeAll(async () => {
+  for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
+  const redisMod = await import('@/lib/redis')
+  redis = redisMod.redis
+  const queuesMod = await import('@/lib/jobs/queues')
+  processors = queuesMod.processors
+})
+
+afterAll(() => {
+  vi.unstubAllEnvs()
+})
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  })
+}
+
+describe('steamAchievementSync processor (BullMQ integration, mocked db + fetch)', () => {
+  let queue: Queue
+  let worker: Worker | undefined
+
+  beforeEach(async () => {
+    queue = new Queue(TEST_QUEUE_NAME, { connection: redis })
+    await queue.drain()
+    vi.resetAllMocks()
+  })
+
+  afterEach(async () => {
+    if (worker) {
+      await worker.close()
+      worker = undefined
+    }
+    await queue.drain()
+    await queue.close()
+    vi.unstubAllGlobals()
+  })
+
+  it(
+    'upserts achievements and sets achievement_sync_status to ok for a public-profile game',
+    async () => {
+      dbMock.mediaItem.findMany.mockResolvedValueOnce([
+        { id: 'game-1', steam_id: 1942 },
+      ])
+      dbMock.achievement.upsert.mockResolvedValue({})
+      dbMock.mediaItem.update.mockResolvedValue({})
+
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+          // GetPlayerAchievements
+          .mockResolvedValueOnce(
+            jsonResponse({
+              playerstats: {
+                steamID: '76561197960287930',
+                gameName: 'Witcher 3',
+                success: true,
+                achievements: [
+                  { apiname: 'ach_01', achieved: 1, unlocktime: 1700000000 },
+                  { apiname: 'ach_02', achieved: 0, unlocktime: 0 },
+                ],
+              },
+            }),
+          )
+          // GetGlobalAchievementPercentagesForApp
+          .mockResolvedValueOnce(
+            jsonResponse({
+              achievementpercentages: {
+                achievements: [
+                  { name: 'ach_01', percent: 75.5 },
+                  { name: 'ach_02', percent: 30.0 },
+                ],
+              },
+            }),
+          )
+          // GetSchemaForGame
+          .mockResolvedValueOnce(
+            jsonResponse({
+              game: {
+                availableGameStats: {
+                  achievements: [
+                    {
+                      name: 'ach_01',
+                      displayName: 'First Steps',
+                      description: 'Take your first step.',
+                      icon: 'http://icon/01.png',
+                    },
+                    {
+                      name: 'ach_02',
+                      displayName: 'Second Steps',
+                      icon: 'http://icon/02.png',
+                    },
+                  ],
+                },
+              },
+            }),
+          ),
+      )
+
+      const processor = processors.steamAchievementSync
+      expect(processor).toBeDefined()
+
+      worker = new Worker(
+        TEST_QUEUE_NAME,
+        async (job) => processor!(job),
+        { connection: redis },
+      )
+
+      await new Promise<void>((resolve, reject) => {
+        worker!.on('completed', () => resolve())
+        worker!.on('failed', (_job, err) => reject(err))
+        queue.add('manual', {}, { jobId: 'test-steam-public' })
+      })
+
+      expect(dbMock.achievement.upsert).toHaveBeenCalledTimes(2)
+      const firstUpsertArgs = dbMock.achievement.upsert.mock.calls[0]![0]
+      expect(firstUpsertArgs).toMatchObject({
+        where: {
+          game_id_steam_api_name: {
+            game_id: 'game-1',
+            steam_api_name: 'ach_01',
+          },
+        },
+        create: expect.objectContaining({
+          game_id: 'game-1',
+          steam_api_name: 'ach_01',
+          display_name: 'First Steps',
+          unlocked: true,
+        }),
+      })
+
+      const updateCalls = dbMock.mediaItem.update.mock.calls
+      expect(updateCalls).toHaveLength(1)
+      expect(updateCalls[0]![0]).toEqual({
+        where: { id: 'game-1' },
+        data: { achievement_sync_status: 'ok' },
+      })
+    },
+    25_000,
+  )
+
+  it(
+    'sets achievement_sync_status to private_profile and does not upsert achievements on 403',
+    async () => {
+      dbMock.mediaItem.findMany.mockResolvedValueOnce([
+        { id: 'game-private', steam_id: 1942 },
+      ])
+      dbMock.achievement.upsert.mockResolvedValue({})
+      dbMock.mediaItem.update.mockResolvedValue({})
+
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+          .mockResolvedValueOnce(new Response('Forbidden', { status: 403 })),
+      )
+
+      const processor = processors.steamAchievementSync
+      expect(processor).toBeDefined()
+
+      worker = new Worker(
+        TEST_QUEUE_NAME,
+        async (job) => processor!(job),
+        { connection: redis },
+      )
+
+      await new Promise<void>((resolve, reject) => {
+        worker!.on('completed', () => resolve())
+        worker!.on('failed', (_job, err) => reject(err))
+        queue.add('manual', {}, { jobId: 'test-steam-private' })
+      })
+
+      expect(dbMock.achievement.upsert).not.toHaveBeenCalled()
+      const updateCalls = dbMock.mediaItem.update.mock.calls
+      expect(updateCalls).toHaveLength(1)
+      expect(updateCalls[0]![0]).toEqual({
+        where: { id: 'game-private' },
+        data: { achievement_sync_status: 'private_profile' },
+      })
+    },
+    25_000,
+  )
+})
+// Reference to MediaType to keep the import from being flagged as unused if
+// the where-clause assertion is removed in a future refactor.
+void MediaType

--- a/lib/jobs/igdbTokenRefresh.ts
+++ b/lib/jobs/igdbTokenRefresh.ts
@@ -1,0 +1,20 @@
+import type { Job } from 'bullmq'
+import { refreshIgdbToken } from '@/lib/api/igdb'
+import { logger } from '@/lib/logger'
+
+export const IGDB_TOKEN_REFRESH_QUEUE = 'igdbTokenRefresh'
+
+export async function igdbTokenRefreshProcessor(
+  _job: Job,
+): Promise<{ expiresAt: number }> {
+  const { expiresAt } = await refreshIgdbToken()
+  logger.info(
+    {
+      event: 'job.refresh.complete',
+      queue: IGDB_TOKEN_REFRESH_QUEUE,
+      expiresAt,
+    },
+    'igdb token refresh complete',
+  )
+  return { expiresAt }
+}

--- a/lib/jobs/queues.ts
+++ b/lib/jobs/queues.ts
@@ -1,9 +1,81 @@
-import type { Queue } from 'bullmq'
+import { Queue, type Job } from 'bullmq'
+import { redis } from '@/lib/redis'
+import { logger } from '@/lib/logger'
+import {
+  IGDB_TOKEN_REFRESH_QUEUE,
+  igdbTokenRefreshProcessor,
+} from '@/lib/jobs/igdbTokenRefresh'
 
-// Registry of all BullMQ queues. Workers in worker.ts spawn a Worker per entry.
-// Future stories add to this list:
-//   - 9.1 IGDB token refresh
-//   - 9.2 Steam achievement sync
-//   - 11.5 import wizard
-//   - 11.6 similarity scan
-export const queues: { name: string; queue?: Queue }[] = []
+// Module-level Queue singletons via the globalThis pattern (mirrors
+// lib/redis.ts and lib/db.ts). Survives dev hot-reload without leaking
+// connection-per-edit Queue instances.
+
+type ProcessorFn = (job: Job) => Promise<unknown>
+type QueueEntry = { name: string; queue: Queue }
+
+const globalForQueues = globalThis as unknown as {
+  __cuatroQueueRegistry?: {
+    queues: QueueEntry[]
+    processors: Record<string, ProcessorFn>
+  }
+}
+
+function makeRegistry(): {
+  queues: QueueEntry[]
+  processors: Record<string, ProcessorFn>
+} {
+  const igdbTokenRefresh = new Queue(IGDB_TOKEN_REFRESH_QUEUE, {
+    connection: redis,
+  })
+
+  return {
+    queues: [{ name: IGDB_TOKEN_REFRESH_QUEUE, queue: igdbTokenRefresh }],
+    processors: {
+      [IGDB_TOKEN_REFRESH_QUEUE]: igdbTokenRefreshProcessor,
+    },
+  }
+}
+
+const registry = globalForQueues.__cuatroQueueRegistry ?? makeRegistry()
+globalForQueues.__cuatroQueueRegistry = registry
+
+export const queues = registry.queues
+export const processors = registry.processors
+
+// Scheduled-job registration runs only from the worker entrypoint at startup,
+// never on module load. Route handlers that just want to enqueue a one-off
+// job import `queues` without triggering cron writes.
+//
+// Repeat patterns:
+//   - igdbTokenRefresh: 0 3 * * * UTC (daily 3am, low-traffic window) per AC-6.
+//
+// jobId on a repeat is BullMQ's dedup key — re-calling registerScheduledJobs
+// on subsequent worker restarts replaces the same scheduler entry instead of
+// fanning out.
+export async function registerScheduledJobs(): Promise<void> {
+  const igdb = queues.find((q) => q.name === IGDB_TOKEN_REFRESH_QUEUE)?.queue
+  if (!igdb) return
+  try {
+    await igdb.add(
+      'refresh',
+      {},
+      {
+        repeat: { pattern: '0 3 * * *', tz: 'UTC' },
+        jobId: 'igdbTokenRefresh-cron',
+      },
+    )
+    logger.info(
+      {
+        event: 'queue.cron.registered',
+        queue: IGDB_TOKEN_REFRESH_QUEUE,
+        pattern: '0 3 * * *',
+      },
+      'cron registered',
+    )
+  } catch (err) {
+    logger.error(
+      { event: 'queue.cron.register_error', queue: IGDB_TOKEN_REFRESH_QUEUE, err },
+      'cron registration failed',
+    )
+  }
+}

--- a/lib/jobs/queues.ts
+++ b/lib/jobs/queues.ts
@@ -5,6 +5,10 @@ import {
   IGDB_TOKEN_REFRESH_QUEUE,
   igdbTokenRefreshProcessor,
 } from '@/lib/jobs/igdbTokenRefresh'
+import {
+  STEAM_ACHIEVEMENT_SYNC_QUEUE,
+  steamAchievementSyncProcessor,
+} from '@/lib/jobs/steamAchievementSync'
 
 // Module-level Queue singletons via the globalThis pattern (mirrors
 // lib/redis.ts and lib/db.ts). Survives dev hot-reload without leaking
@@ -27,11 +31,18 @@ function makeRegistry(): {
   const igdbTokenRefresh = new Queue(IGDB_TOKEN_REFRESH_QUEUE, {
     connection: redis,
   })
+  const steamAchievementSync = new Queue(STEAM_ACHIEVEMENT_SYNC_QUEUE, {
+    connection: redis,
+  })
 
   return {
-    queues: [{ name: IGDB_TOKEN_REFRESH_QUEUE, queue: igdbTokenRefresh }],
+    queues: [
+      { name: IGDB_TOKEN_REFRESH_QUEUE, queue: igdbTokenRefresh },
+      { name: STEAM_ACHIEVEMENT_SYNC_QUEUE, queue: steamAchievementSync },
+    ],
     processors: {
       [IGDB_TOKEN_REFRESH_QUEUE]: igdbTokenRefreshProcessor,
+      [STEAM_ACHIEVEMENT_SYNC_QUEUE]: steamAchievementSyncProcessor,
     },
   }
 }
@@ -47,35 +58,64 @@ export const processors = registry.processors
 // job import `queues` without triggering cron writes.
 //
 // Repeat patterns:
-//   - igdbTokenRefresh: 0 3 * * * UTC (daily 3am, low-traffic window) per AC-6.
+//   - igdbTokenRefresh: 0 3 * * * UTC (daily 3am, low-traffic window) per Story 9.1 AC-6.
+//   - steamAchievementSync: 0 */6 * * * UTC (every 6h) per Story 9.2 AC-8.
 //
 // jobId on a repeat is BullMQ's dedup key — re-calling registerScheduledJobs
 // on subsequent worker restarts replaces the same scheduler entry instead of
 // fanning out.
+type CronEntry = {
+  queueName: string
+  jobName: string
+  jobId: string
+  pattern: string
+}
+
+const CRONS: CronEntry[] = [
+  {
+    queueName: IGDB_TOKEN_REFRESH_QUEUE,
+    jobName: 'refresh',
+    jobId: 'igdbTokenRefresh-cron',
+    pattern: '0 3 * * *',
+  },
+  {
+    queueName: STEAM_ACHIEVEMENT_SYNC_QUEUE,
+    jobName: 'sync',
+    jobId: 'steamAchievementSync-cron',
+    pattern: '0 */6 * * *',
+  },
+]
+
 export async function registerScheduledJobs(): Promise<void> {
-  const igdb = queues.find((q) => q.name === IGDB_TOKEN_REFRESH_QUEUE)?.queue
-  if (!igdb) return
-  try {
-    await igdb.add(
-      'refresh',
-      {},
-      {
-        repeat: { pattern: '0 3 * * *', tz: 'UTC' },
-        jobId: 'igdbTokenRefresh-cron',
-      },
-    )
-    logger.info(
-      {
-        event: 'queue.cron.registered',
-        queue: IGDB_TOKEN_REFRESH_QUEUE,
-        pattern: '0 3 * * *',
-      },
-      'cron registered',
-    )
-  } catch (err) {
-    logger.error(
-      { event: 'queue.cron.register_error', queue: IGDB_TOKEN_REFRESH_QUEUE, err },
-      'cron registration failed',
-    )
+  for (const cron of CRONS) {
+    const entry = queues.find((q) => q.name === cron.queueName)
+    if (!entry) continue
+    try {
+      await entry.queue.add(
+        cron.jobName,
+        {},
+        {
+          repeat: { pattern: cron.pattern, tz: 'UTC' },
+          jobId: cron.jobId,
+        },
+      )
+      logger.info(
+        {
+          event: 'queue.cron.registered',
+          queue: cron.queueName,
+          pattern: cron.pattern,
+        },
+        'cron registered',
+      )
+    } catch (err) {
+      logger.error(
+        {
+          event: 'queue.cron.register_error',
+          queue: cron.queueName,
+          err,
+        },
+        'cron registration failed',
+      )
+    }
   }
 }

--- a/lib/jobs/steamAchievementSync.ts
+++ b/lib/jobs/steamAchievementSync.ts
@@ -1,0 +1,140 @@
+import type { Job } from 'bullmq'
+import { MediaType } from '@prisma/client'
+import { db } from '@/lib/db'
+import { env } from '@/lib/env'
+import { logger } from '@/lib/logger'
+import {
+  SteamApiError,
+  getPlayerAchievements,
+  getSchemaForGame,
+} from '@/lib/api/steam'
+
+export const STEAM_ACHIEVEMENT_SYNC_QUEUE = 'steamAchievementSync'
+
+export type SteamAchievementSyncTotals = {
+  ok: number
+  private_profile: number
+  failed: number
+  processed: number
+}
+
+export async function steamAchievementSyncProcessor(
+  _job: Job,
+): Promise<{ totals: SteamAchievementSyncTotals }> {
+  const games = await db.mediaItem.findMany({
+    where: { type: MediaType.GAME, steam_id: { not: null } },
+    select: { id: true, steam_id: true },
+  })
+
+  const totals: SteamAchievementSyncTotals = {
+    ok: 0,
+    private_profile: 0,
+    failed: 0,
+    processed: 0,
+  }
+
+  for (const game of games) {
+    totals.processed += 1
+    if (game.steam_id === null) continue
+    const appId = String(game.steam_id)
+
+    try {
+      const result = await getPlayerAchievements(env.STEAM_USER_ID, appId)
+      if (result.status === 'private_profile') {
+        logger.warn(
+          {
+            event: 'job.sync.private_profile',
+            queue: STEAM_ACHIEVEMENT_SYNC_QUEUE,
+            gameId: game.id,
+            appId,
+          },
+          'steam sync: private profile',
+        )
+        await db.mediaItem.update({
+          where: { id: game.id },
+          data: { achievement_sync_status: 'private_profile' },
+        })
+        totals.private_profile += 1
+        continue
+      }
+
+      const schema = await getSchemaForGame(appId)
+      const schemaByName = new Map(schema.map((s) => [s.name, s]))
+
+      for (const ach of result.achievements) {
+        const meta = schemaByName.get(ach.steam_api_name)
+        await db.achievement.upsert({
+          where: {
+            game_id_steam_api_name: {
+              game_id: game.id,
+              steam_api_name: ach.steam_api_name,
+            },
+          },
+          create: {
+            game_id: game.id,
+            steam_api_name: ach.steam_api_name,
+            display_name: meta?.displayName ?? ach.steam_api_name,
+            description: meta?.description ?? null,
+            icon_url: meta?.icon ?? null,
+            unlocked: ach.unlocked_at !== null,
+            unlocked_at: ach.unlocked_at,
+          },
+          update: {
+            display_name: meta?.displayName ?? ach.steam_api_name,
+            description: meta?.description ?? null,
+            icon_url: meta?.icon ?? null,
+            unlocked: ach.unlocked_at !== null,
+            unlocked_at: ach.unlocked_at,
+          },
+        })
+      }
+
+      await db.mediaItem.update({
+        where: { id: game.id },
+        data: { achievement_sync_status: 'ok' },
+      })
+
+      logger.info(
+        {
+          event: 'job.sync.game_ok',
+          queue: STEAM_ACHIEVEMENT_SYNC_QUEUE,
+          gameId: game.id,
+          appId,
+          achievementCount: result.achievements.length,
+        },
+        'steam sync: game ok',
+      )
+      totals.ok += 1
+    } catch (err) {
+      const httpStatus =
+        err instanceof SteamApiError ? err.httpStatus : undefined
+      logger.error(
+        {
+          event: 'job.sync.failed',
+          queue: STEAM_ACHIEVEMENT_SYNC_QUEUE,
+          gameId: game.id,
+          appId,
+          httpStatus,
+          err,
+        },
+        'steam sync: game failed',
+      )
+      await db.mediaItem.update({
+        where: { id: game.id },
+        data: { achievement_sync_status: 'failed' },
+      })
+      totals.failed += 1
+    }
+  }
+
+  logger.info(
+    {
+      event: 'job.sync.complete',
+      queue: STEAM_ACHIEVEMENT_SYNC_QUEUE,
+      totals,
+    },
+    'steam sync complete',
+  )
+
+  return { totals }
+}

--- a/prisma/migrations/20260521120000_add_achievement_sync_status/migration.sql
+++ b/prisma/migrations/20260521120000_add_achievement_sync_status/migration.sql
@@ -1,0 +1,12 @@
+-- Story 9.2: track Steam achievement sync state per game.
+-- Default 'never_synced' covers all existing rows (no GAME rows exist yet but
+-- the column is non-null for every MediaItem so non-game types take the same
+-- default; the sync job only touches type = 'GAME' rows).
+ALTER TABLE "MediaItem"
+  ADD COLUMN "achievement_sync_status" TEXT NOT NULL DEFAULT 'never_synced';
+
+-- CHECK constraint. Prisma DSL cannot express this; the SQL is the source
+-- of truth. Mirrors the pattern at 20260508133713_phase2_constraint_hardening.
+ALTER TABLE "MediaItem"
+  ADD CONSTRAINT "MediaItem_achievement_sync_status_check"
+  CHECK ("achievement_sync_status" IN ('ok', 'private_profile', 'never_synced', 'failed'));

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,6 +139,12 @@ model MediaItem {
   season_year     Int? // AniList seasonYear (anime release / airing year)
   source_material String? // AniList source: MANGA / LIGHT_NOVEL / ORIGINAL / VISUAL_NOVEL / etc.
 
+  // Steam achievement sync status (Story 9.2). Raw SQL CHECK constraint in
+  // migration 20260521120000 restricts to ('ok', 'private_profile',
+  // 'never_synced', 'failed'); the Prisma DSL cannot express CHECK so the
+  // migration sql is the source of truth.
+  achievement_sync_status String @default("never_synced")
+
   user_entry    UserEntry?
   achievements  Achievement[]     @relation("AchievementGame")
   merge_sources MergeSuggestion[] @relation("MergeSource")

--- a/worker.ts
+++ b/worker.ts
@@ -4,7 +4,7 @@ import { env } from '@/lib/env'
 import { redis } from '@/lib/redis'
 import { logger } from '@/lib/logger'
 import { scrubEvent } from '@/lib/sentry-scrub'
-import { queues } from '@/lib/jobs/queues'
+import { processors, queues, registerScheduledJobs } from '@/lib/jobs/queues'
 
 if (env.SENTRY_DSN) {
   Sentry.init({
@@ -27,7 +27,11 @@ const workers = queues.map(({ name }) =>
         'job started',
       )
       try {
-        const result = undefined
+        const processor = processors[name]
+        if (!processor) {
+          throw new Error(`No processor bound for queue: ${name}`)
+        }
+        const result = await processor(job)
         logger.info(
           {
             event: 'job.complete',
@@ -55,6 +59,8 @@ const workers = queues.map(({ name }) =>
     { connection: redis },
   ),
 )
+
+void registerScheduledJobs()
 
 logger.info(
   { event: 'worker.ready', queues: queues.map((q) => q.name) },


### PR DESCRIPTION
Epic 9 · Bundle A · Stories 9.1 + 9.2

Closes #145
Closes #146

## Summary

First real BullMQ processors on top of the Story 1.23 worker scaffold:

- **IGDB adapter** with Twitch app-token persistence to Redis (`igdb:token` + `igdb:token:expiresAt`), 24h refresh threshold, in-process single-flight, 4 req/s slot-limiter, retry on 429/5xx with 1s/2s/4s backoff, custom `IgdbApiError` mirroring `AnilistApiError`.
- **Steam adapter** with discriminated-union `getPlayerAchievements` (`{ status: ''private_profile'' }` on 403, merged percent_global on 200), `getOwnedGames`, `getSchemaForGame`, `SteamApiError`, retry on 5xx.
- **Worker dispatch refactor**: `lib/jobs/queues.ts` exports both `queues` and a `processors` map keyed by queue name. `worker.ts` looks up `processors[name]` and throws on unbound queues. Cron registration moved into a `registerScheduledJobs` function called from worker startup (no more module-load side effects in route-handler imports).
- **Cron jobs**: IGDB token refresh at `0 3 * * *` UTC (Story 9.1); Steam achievement sync at `0 */6 * * *` UTC (Story 9.2). Both registered via the iterated `CRONS` array.
- **Schema migration** `20260521120000_add_achievement_sync_status`: adds `MediaItem.achievement_sync_status TEXT NOT NULL DEFAULT ''never_synced''` with hand-edited CHECK `IN (''ok'', ''private_profile'', ''never_synced'', ''failed'')`, mirroring the canonical pattern at `20260508133713_phase2_constraint_hardening`.
- **Sync job processor** iterates `MediaItem WHERE type = ''GAME'' AND steam_id IS NOT NULL` sequentially, upserts achievements on the composite key `(game_id, steam_api_name)`, updates `achievement_sync_status` per outcome. Per-game failures do NOT fail the whole job.

## Decisions captured

- **Q4 worker dispatch pattern**: Map-based `processors` keyed by queue name (Story 9.1 decision-log).
- **Q5 IGDB image URL**: schema captures `image_id` strings only; helper deferred to Story 9.3 mirroring `lib/api/tmdb-images.ts` (Story 9.1 decision-log).
- **`steam_id` vs `steam_app_id`** (Q3): used existing `steam_id` column for the sync job filter; rename / split is Story 9.3 scope.
- **`Achievement.percent_global`** column: NOT added (handoff Bundle C concern; Story 9.5 owns it since it consumes the value in the UI).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` zero warnings
- [x] `pnpm test` 848/848 passing (was 823 on main; +25 new tests)
- [x] `pnpm prisma migrate dev` applies cleanly; `pnpm prisma migrate status` shows database in sync
- [x] BullMQ integration tests run against live Redis from `pnpm infra`

## LOC overrun (heads-up)

Bundle A diff is `2265 +` / `11 -` across 12 files — about 50% over the handoff''s 1.5K ceiling. Test files account for ~1100 lines (igdb 432 + steam 343 + igdbTokenRefresh 115 + steamAchievementSync 231). Implementation code is ~1155 lines.

Considered splitting per the handoff fallback ("ship 9.1 alone first, then 9.2 alone"), but the two stories share the `queues.ts` refactor (Story 9.1 establishes the Map-based dispatch; Story 9.2 adds the second entry) and the dependency would re-touch the same file. Decision: ship as one PR and flag the overrun here so you can opt to split at review time if the size is a problem.

## Out of scope (per handoff)

- `Achievement.percent_global` column → Story 9.5 (Bundle C).
- `steam_id` → `steam_app_id` rename → Story 9.3 (Bundle B).
- `/games` grid / detail page → Bundles B and C.
- IGDB image helper (`lib/api/igdb-images.ts`) → Story 9.3 alongside the normaliser.