### PR TITLE
chore(games): apply Bundle B Pass 4 code-review followups (#153)

### DIFF
--- a/components/molecules/SearchResultRow/__tests__/SearchResultRow.test.tsx
+++ b/components/molecules/SearchResultRow/__tests__/SearchResultRow.test.tsx
@@ -222,7 +222,7 @@ describe('SearchResultRow', () => {
     // Regression for "Games image broken in search results": IGDB stores bare
     // image_id strings on the wire (NFR15 / Story 9.3 AC-8). Before this fix,
     // a game's poster_path ('co1xkj') was being fed to getImageUrl which
-    // produced https://image.tmdb.org/t/p/w185co1xkj — a 404.
+    // produced https://image.tmdb.org/t/p/w185co1xkj, a 404.
     const { container } = render(
       <SearchResultRow
         result={makeResult({

--- a/lib/normalise/__tests__/game.test.ts
+++ b/lib/normalise/__tests__/game.test.ts
@@ -283,6 +283,30 @@ describe('lib/normalise/game', () => {
       )
       expect(result.poster_path).toBeNull()
     })
+
+    it('returns poster_path: null when cover.image_id is whitespace-only', async () => {
+      const { normaliseIgdbGame } = await import('@/lib/normalise/game')
+      const result = normaliseIgdbGame(
+        makeIgdbGame({
+          cover: { id: 1, image_id: '  ' },
+        }),
+      )
+      expect(result.poster_path).toBeNull()
+    })
+
+    it('filters out whitespace-only image_ids from screenshots', async () => {
+      const { normaliseIgdbGame } = await import('@/lib/normalise/game')
+      const result = normaliseIgdbGame(
+        makeIgdbGame({
+          screenshots: [
+            { id: 1, image_id: 'sc1' },
+            { id: 2, image_id: '   ' },
+            { id: 3, image_id: 'sc3' },
+          ],
+        }),
+      )
+      expect(result.screenshots).toEqual(['sc1', 'sc3'])
+    })
   })
 
   describe('developer/publisher selection', () => {
@@ -389,6 +413,13 @@ describe('lib/normalise/game', () => {
       {
         label: 'first_release_date null + release_dates missing entirely',
         overrides: { first_release_date: null, release_dates: undefined },
+      },
+      {
+        label: 'first_release_date null + release_dates[].y exceeds Date.UTC range',
+        overrides: {
+          first_release_date: null,
+          release_dates: [{ id: 1, y: 1_000_000_000 }],
+        },
       },
     ])(
       'release_date is always a valid Date ($label)',

--- a/lib/normalise/game.ts
+++ b/lib/normalise/game.ts
@@ -40,6 +40,8 @@ function pickPublisherName(
 // year wins so the chronological timeline (Epic 10) sorts by canonical
 // release. y must be > 0 because JS Date.UTC(0, ...) maps year 0 -> 1900
 // (two-digit-year rule) and IGDB uses y: 0 as an "unknown year" sentinel.
+// y <= 275760 because JS Date.UTC overflows beyond that range; a far-future
+// IGDB placeholder would otherwise yield an Invalid Date and violate NFR13.
 function computeReleaseDate(source: IgdbGame): Date {
   if (
     typeof source.first_release_date === 'number' &&
@@ -52,10 +54,15 @@ function computeReleaseDate(source: IgdbGame): Date {
   const validYears = source.release_dates
     ?.map((r) => r.y)
     .filter(
-      (y): y is number => typeof y === 'number' && Number.isFinite(y) && y > 0,
+      (y): y is number =>
+        typeof y === 'number' &&
+        Number.isFinite(y) &&
+        y > 0 &&
+        y <= 275760,
     )
   if (validYears && validYears.length > 0) {
-    return new Date(Date.UTC(Math.min(...validYears), 0, 1))
+    const utc = Date.UTC(Math.min(...validYears), 0, 1)
+    if (!Number.isNaN(utc)) return new Date(utc)
   }
   return new Date(RELEASE_DATE_SENTINEL)
 }
@@ -84,19 +91,19 @@ export function normaliseIgdbGame(
   const source = IgdbGameSchema.parse(raw)
 
   // IgdbCoverSchema / IgdbScreenshotSchema accept empty-string image_id; the
-  // `|| null` and `.filter(...)` guards stop empty strings from reaching the
-  // DB (which would produce broken CDN URLs at render time via
-  // lib/api/igdb-images.ts).
+  // `.trim() || null` and `.filter(...)` guards stop empty AND whitespace-only
+  // strings from reaching the DB (which would produce broken CDN URLs at
+  // render time via lib/api/igdb-images.ts).
   const base: Prisma.MediaItemCreateInput = {
     type: MediaType.GAME,
     title: source.name,
     release_date: computeReleaseDate(source),
     overview: source.summary ?? null,
-    poster_path: source.cover?.image_id || null,
+    poster_path: source.cover?.image_id?.trim() || null,
     screenshots:
       source.screenshots
         ?.map((s) => s.image_id)
-        .filter((id) => id.length > 0) ?? [],
+        .filter((id) => id.trim().length > 0) ?? [],
     genres: source.genres?.map((g) => g.name) ?? [],
     platforms: source.platforms?.map((p) => p.name) ?? [],
     developer_name: pickDeveloperName(source.involved_companies),


### PR DESCRIPTION
## Summary
- Apply 3 patches from Pass 4 bmad-code-review (2026-05-27) on the merged Bundle B ([PR #152](https://github.com/LuigiEspinosa/cuatro-tracker/pull/152)). Acceptance Auditor confirmed all 20 ACs satisfied; this followup carries the patches and the +3 regression tests.
- Mirrors the Bundle A -> [PR #148](https://github.com/LuigiEspinosa/cuatro-tracker/pull/148) followup pattern.
- Closes [#153](https://github.com/LuigiEspinosa/cuatro-tracker/issues/153).

## Patches
- **P1** `lib/normalise/game.ts` -- `computeReleaseDate` year-only fallback: post-construction NaN guard on `Date.UTC(...)` plus an upper-bound `y <= 275760` filter (JS Date.UTC overflow boundary). Pre-patch a far-future `release_dates[].y` would violate NFR13.
- **P3** `lib/normalise/game.ts` -- cover + screenshot `.trim()` guards so whitespace-only `image_id`s (`"  "`, truthy in JS) no longer reach the DB and break the IGDB CDN URL at render.
- **P5** `components/molecules/SearchResultRow/__tests__/SearchResultRow.test.tsx` -- em-dash to comma in test comment, enforcing the workspace no-em-dash policy.

## Tests
+3 cases in `lib/normalise/__tests__/game.test.ts`:
- whitespace `cover.image_id` (`"  "`) returns `poster_path: null`
- whitespace `screenshots[].image_id` (`"   "`) is filtered out
- NFR13 `it.each`: `release_dates[].y === 1_000_000_000` still produces a valid Date via the sentinel fallback

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint --max-warnings=0` clean
- [x] `pnpm test lib/normalise/__tests__/game.test.ts components/molecules/SearchResultRow/__tests__/SearchResultRow.test.tsx` scoped green
- [x] `pnpm test` full sweep 928/928 (was 925; +3 new)
- [ ] Browser visual smoke not required: changes are normaliser + 1 test comment; no UI surface touched

## Deferred / decision-needed
7 additional findings appended to `_bmad-output/implementation-artifacts/deferred-work.md` under "Bundle B Pass 4". 1 decision-needed (`deriveYear === 1970` sentinel collision with real 1970 releases) deferred to Epic 10 per owner direction.