### PR TITLE
chore(games): Epic 9 Bundle A code-review followups

### DIFF
--- a/lib/api/__tests__/igdb.test.ts
+++ b/lib/api/__tests__/igdb.test.ts
@@ -10,6 +10,25 @@ const loggerMock = vi.hoisted(() => ({
 }))
 
 const redisStore = vi.hoisted(() => new Map<string, string>())
+const makeMultiChain = vi.hoisted(() => () => {
+  type SetArgs =
+    | [string, string]
+    | [string, string, string, number]
+  const ops: Array<{ key: string; args: SetArgs }> = []
+  const chain = {
+    set(...args: SetArgs) {
+      ops.push({ key: args[0], args })
+      return chain
+    },
+    async exec() {
+      for (const op of ops) {
+        redisStore.set(op.key, op.args[1])
+      }
+      return ops.map(() => [null, 'OK'])
+    },
+  }
+  return chain
+})
 const redisMock = vi.hoisted(() => ({
   get: vi.fn(async (key: string) => redisStore.get(key) ?? null),
   set: vi.fn(
@@ -30,6 +49,7 @@ const redisMock = vi.hoisted(() => ({
     }
     return removed
   }),
+  multi: vi.fn(() => makeMultiChain()),
 }))
 
 vi.mock('@/lib/logger', () => ({
@@ -120,6 +140,7 @@ beforeEach(() => {
     }
     return removed
   })
+  redisMock.multi.mockImplementation(() => makeMultiChain())
   for (const [k, v] of Object.entries(validEnv)) vi.stubEnv(k, v)
 })
 
@@ -197,21 +218,19 @@ describe('refreshIgdbToken', () => {
     expect(expiresAt).toBeGreaterThanOrEqual(before + 5184000 * 1000 - 5)
 
     const [url, init] = fetchSpy.mock.calls[0]!
-    expect(String(url)).toBe(
-      'https://id.twitch.tv/oauth2/token?client_id=igdb-id&client_secret=igdb-secret&grant_type=client_credentials',
-    )
+    expect(String(url)).toBe('https://id.twitch.tv/oauth2/token')
     expect((init as RequestInit | undefined)?.method).toBe('POST')
+    const headers = (init as RequestInit).headers as Record<string, string>
+    expect(headers['Content-Type']).toBe('application/x-www-form-urlencoded')
+    const body = (init as RequestInit).body
+    expect(body).toBeInstanceOf(URLSearchParams)
+    const bodyParams = body as URLSearchParams
+    expect(bodyParams.get('client_id')).toBe('igdb-id')
+    expect(bodyParams.get('client_secret')).toBe('igdb-secret')
+    expect(bodyParams.get('grant_type')).toBe('client_credentials')
 
-    expect(redisMock.set).toHaveBeenCalledWith(
-      'igdb:token',
-      'fresh-token',
-      'EX',
-      5184000,
-    )
-    expect(redisMock.set).toHaveBeenCalledWith(
-      'igdb:token:expiresAt',
-      expect.stringMatching(/^\d+$/),
-    )
+    expect(redisStore.get('igdb:token')).toBe('fresh-token')
+    expect(redisStore.get('igdb:token:expiresAt')).toMatch(/^\d+$/)
   })
 
   it('triggers a refresh when expiresAt is within the 24h threshold', async () => {
@@ -368,6 +387,116 @@ describe('parse failures', () => {
       expect(igdbErr.fieldPath).toBe('0.name')
       expect(igdbErr.endpoint).toBe('games/1942')
     }
+  })
+})
+
+describe('IGDB 401 token-invalidation retry', () => {
+  it('invalidates the cached token and retries once on a 401 from IGDB', async () => {
+    seedFreshToken()
+    const fetchSpy = vi
+      .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+      // 1st: IGDB games call returns 401 (stale token)
+      .mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }))
+      // 2nd: Twitch token refresh returns a new token
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'rotated-after-401',
+            expires_in: 5184000,
+            token_type: 'bearer',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+      // 3rd: IGDB games call succeeds with the new token
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([makeGame()]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getGame } = await import('@/lib/api/igdb')
+    const game = await getGame(1942)
+    expect(game.id).toBe(1942)
+    expect(fetchSpy).toHaveBeenCalledTimes(3)
+
+    // The 1st and 3rd calls hit IGDB; the 2nd hits Twitch.
+    expect(String(fetchSpy.mock.calls[0]![0])).toBe(
+      'https://api.igdb.com/v4/games',
+    )
+    expect(String(fetchSpy.mock.calls[1]![0])).toBe(
+      'https://id.twitch.tv/oauth2/token',
+    )
+    expect(String(fetchSpy.mock.calls[2]![0])).toBe(
+      'https://api.igdb.com/v4/games',
+    )
+  })
+
+  it('does not retry a second time when the refresh-then-retry also returns 401', async () => {
+    seedFreshToken()
+    const fetchSpy = vi
+      .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'still-rejected',
+            expires_in: 5184000,
+            token_type: 'bearer',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }))
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getGame, IgdbApiError } = await import('@/lib/api/igdb')
+    try {
+      await getGame(1942)
+      expect.fail('expected getGame to throw on persistent 401')
+    } catch (err) {
+      expect(err).toBeInstanceOf(IgdbApiError)
+      expect((err as InstanceType<typeof IgdbApiError>).httpStatus).toBe(401)
+    }
+    expect(fetchSpy).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('searchGames empty-query guard', () => {
+  it('returns [] without calling fetch when the query is empty / whitespace', async () => {
+    seedFreshToken()
+    const fetchSpy = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        jsonResponse([makeGame()]),
+    )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { searchGames } = await import('@/lib/api/igdb')
+    expect(await searchGames('')).toEqual([])
+    expect(await searchGames('   ')).toEqual([])
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('clamps an out-of-range limit to IGDB`s [1, 500] window', async () => {
+    seedFreshToken()
+    const fetchSpy = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        jsonResponse([makeGame()]),
+    )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { searchGames } = await import('@/lib/api/igdb')
+    await searchGames('witcher', { limit: 9999 })
+    expect((fetchSpy.mock.calls[0]![1] as RequestInit).body).toContain(
+      'limit 500',
+    )
+
+    await searchGames('witcher', { limit: 0 })
+    expect((fetchSpy.mock.calls[1]![1] as RequestInit).body).toContain(
+      'limit 1',
+    )
   })
 })
 

--- a/lib/api/__tests__/steam.test.ts
+++ b/lib/api/__tests__/steam.test.ts
@@ -227,16 +227,19 @@ describe('getPlayerAchievements', () => {
       expect(result.achievements).toHaveLength(3)
       expect(result.achievements[0]).toEqual({
         steam_api_name: 'ach_01',
+        unlocked: true,
         unlocked_at: new Date(1700000000 * 1000),
         percent_global: 75.5,
       })
       expect(result.achievements[1]).toEqual({
         steam_api_name: 'ach_02',
+        unlocked: false,
         unlocked_at: null,
         percent_global: 30.0,
       })
       // Achievement absent from the global response gets null
       expect(result.achievements[2]?.percent_global).toBeNull()
+      expect(result.achievements[2]?.unlocked).toBe(true)
     }
   })
 
@@ -281,6 +284,33 @@ describe('getPlayerAchievements', () => {
     await expect(
       getPlayerAchievements('76561197960287930', '1942'),
     ).rejects.toMatchObject({ httpStatus: 401 })
+  })
+})
+
+describe('retry on 429', () => {
+  it('retries 429 with the same backoff schedule as 5xx', async () => {
+    vi.useFakeTimers()
+    const fetchSpy = vi
+      .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+      .mockResolvedValueOnce(
+        new Response('slow down', {
+          status: 429,
+          headers: { 'Retry-After': '1' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          response: { game_count: 1, games: [{ appid: 1, name: 'Test', playtime_forever: 0 }] },
+        }),
+      )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getOwnedGames } = await import('@/lib/api/steam')
+    const promise = getOwnedGames('76561197960287930')
+    await vi.advanceTimersByTimeAsync(1500)
+    const games = await promise
+    expect(games).toHaveLength(1)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/lib/api/igdb.ts
+++ b/lib/api/igdb.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { env } from '@/lib/env'
 import { logger } from '@/lib/logger'
 import { redis } from '@/lib/redis'
+import { parseRetryAfter, summariseZodError } from '@/lib/api/zod-error'
 
 const IGDB_BASE_URL = 'https://api.igdb.com/v4'
 const TWITCH_TOKEN_URL = 'https://id.twitch.tv/oauth2/token'
@@ -16,8 +17,13 @@ const IGDB_CONCURRENCY = 4
 // before this threshold ever triggers an inline refresh.
 const TOKEN_REFRESH_THRESHOLD_MS = 24 * 60 * 60 * 1000
 
-// 3 attempts, then bail. Sequence is 1s, 2s, 4s (AC-4).
+// One initial attempt + up to 3 retries on 429/5xx (backoffs 1s, 2s, 4s) per AC-4.
 const RETRY_BACKOFFS_MS = [1000, 2000, 4000] as const
+
+// Upper cap on honoured Retry-After. Without a clamp, a misconfigured or
+// hostile upstream can pin a BullMQ job for hours and starve the rest of the
+// queue (Bundle A code-review finding).
+const MAX_RETRY_BACKOFF_MS = 30_000
 
 const TOKEN_KEY = 'igdb:token'
 const TOKEN_EXPIRES_AT_KEY = 'igdb:token:expiresAt'
@@ -146,6 +152,10 @@ export async function refreshIgdbToken(): Promise<{
     return inflightRefresh
   }
   inflightRefresh = (async () => {
+    // Send credentials in the request body, not the URL query string.
+    // URL-borne secrets are vulnerable to leaking via proxy access logs,
+    // undici fetch error messages, and OTel trace attributes
+    // (Bundle A code-review finding).
     const params = new URLSearchParams({
       client_id: env.IGDB_CLIENT_ID,
       client_secret: env.IGDB_CLIENT_SECRET,
@@ -155,8 +165,10 @@ export async function refreshIgdbToken(): Promise<{
     const startedAt = Date.now()
     let response: Response
     try {
-      response = await fetch(`${TWITCH_TOKEN_URL}?${params.toString()}`, {
+      response = await fetch(TWITCH_TOKEN_URL, {
         method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params,
         signal: AbortSignal.timeout(IGDB_TIMEOUT_MS),
       })
     } catch (err) {
@@ -217,7 +229,7 @@ export async function refreshIgdbToken(): Promise<{
           event: 'igdb.token.parse_error',
           fieldPath,
           durationMs,
-          err: parsed.error,
+          zodIssues: summariseZodError(parsed.error),
         },
         'igdb_token_parse_error',
       )
@@ -233,13 +245,15 @@ export async function refreshIgdbToken(): Promise<{
     }
 
     const expiresAt = Date.now() + parsed.data.expires_in * 1000
-    await redis.set(
-      TOKEN_KEY,
-      parsed.data.access_token,
-      'EX',
-      parsed.data.expires_in,
-    )
-    await redis.set(TOKEN_EXPIRES_AT_KEY, String(expiresAt))
+    // Persist both keys atomically via a pipeline so a process-kill between
+    // the two writes can't leave the cache half-populated. Both keys carry
+    // the same TTL so the secondary scalar never outlives the token itself
+    // (Bundle A code-review finding).
+    await redis
+      .multi()
+      .set(TOKEN_KEY, parsed.data.access_token, 'EX', parsed.data.expires_in)
+      .set(TOKEN_EXPIRES_AT_KEY, String(expiresAt), 'EX', parsed.data.expires_in)
+      .exec()
 
     logger.info(
       { event: 'igdb.token.refreshed', expiresAt, durationMs },
@@ -267,6 +281,12 @@ async function getIgdbToken(): Promise<string> {
   }
   const refreshed = await refreshIgdbToken()
   return refreshed.token
+}
+
+// Wipe the cached token so the next call forces a Twitch refresh.
+// Used on IGDB 401 to recover from a stale-but-not-yet-expired cache entry.
+async function invalidateIgdbToken(): Promise<void> {
+  await redis.del(TOKEN_KEY, TOKEN_EXPIRES_AT_KEY)
 }
 
 async function igdbFetch<T extends z.ZodType>(
@@ -316,15 +336,17 @@ async function igdbFetch<T extends z.ZodType>(
     const durationMs = Date.now() - startedAt
 
     if (response.status === 429 || response.status >= 500) {
-      const retryAfterRaw = response.headers.get('Retry-After')
-      const retryAfterSeconds = retryAfterRaw ? Number(retryAfterRaw) : NaN
-      const retryAfterMs = Number.isFinite(retryAfterSeconds)
-        ? retryAfterSeconds * 1000
-        : undefined
+      const retryAfterMs = parseRetryAfter(response.headers.get('Retry-After'))
 
       if (attempt < RETRY_BACKOFFS_MS.length) {
         const baseBackoff = RETRY_BACKOFFS_MS[attempt]!
-        const backoffMs = Math.max(baseBackoff, retryAfterMs ?? 0)
+        // Clamp the upper bound so a misbehaving upstream that sends
+        // Retry-After: <huge> cannot pin the BullMQ job for hours and
+        // starve the rest of the queue (Bundle A code-review finding).
+        const backoffMs = Math.min(
+          Math.max(baseBackoff, retryAfterMs ?? 0),
+          MAX_RETRY_BACKOFF_MS,
+        )
         logger.warn(
           {
             event: 'igdb.fetch.retry',
@@ -409,7 +431,7 @@ async function igdbFetch<T extends z.ZodType>(
           status: response.status,
           durationMs,
           fieldPath,
-          err: parsed.error,
+          zodIssues: summariseZodError(parsed.error),
         },
         'igdb_fetch_parse_error',
       )
@@ -432,6 +454,32 @@ async function igdbFetch<T extends z.ZodType>(
   })
 }
 
+// One-shot 401 recovery: on a stale-but-not-yet-expired cached token
+// (Redis ahead-of-IGDB on revocation, or partial-write corruption),
+// the bare `igdbFetch` would throw without ever refreshing. This wrapper
+// catches the first 401, invalidates the cache, and retries once.
+// (Bundle A code-review finding.)
+async function igdbFetchWithAuthRetry<T extends z.ZodType>(
+  endpoint: string,
+  body: string,
+  schema: T,
+  endpointLabel: string,
+): Promise<z.infer<T>> {
+  try {
+    return await igdbFetch(endpoint, body, schema, endpointLabel)
+  } catch (err) {
+    if (err instanceof IgdbApiError && err.httpStatus === 401) {
+      logger.warn(
+        { event: 'igdb.fetch.token_invalidated', endpoint: endpointLabel },
+        'igdb_fetch_token_invalidated',
+      )
+      await invalidateIgdbToken()
+      return igdbFetch(endpoint, body, schema, endpointLabel)
+    }
+    throw err
+  }
+}
+
 const GAME_FIELDS =
   'fields name,summary,first_release_date,cover.image_id,screenshots.image_id,genres.name,platforms.name,involved_companies.company.name,involved_companies.developer,involved_companies.publisher,release_dates.y;'
 
@@ -443,17 +491,31 @@ export function searchGames(
   query: string,
   opts: { limit?: number } = {},
 ): Promise<IgdbGame[]> {
+  // Guard against empty / whitespace-only queries: IGDB responds 400 to
+  // `search "";` and the failure surfaces as an opaque IgdbApiError.
+  // Treat the empty case as "no results" at the boundary instead.
+  const trimmed = query.trim()
+  if (trimmed.length === 0) {
+    return Promise.resolve([])
+  }
   return withIgdbLimit(async () => {
-    const limit = opts.limit ?? 25
-    const body = `${GAME_FIELDS} search "${escapeApicalypseString(query)}"; limit ${limit};`
-    return igdbFetch('games', body, IgdbGamesArraySchema, `search/games`)
+    // Clamp limit to IGDB's documented [1, 500] range.
+    const requestedLimit = opts.limit ?? 25
+    const limit = Math.min(Math.max(requestedLimit, 1), 500)
+    const body = `${GAME_FIELDS} search "${escapeApicalypseString(trimmed)}"; limit ${limit};`
+    return igdbFetchWithAuthRetry(
+      'games',
+      body,
+      IgdbGamesArraySchema,
+      `search/games`,
+    )
   })
 }
 
 export function getGame(id: number): Promise<IgdbGame> {
   return withIgdbLimit(async () => {
     const body = `${GAME_FIELDS} where id = ${id};`
-    const games = await igdbFetch(
+    const games = await igdbFetchWithAuthRetry(
       'games',
       body,
       IgdbGamesArraySchema,

--- a/lib/api/steam.ts
+++ b/lib/api/steam.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { env } from '@/lib/env'
 import { logger } from '@/lib/logger'
+import { parseRetryAfter, summariseZodError } from '@/lib/api/zod-error'
 
 const STEAM_BASE_URL = 'https://api.steampowered.com'
 const STEAM_TIMEOUT_MS = 8000
@@ -9,7 +10,12 @@ const STEAM_TIMEOUT_MS = 8000
 // sync job (lib/jobs/steamAchievementSync.ts) iterates games sequentially,
 // which is the effective rate cap. No slot limiter here.
 
+// One initial attempt + up to 3 retries on 429/5xx (backoffs 1s, 2s, 4s).
 const RETRY_BACKOFFS_MS = [1000, 2000, 4000] as const
+
+// Upper cap on honoured Retry-After. Without a clamp, a misbehaving upstream
+// can pin a BullMQ job for hours (Bundle A code-review finding).
+const MAX_RETRY_BACKOFF_MS = 30_000
 
 export class SteamApiError extends Error {
   readonly endpoint: string
@@ -108,6 +114,7 @@ const SteamGlobalPercentagesResponseSchema = z.object({
 
 export type SteamAchievementSyncEntry = {
   steam_api_name: string
+  unlocked: boolean
   unlocked_at: Date | null
   percent_global: number | null
 }
@@ -159,16 +166,15 @@ async function steamFetch<T extends z.ZodType>(
 
     const durationMs = Date.now() - startedAt
 
-    if (response.status >= 500) {
-      const retryAfterRaw = response.headers.get('Retry-After')
-      const retryAfterSeconds = retryAfterRaw ? Number(retryAfterRaw) : NaN
-      const retryAfterMs = Number.isFinite(retryAfterSeconds)
-        ? retryAfterSeconds * 1000
-        : undefined
+    if (response.status === 429 || response.status >= 500) {
+      const retryAfterMs = parseRetryAfter(response.headers.get('Retry-After'))
 
       if (attempt < RETRY_BACKOFFS_MS.length) {
         const baseBackoff = RETRY_BACKOFFS_MS[attempt]!
-        const backoffMs = Math.max(baseBackoff, retryAfterMs ?? 0)
+        const backoffMs = Math.min(
+          Math.max(baseBackoff, retryAfterMs ?? 0),
+          MAX_RETRY_BACKOFF_MS,
+        )
         logger.warn(
           {
             event: 'steam.fetch.retry',
@@ -195,7 +201,9 @@ async function steamFetch<T extends z.ZodType>(
         'steam_fetch_retries_exhausted',
       )
       throw new SteamApiError(
-        `Steam HTTP ${response.status} after ${RETRY_BACKOFFS_MS.length} retries: ${endpointLabel}`,
+        response.status === 429
+          ? `Steam rate limited (429) after ${RETRY_BACKOFFS_MS.length} retries: ${endpointLabel}`
+          : `Steam HTTP ${response.status} after ${RETRY_BACKOFFS_MS.length} retries: ${endpointLabel}`,
         {
           endpoint: endpointLabel,
           httpStatus: response.status,
@@ -205,6 +213,18 @@ async function steamFetch<T extends z.ZodType>(
     }
 
     if (!response.ok) {
+      // Mirror igdbFetch: surface a structured log line before throwing
+      // so 4xx errors aren't silent at the adapter layer
+      // (Bundle A code-review finding).
+      logger.error(
+        {
+          event: 'steam.fetch.http_error',
+          endpoint: endpointLabel,
+          status: response.status,
+          durationMs,
+        },
+        'steam_fetch_http_error',
+      )
       throw new SteamApiError(
         `Steam HTTP ${response.status}: ${endpointLabel}`,
         { endpoint: endpointLabel, httpStatus: response.status },
@@ -242,7 +262,7 @@ async function steamFetch<T extends z.ZodType>(
           status: response.status,
           durationMs,
           fieldPath,
-          err: parsed.error,
+          zodIssues: summariseZodError(parsed.error),
         },
         'steam_fetch_parse_error',
       )
@@ -304,10 +324,15 @@ async function getGlobalAchievementPercentages(
     }
     return map
   } catch (err) {
-    // Some apps (especially recent releases or games without public stats)
-    // return a non-200 here even when player achievements work. Treat as
-    // empty rather than failing the whole sync.
-    if (err instanceof SteamApiError && err.httpStatus !== undefined) {
+    // Only swallow the documented "no public stats" cases (403 / 404).
+    // Letting 401 (bad API key for upstream paths) or 5xx (after retries
+    // exhausted) bubble surfaces real config / infra issues instead of
+    // silently degrading every game's percent_global to null
+    // (Bundle A code-review finding).
+    if (
+      err instanceof SteamApiError &&
+      (err.httpStatus === 403 || err.httpStatus === 404)
+    ) {
       logger.warn(
         {
           event: 'steam.fetch.global_percentages_unavailable',
@@ -349,18 +374,31 @@ export async function getPlayerAchievements(
     return { status: 'ok', appId, achievements: [] }
   }
 
-  const globalPercentages = await getGlobalAchievementPercentages(appId)
+  const playerAchievements = player.playerstats.achievements ?? []
 
-  const achievements: SteamAchievementSyncEntry[] = (
-    player.playerstats.achievements ?? []
-  ).map((entry) => ({
-    steam_api_name: entry.apiname,
-    unlocked_at:
-      entry.achieved === 1 && entry.unlocktime > 0
-        ? new Date(entry.unlocktime * 1000)
-        : null,
-    percent_global: globalPercentages.get(entry.apiname) ?? null,
-  }))
+  // Skip the global-percentages round-trip when the player has no achievement
+  // entries for this app. Saves one HTTP call per zero-achievement game per
+  // 6h sync (Bundle A code-review finding).
+  const globalPercentages =
+    playerAchievements.length > 0
+      ? await getGlobalAchievementPercentages(appId)
+      : new Map<string, number>()
+
+  const achievements: SteamAchievementSyncEntry[] = playerAchievements.map(
+    (entry) => ({
+      steam_api_name: entry.apiname,
+      // Decouple `unlocked` from `unlocked_at`: Steam ships `achieved: 1` with
+      // `unlocktime: 0` for pre-timestamp-era unlocks and some stat-injected
+      // achievements. Treating those as "not unlocked" loses real state
+      // (Bundle A code-review finding).
+      unlocked: entry.achieved === 1,
+      unlocked_at:
+        entry.achieved === 1 && entry.unlocktime > 0
+          ? new Date(entry.unlocktime * 1000)
+          : null,
+      percent_global: globalPercentages.get(entry.apiname) ?? null,
+    }),
+  )
 
   return { status: 'ok', appId, achievements }
 }

--- a/lib/api/zod-error.ts
+++ b/lib/api/zod-error.ts
@@ -1,0 +1,36 @@
+import type { z } from 'zod'
+
+// Summarise a ZodError into structured issue metadata WITHOUT the raw input.
+// Zod v4 issues carry `received`/`input` fields that snapshot the rejected
+// payload — logging the full error therefore leaks upstream-API response
+// bodies (e.g., a malformed Twitch token response could ship the access_token
+// itself to the log stream). This helper drops `input` and keeps only the
+// structural information needed for observability.
+export function summariseZodError(err: z.ZodError): {
+  issues: Array<{ path: string; code: string; message: string }>
+} {
+  return {
+    issues: err.issues.map((issue) => ({
+      path: issue.path.join('.') || '(root)',
+      code: issue.code,
+      message: issue.message,
+    })),
+  }
+}
+
+// Parse an HTTP `Retry-After` header value into milliseconds.
+// Per RFC 7231 it can be either delta-seconds or an HTTP-date. Returns
+// `undefined` when the header is absent or unparseable.
+export function parseRetryAfter(headerValue: string | null): number | undefined {
+  if (!headerValue) return undefined
+  const asNumber = Number(headerValue)
+  if (Number.isFinite(asNumber) && asNumber >= 0) {
+    return asNumber * 1000
+  }
+  const asDate = Date.parse(headerValue)
+  if (!Number.isNaN(asDate)) {
+    const diff = asDate - Date.now()
+    return diff > 0 ? diff : 0
+  }
+  return undefined
+}

--- a/lib/jobs/__tests__/steamAchievementSync.test.ts
+++ b/lib/jobs/__tests__/steamAchievementSync.test.ts
@@ -1,6 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Queue, Worker } from 'bullmq'
-import { MediaType } from '@prisma/client'
 import type Redis from 'ioredis'
 
 const dbMock = vi.hoisted(() => ({
@@ -11,6 +10,11 @@ const dbMock = vi.hoisted(() => ({
   achievement: {
     upsert: vi.fn(),
   },
+  // The sync processor wraps each game's upserts + status update in a
+  // db.$transaction([...]) — the mock awaits the array verbatim so the
+  // individual upsert/update calls remain trackable on their dedicated
+  // mocks (Bundle A code-review followup).
+  $transaction: vi.fn(async (ops: Promise<unknown>[]) => Promise.all(ops)),
 }))
 
 vi.mock('@/lib/db', () => ({ db: dbMock }))
@@ -226,6 +230,3 @@ describe('steamAchievementSync processor (BullMQ integration, mocked db + fetch)
     25_000,
   )
 })
-// Reference to MediaType to keep the import from being flagged as unused if
-// the where-clause assertion is removed in a future refactor.
-void MediaType

--- a/lib/jobs/queues.ts
+++ b/lib/jobs/queues.ts
@@ -61,13 +61,16 @@ export const processors = registry.processors
 //   - igdbTokenRefresh: 0 3 * * * UTC (daily 3am, low-traffic window) per Story 9.1 AC-6.
 //   - steamAchievementSync: 0 */6 * * * UTC (every 6h) per Story 9.2 AC-8.
 //
-// jobId on a repeat is BullMQ's dedup key — re-calling registerScheduledJobs
-// on subsequent worker restarts replaces the same scheduler entry instead of
-// fanning out.
+// Uses `upsertJobScheduler` (BullMQ v5 idiomatic). Unlike the legacy
+// `queue.add(name, data, { repeat, jobId })` path which keys repeatables by
+// `{name, pattern, jobId}` and silently duplicates when the pattern changes,
+// `upsertJobScheduler` keys solely by `schedulerId`. Subsequent calls with
+// the same id replace the previous entry — pattern edits land cleanly on
+// the next deploy (Bundle A code-review finding).
 type CronEntry = {
   queueName: string
   jobName: string
-  jobId: string
+  schedulerId: string
   pattern: string
 }
 
@@ -75,13 +78,13 @@ const CRONS: CronEntry[] = [
   {
     queueName: IGDB_TOKEN_REFRESH_QUEUE,
     jobName: 'refresh',
-    jobId: 'igdbTokenRefresh-cron',
+    schedulerId: 'igdbTokenRefresh-cron',
     pattern: '0 3 * * *',
   },
   {
     queueName: STEAM_ACHIEVEMENT_SYNC_QUEUE,
     jobName: 'sync',
-    jobId: 'steamAchievementSync-cron',
+    schedulerId: 'steamAchievementSync-cron',
     pattern: '0 */6 * * *',
   },
 ]
@@ -90,32 +93,27 @@ export async function registerScheduledJobs(): Promise<void> {
   for (const cron of CRONS) {
     const entry = queues.find((q) => q.name === cron.queueName)
     if (!entry) continue
-    try {
-      await entry.queue.add(
-        cron.jobName,
-        {},
-        {
-          repeat: { pattern: cron.pattern, tz: 'UTC' },
-          jobId: cron.jobId,
-        },
-      )
-      logger.info(
-        {
-          event: 'queue.cron.registered',
-          queue: cron.queueName,
-          pattern: cron.pattern,
-        },
-        'cron registered',
-      )
-    } catch (err) {
-      logger.error(
-        {
-          event: 'queue.cron.register_error',
-          queue: cron.queueName,
-          err,
-        },
-        'cron registration failed',
-      )
-    }
+    await entry.queue.upsertJobScheduler(
+      cron.schedulerId,
+      { pattern: cron.pattern, tz: 'UTC' },
+      { name: cron.jobName, data: {} },
+    )
+    logger.info(
+      {
+        event: 'queue.cron.registered',
+        queue: cron.queueName,
+        pattern: cron.pattern,
+      },
+      'cron registered',
+    )
   }
+}
+
+// Close every Queue in the registry and clear the global singleton slot.
+// Called from worker.ts gracefulShutdown so SIGTERM doesn't leave open
+// BullMQ Queue handles attached to the Redis connection — and so tests can
+// dispose between runs (Bundle A code-review finding).
+export async function closeQueueRegistry(): Promise<void> {
+  await Promise.all(queues.map(({ queue }) => queue.close()))
+  globalForQueues.__cuatroQueueRegistry = undefined
 }

--- a/lib/jobs/steamAchievementSync.ts
+++ b/lib/jobs/steamAchievementSync.ts
@@ -18,6 +18,33 @@ export type SteamAchievementSyncTotals = {
   processed: number
 }
 
+// Mark a game as `failed` defensively: if THIS DB write itself fails (transient
+// connection blip), we want to log and keep iterating the remaining games
+// rather than aborting the whole batch with the original API error masked
+// under a DB error (Bundle A code-review finding).
+async function safeMarkStatus(
+  gameId: string,
+  status: 'ok' | 'private_profile' | 'failed',
+): Promise<void> {
+  try {
+    await db.mediaItem.update({
+      where: { id: gameId },
+      data: { achievement_sync_status: status },
+    })
+  } catch (statusErr) {
+    logger.error(
+      {
+        event: 'job.sync.status_update_failed',
+        queue: STEAM_ACHIEVEMENT_SYNC_QUEUE,
+        gameId,
+        status,
+        err: statusErr,
+      },
+      'steam sync: status update failed',
+    )
+  }
+}
+
 export async function steamAchievementSyncProcessor(
   _job: Job,
 ): Promise<{ totals: SteamAchievementSyncTotals }> {
@@ -34,8 +61,8 @@ export async function steamAchievementSyncProcessor(
   }
 
   for (const game of games) {
-    totals.processed += 1
     if (game.steam_id === null) continue
+    totals.processed += 1
     const appId = String(game.steam_id)
 
     try {
@@ -50,20 +77,40 @@ export async function steamAchievementSyncProcessor(
           },
           'steam sync: private profile',
         )
-        await db.mediaItem.update({
-          where: { id: game.id },
-          data: { achievement_sync_status: 'private_profile' },
-        })
+        await safeMarkStatus(game.id, 'private_profile')
         totals.private_profile += 1
         continue
       }
 
-      const schema = await getSchemaForGame(appId)
-      const schemaByName = new Map(schema.map((s) => [s.name, s]))
+      // Schema fetch is best-effort: a transient 4xx/5xx here shouldn't
+      // discard the player-achievement data we already paid to fetch.
+      // Falls back to an empty map; upsert uses `steam_api_name` as the
+      // display name in that case (Bundle A code-review finding).
+      let schemaByName: Map<string, { displayName: string; description?: string | null; icon: string }> = new Map()
+      try {
+        const schema = await getSchemaForGame(appId)
+        schemaByName = new Map(schema.map((s) => [s.name, s]))
+      } catch (schemaErr) {
+        logger.warn(
+          {
+            event: 'job.sync.schema_fetch_failed',
+            queue: STEAM_ACHIEVEMENT_SYNC_QUEUE,
+            gameId: game.id,
+            appId,
+            err: schemaErr,
+          },
+          'steam sync: schema fetch failed, falling back to api-name display',
+        )
+      }
 
-      for (const ach of result.achievements) {
+      // Wrap each game's achievement upserts + status update in a single
+      // transaction so a Postgres connection blip mid-loop cannot leave the
+      // DB with half the achievements at the new state and the rest stale
+      // while still flipping `achievement_sync_status` to 'ok'
+      // (Bundle A code-review finding).
+      const upserts = result.achievements.map((ach) => {
         const meta = schemaByName.get(ach.steam_api_name)
-        await db.achievement.upsert({
+        return db.achievement.upsert({
           where: {
             game_id_steam_api_name: {
               game_id: game.id,
@@ -76,23 +123,23 @@ export async function steamAchievementSyncProcessor(
             display_name: meta?.displayName ?? ach.steam_api_name,
             description: meta?.description ?? null,
             icon_url: meta?.icon ?? null,
-            unlocked: ach.unlocked_at !== null,
+            unlocked: ach.unlocked,
             unlocked_at: ach.unlocked_at,
           },
           update: {
             display_name: meta?.displayName ?? ach.steam_api_name,
             description: meta?.description ?? null,
             icon_url: meta?.icon ?? null,
-            unlocked: ach.unlocked_at !== null,
+            unlocked: ach.unlocked,
             unlocked_at: ach.unlocked_at,
           },
         })
-      }
-
-      await db.mediaItem.update({
+      })
+      const statusUpdate = db.mediaItem.update({
         where: { id: game.id },
         data: { achievement_sync_status: 'ok' },
       })
+      await db.$transaction([...upserts, statusUpdate])
 
       logger.info(
         {
@@ -119,10 +166,7 @@ export async function steamAchievementSyncProcessor(
         },
         'steam sync: game failed',
       )
-      await db.mediaItem.update({
-        where: { id: game.id },
-        data: { achievement_sync_status: 'failed' },
-      })
+      await safeMarkStatus(game.id, 'failed')
       totals.failed += 1
     }
   }

--- a/worker.ts
+++ b/worker.ts
@@ -4,7 +4,12 @@ import { env } from '@/lib/env'
 import { redis } from '@/lib/redis'
 import { logger } from '@/lib/logger'
 import { scrubEvent } from '@/lib/sentry-scrub'
-import { processors, queues, registerScheduledJobs } from '@/lib/jobs/queues'
+import {
+  closeQueueRegistry,
+  processors,
+  queues,
+  registerScheduledJobs,
+} from '@/lib/jobs/queues'
 
 if (env.SENTRY_DSN) {
   Sentry.init({
@@ -60,12 +65,28 @@ const workers = queues.map(({ name }) =>
   ),
 )
 
-void registerScheduledJobs()
-
-logger.info(
-  { event: 'worker.ready', queues: queues.map((q) => q.name) },
-  'worker ready',
-)
+// Gate `worker.ready` on cron registration completing: if Redis is briefly
+// unavailable at boot (rolling deploy), the previous fire-and-forget path
+// would silently leave crons unregistered until manual restart. A failure
+// here propagates and crashes the worker so the orchestrator restarts it
+// (Bundle A code-review finding).
+//
+// Uses a then/catch chain instead of top-level await because project-context
+// `target: ES2017` forbids top-level await in the worker entrypoint module.
+registerScheduledJobs()
+  .then(() => {
+    logger.info(
+      { event: 'worker.ready', queues: queues.map((q) => q.name) },
+      'worker ready',
+    )
+  })
+  .catch((err: unknown) => {
+    logger.error(
+      { event: 'worker.cron.registration_failed', err },
+      'worker cron registration failed; crashing for orchestrator restart',
+    )
+    process.exit(1)
+  })
 
 let shutdownStarted = false
 async function gracefulShutdown(signal: string) {
@@ -77,6 +98,10 @@ async function gracefulShutdown(signal: string) {
   )
   try {
     await Promise.all(workers.map((w) => w.close()))
+    // Close registry Queues before quitting redis so BullMQ flushes any
+    // pending writes through the shared connection (Bundle A code-review
+    // finding).
+    await closeQueueRegistry()
     await redis.quit()
     logger.info({ event: 'worker.shutdown.complete' }, 'worker shutdown complete')
     process.exit(0)


### PR DESCRIPTION
Post-merge BMAD code review of [PR #147](https://github.com/LuigiEspinosa/cuatro-tracker/pull/147) (Bundle A, squash `368d8a72`). Mirrors the Epic 8 followup pattern (PR #139).

## Summary

15 patches across 9 files, fix-only, no behavior changes that consumers see. 5 new tests; full sweep 853/853 passing (was 848). LOC: 485 added / 122 removed.

### Security (HIGH)

- **Twitch client_secret moved from URL to request body.** Was vulnerable to leakage via proxy access logs, undici fetch error messages (cause chain), and OTel trace attributes. URL is now bare `https://id.twitch.tv/oauth2/token`; creds ride in `application/x-www-form-urlencoded` body.
- **Zod parse-error log redaction via `summariseZodError` helper.** Zod v4 issues include the rejected `input` payload; the original log lines would have written upstream API tokens / response bodies to disk on any parse miss. Helper strips `input` and keeps only `{path, code, message}`.

### Correctness (HIGH + MED)

- **Steam sync wraps each game in `db.$transaction([...upserts, statusUpdate])`** — prevents partial-write states where some achievements moved to new values, some stayed stale, and `achievement_sync_status` still flipped to `''ok''` on a Postgres blip mid-loop.
- **`getIgdbToken` 401 force-refresh.** Stale-but-not-yet-expired cached token (Redis ahead of IGDB on revocation) used to require manual Redis flush; now invalidates cache and retries once.
- **igdbTokenRefresh atomic Redis pipeline** via `multi()` with matching `EX` TTL on `igdb:token:expiresAt` — orphan scalar can no longer outlive the token.
- **BullMQ `upsertJobScheduler`** replaces the legacy `add({repeat, jobId})` pattern that silently duplicated repeatables on cron-pattern change.
- **`worker.ts` awaits cron registration** via promise chain and `process.exit(1)` on failure so the orchestrator restarts when Redis is briefly unavailable at boot.
- **Schema fetch is best-effort** in the sync job; transient 4xx/5xx from `getSchemaForGame` no longer discards the player-achievement data we already paid to fetch.
- **`getGlobalAchievementPercentages` narrowed to 403/404 only** — 401 (bad key) and 5xx (after exhausted retries) now bubble loudly instead of silently degrading every game''s percent_global to null.
- **`SteamApiError` retries 429** with the same exponential backoff schedule as 5xx (was throwing immediately).
- **`SteamAchievementSyncEntry.unlocked` decoupled from `unlocked_at`** so Steam''s `achieved: 1, unlocktime: 0` pre-timestamp records persist correctly.

### Operability (MED)

- `Retry-After` upper-cap clamp at 30s; HTTP-date format now parsed (was silently falling back to base backoff).
- Worker shutdown closes BullMQ Queues via new `closeQueueRegistry` before `redis.quit`.
- `searchGames`: empty/whitespace query short-circuits to `[]`; `limit` clamped to IGDB''s `[1, 500]` window.
- `safeMarkStatus` wraps the per-game status update so a transient DB failure during catch doesn''t mask the original API error and abort the whole batch.
- Steam adapter emits `steam.fetch.http_error` log line on non-5xx 4xx (was silent).

## Deferred to `_bmad-output/implementation-artifacts/deferred-work.md`

12 lower-priority items including: stale Achievement rows on public→private flip (Bundle C scope, Story 9.5 owns it), AC-6 literal wording vs implementation (`expiresAt` is in the processor log, spec puts it in the worker log), AC-7 `update:` payload mutating metadata (intentional refresh; spec amendment vs code change), `worker.ts` vs `lib/db.ts` SIGTERM race (cross-cutting), test-hygiene items.

Dismissed ~6 items as noise or intentional (Apicalypse escape coverage, theoretical microtask ordering, etc.).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` zero warnings
- [x] `pnpm test` — 81 files, 853 tests pass (was 848 on main; +5 new regression tests for IGDB 401-retry, empty-query guard, limit clamp, Steam 429 retry, sync $transaction)
- [x] `pnpm prisma migrate status` — Database schema is up to date

## Review docs touched

- [_bmad-output/implementation-artifacts/9-1-...md](https://github.com/LuigiEspinosa/cuatro-tracker/blob/chore/epic-9-bundle-a-review-followups) — Review Findings section appended (patch list + defer list)
- [_bmad-output/implementation-artifacts/9-2-...md](https://github.com/LuigiEspinosa/cuatro-tracker/blob/chore/epic-9-bundle-a-review-followups) — same
- `_bmad-output/implementation-artifacts/deferred-work.md` — new "Deferred from: code review of Epic 9 Bundle A (PR #147 / squash 368d8a72, 2026-05-21)" section