### PR TITLE
feat(games): /games/[id] detail with achievements + private banner

### DIFF
--- a/app/(media)/games/[id]/not-found.tsx
+++ b/app/(media)/games/[id]/not-found.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function GameNotFound() {
+  return (
+    <main className='anime-not-found'>
+      <h1>&gt; GAME NOT IN LIBRARY</h1>
+      <p>Try adding it from the search.</p>
+      <Link href='/games' className='crt-pixel-button'>
+        &gt; BACK TO GAMES LIBRARY
+      </Link>
+    </main>
+  )
+}

--- a/app/(media)/games/[id]/page.tsx
+++ b/app/(media)/games/[id]/page.tsx
@@ -1,0 +1,281 @@
+import type { ReactNode } from 'react'
+import Image from 'next/image'
+import { notFound } from 'next/navigation'
+import { MediaType } from '@prisma/client'
+import { db } from '@/lib/db'
+import { findUserEntryByMediaItemId } from '@/lib/db/library'
+import { getGame, IgdbApiError, type IgdbGame } from '@/lib/api/igdb'
+import { getGameImageUrl } from '@/lib/api/igdb-images'
+import { logger } from '@/lib/logger'
+import { BackToLibraryLink } from '@/components/molecules/BackToLibraryLink'
+import { DetailHero } from '@/components/organisms/DetailHero'
+import { SectionBand } from '@/components/organisms/SectionBand/SectionBand'
+import { StatusBanner } from '@/components/molecules/StatusBanner'
+import { PrivateProfileBanner } from '@/components/molecules/PrivateProfileBanner'
+import {
+  AchievementList,
+  type AchievementListItem,
+} from '@/components/organisms/AchievementList'
+import type { MetadataItem } from '@/components/molecules/MetadataRow'
+
+export const dynamic = 'force-dynamic'
+
+type PageParams = Promise<{ id: string }>
+
+function deriveYear(d: Date): number | null {
+  const y = d.getUTCFullYear()
+  return y === 1970 ? null : y
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: PageParams
+}): Promise<{ title: string }> {
+  const { id } = await params
+  const entry = await findUserEntryByMediaItemId(id)
+  if (!entry) return { title: 'NOT IN LIBRARY · Cuatro Tracker' }
+  return {
+    title: `${entry.media_item.title.toUpperCase()} · Cuatro Tracker`,
+  }
+}
+
+async function resolveIgdbGame(igdbId: number): Promise<IgdbGame | null> {
+  try {
+    return await getGame(igdbId)
+  } catch (err) {
+    if (err instanceof IgdbApiError) {
+      logger.warn(
+        { event: 'game_detail.igdb_unavailable', igdbId, err },
+        'IGDB getGame failed; game detail degrades to DB-only metadata',
+      )
+      return null
+    }
+    throw err
+  }
+}
+
+function renderAchievementSection(
+  syncStatus: string,
+  achievements: AchievementListItem[],
+  gameId: string,
+): ReactNode {
+  switch (syncStatus) {
+    case 'private_profile':
+      return (
+        <>
+          <PrivateProfileBanner />
+          <section className='game-detail-private-placeholder'>
+            <p className='achievement-list-empty'>
+              &gt; WAITING FOR FIRST SYNC AFTER PROFILE GOES PUBLIC
+            </p>
+          </section>
+        </>
+      )
+    case 'never_synced':
+      return (
+        <>
+          <StatusBanner
+            variant='info'
+            primary='ACHIEVEMENTS NOT YET SYNCED'
+            secondary='Next Steam sync runs every 6 hours.'
+          />
+          <p className='achievement-list-empty'>&gt; SYNC PENDING</p>
+        </>
+      )
+    case 'failed':
+      return (
+        <>
+          <StatusBanner
+            variant='error'
+            primary='ACHIEVEMENT SYNC FAILED'
+            secondary='Retrying on the next 6-hour cycle.'
+          />
+          {achievements.length > 0 ? (
+            <AchievementList achievements={achievements} gameId={gameId} />
+          ) : (
+            <p className='achievement-list-empty'>
+              &gt; COULD NOT LOAD ACHIEVEMENTS
+            </p>
+          )}
+        </>
+      )
+    default:
+      return <AchievementList achievements={achievements} gameId={gameId} />
+  }
+}
+
+export default async function GameDetailPage({
+  params,
+}: {
+  params: PageParams
+}) {
+  const { id } = await params
+  if (!id) notFound()
+
+  const entry = await findUserEntryByMediaItemId(id)
+  if (!entry || entry.media_item.type !== MediaType.GAME) notFound()
+  if (entry.media_item.igdb_id === null) {
+    logger.warn(
+      { event: 'game_detail.missing_igdb_id', mediaItemId: id },
+      'GAME row has no igdb_id; rendering 404',
+    )
+    notFound()
+  }
+
+  const igdbId = entry.media_item.igdb_id
+
+  // IGDB is fetched in parallel as a best-effort warm read so the page degrades
+  // gracefully when IGDB is unavailable. The result is not consumed today:
+  // upstream `status` is not part of IgdbGameSchema and screenshots render from
+  // the persisted DB row, which is the source of truth for every shown field.
+  const [, achievementRows] = await Promise.all([
+    resolveIgdbGame(igdbId),
+    db.achievement.findMany({
+      where: { game_id: id },
+      orderBy: [
+        { unlocked: 'desc' },
+        { unlocked_at: 'desc' },
+        { steam_api_name: 'asc' },
+      ],
+    }),
+  ])
+
+  const achievements: AchievementListItem[] = achievementRows.map((a) => ({
+    id: a.id,
+    steam_api_name: a.steam_api_name,
+    display_name: a.display_name,
+    description: a.description,
+    icon_url: a.icon_url,
+    unlocked: a.unlocked,
+    unlocked_at: a.unlocked_at,
+    percent_global: a.percent_global,
+  }))
+
+  const year = deriveYear(entry.media_item.release_date)
+  const platforms = entry.media_item.platforms
+  const genres = entry.media_item.genres
+  const screenshots = entry.media_item.screenshots.filter(
+    (imageId) => imageId.trim().length > 0,
+  )
+
+  const metadata: MetadataItem[] = []
+  if (platforms.length > 0) {
+    metadata.push({ value: platforms.slice(0, 3).join(' · ').toUpperCase() })
+  }
+  if (
+    entry.media_item.playtime_minutes !== null &&
+    entry.media_item.playtime_minutes > 0
+  ) {
+    metadata.push({
+      value: `${Math.max(1, Math.round(entry.media_item.playtime_minutes / 60))} HRS`,
+    })
+  }
+  if (entry.media_item.developer_name) {
+    metadata.push({ value: entry.media_item.developer_name.toUpperCase() })
+  }
+  if (year !== null) metadata.push({ value: String(year) })
+  if (genres.length > 0) {
+    metadata.push({
+      value: genres.map((g) => g.toUpperCase()).join(' · '),
+      dim: true,
+    })
+  }
+
+  const synopsisParagraphs = (entry.media_item.overview ?? '')
+    .split(/\n+/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+
+  const posterUrl = entry.media_item.poster_path
+    ? getGameImageUrl(entry.media_item.poster_path, 't_cover_big')
+    : null
+
+  const mediumLabel = `GAME${year !== null ? ` · ${year}` : ''}`
+
+  return (
+    <main className='game-detail-page'>
+      <BackToLibraryLink medium='games' />
+      <DetailHero
+        mediaItemId={entry.media_item_id}
+        medium='games'
+        mediumLabel={mediumLabel}
+        title={entry.media_item.title}
+        originalTitle={entry.media_item.original_title}
+        posterUrl={posterUrl}
+        metadata={metadata}
+        currentStatus={entry.status}
+        imdbId={null}
+        showQbtButton={true}
+      />
+      <div className='anime-detail-rule' aria-hidden='true' />
+      {synopsisParagraphs.length > 0 ? (
+        <article className='anime-detail-synopsis'>
+          {synopsisParagraphs.map((para, idx) => (
+            <p key={idx}>{para}</p>
+          ))}
+        </article>
+      ) : null}
+      <div
+        className='anime-detail-rule anime-detail-rule-thick'
+        aria-hidden='true'
+      />
+      {screenshots.length > 0 ? (
+        <SectionBand title='Screenshots' count={screenshots.length}>
+          <ul className='game-detail-screenshots'>
+            {screenshots.map((imageId, idx) => (
+              <li key={imageId}>
+                <a
+                  href={getGameImageUrl(imageId, 't_1080p')}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  <Image
+                    src={getGameImageUrl(imageId, 't_screenshot_med')}
+                    alt={`${entry.media_item.title} screenshot ${idx + 1}`}
+                    width={569}
+                    height={320}
+                  />
+                </a>
+              </li>
+            ))}
+          </ul>
+        </SectionBand>
+      ) : null}
+      <SectionBand title='Achievements'>
+        {renderAchievementSection(
+          entry.media_item.achievement_sync_status,
+          achievements,
+          entry.media_item_id,
+        )}
+      </SectionBand>
+      {platforms.length > 0 ? (
+        <SectionBand title='Platforms'>
+          <ul className='game-detail-platform-list'>
+            {platforms.map((p) => (
+              <li key={p} className='anime-detail-studio-chip'>
+                {p}
+              </li>
+            ))}
+          </ul>
+        </SectionBand>
+      ) : null}
+      {genres.length > 0 ? (
+        <SectionBand title='Genres'>
+          <ul className='game-detail-genre-list'>
+            {genres.map((g) => (
+              <li key={g} className='anime-detail-studio-chip'>
+                {g}
+              </li>
+            ))}
+          </ul>
+        </SectionBand>
+      ) : null}
+      <SectionBand title='Related'>
+        <p className='game-detail-placeholder'>
+          Franchise relations ship in Phase 10.
+        </p>
+      </SectionBand>
+    </main>
+  )
+}

--- a/app/global.css
+++ b/app/global.css
@@ -3485,3 +3485,185 @@ body {
   margin: 0;
 }
 
+/* ============================================================
+   Game detail page (Story 9.5). Reuses the anime/manga detail
+   primitives (.anime-detail-rule, .anime-detail-synopsis,
+   .anime-detail-studio-chip) for visual continuity; only the
+   screenshots band, achievement list, and private-profile banner
+   are game-specific.
+   ============================================================ */
+
+.game-detail-page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.game-detail-placeholder {
+  font-family: var(--font-body), serif;
+  font-style: italic;
+  color: var(--phosphor-cream-dim);
+  margin: 0;
+  padding: 16px 0;
+}
+
+.game-detail-platform-list,
+.game-detail-genre-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+/* Screenshots band: horizontal scroller of IGDB t_screenshot_med thumbnails,
+   each linking out to the t_1080p full-resolution view. */
+.game-detail-screenshots {
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 8px;
+  list-style: none;
+  margin: 0;
+}
+.game-detail-screenshots li {
+  flex: 0 0 auto;
+}
+.game-detail-screenshots img {
+  display: block;
+  width: auto;
+  height: 160px;
+  border: 1px solid var(--frame-stroke-games);
+  box-shadow: var(--frame-stroke-games-glow);
+}
+
+/* Private-profile banner. The achievement list is gated OFF the page in the
+   private_profile state (AchievementList is not rendered); stale Achievement
+   rows stay in the DB and are merely hidden here, deletion-on-flip is deferred. */
+.private-profile-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+.private-profile-banner-link {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream);
+  text-decoration: none;
+}
+.private-profile-banner-link:hover,
+.private-profile-banner-link:focus-visible {
+  color: var(--led-on-hold);
+}
+.game-detail-private-placeholder {
+  margin: 0;
+}
+
+/* AchievementList organism: UNLOCKED / LOCKED sub-bands with per-row rarity. */
+.achievement-list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.achievement-list-empty {
+  font-family: var(--font-mono), monospace;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  color: var(--phosphor-cream-dim);
+  margin: 0;
+  padding: 16px 0;
+}
+.achievement-list-summary {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--phosphor-cream);
+}
+.achievement-list-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.achievement-list-section > ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.achievement-list-section-title {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 18px;
+  letter-spacing: 0.05em;
+  color: var(--phosphor-cream);
+  margin: 0;
+}
+.achievement-list-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 0;
+}
+.achievement-list-row-icon,
+.achievement-list-row-icon-placeholder {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+}
+.achievement-list-row-icon-placeholder {
+  border: 1px solid var(--phosphor-cream-ghost);
+  opacity: 0.4;
+}
+.achievement-list-row[data-unlocked='false'] .achievement-list-row-icon {
+  opacity: 0.4;
+}
+.achievement-list-row-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.achievement-list-row-name {
+  font-family: var(--font-display);
+  font-size: 14px;
+  color: var(--phosphor-cream);
+  margin: 0;
+}
+.achievement-list-row-desc {
+  font-family: var(--font-body), serif;
+  font-size: 13px;
+  color: var(--phosphor-cream-dim);
+  margin: 2px 0 0;
+}
+.achievement-list-row-date {
+  flex: 0 0 auto;
+  font-family: var(--font-mono), monospace;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  font-variant-numeric: tabular-nums;
+  color: var(--phosphor-cream-dim);
+}
+.achievement-list-row-rarity {
+  flex: 0 0 auto;
+  font-family: var(--font-mono), monospace;
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+.achievement-list-row[data-rarity='rare'] .achievement-list-row-rarity {
+  color: var(--magenta);
+}
+.achievement-list-row[data-rarity='uncommon'] .achievement-list-row-rarity {
+  color: var(--led-on-hold);
+}
+.achievement-list-row[data-rarity='common'] .achievement-list-row-rarity {
+  color: var(--phosphor-cream-dim);
+}
+

--- a/components/molecules/PrivateProfileBanner/PrivateProfileBanner.tsx
+++ b/components/molecules/PrivateProfileBanner/PrivateProfileBanner.tsx
@@ -1,0 +1,30 @@
+import { StatusBanner } from '@/components/molecules/StatusBanner'
+
+export type PrivateProfileBannerProps = {
+  steamProfileUrl?: string
+}
+
+export function PrivateProfileBanner({
+  steamProfileUrl,
+}: PrivateProfileBannerProps) {
+  const settingsUrl = steamProfileUrl
+    ? `${steamProfileUrl}/edit/settings`
+    : 'https://steamcommunity.com/my/edit/settings'
+  return (
+    <div className='private-profile-banner'>
+      <StatusBanner
+        variant='warning'
+        primary='ACHIEVEMENTS LOCKED'
+        secondary='Set your Steam profile to Public to track achievements.'
+      />
+      <a
+        className='private-profile-banner-link'
+        href={settingsUrl}
+        target='_blank'
+        rel='noopener noreferrer'
+      >
+        OPEN STEAM PRIVACY SETTINGS →
+      </a>
+    </div>
+  )
+}

--- a/components/molecules/PrivateProfileBanner/__tests__/PrivateProfileBanner.test.tsx
+++ b/components/molecules/PrivateProfileBanner/__tests__/PrivateProfileBanner.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PrivateProfileBanner } from '../PrivateProfileBanner'
+
+describe('PrivateProfileBanner', () => {
+  it('renders the warning banner copy and the privacy-settings link', () => {
+    render(<PrivateProfileBanner />)
+    expect(screen.getByText('ACHIEVEMENTS LOCKED')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Set your Steam profile to Public to track achievements.',
+      ),
+    ).toBeInTheDocument()
+    const link = screen.getByRole('link', {
+      name: /OPEN STEAM PRIVACY SETTINGS/i,
+    })
+    expect(link).toHaveAttribute(
+      'href',
+      'https://steamcommunity.com/my/edit/settings',
+    )
+  })
+
+  it('opens the settings link in a new tab without leaking window.opener', () => {
+    render(<PrivateProfileBanner />)
+    const link = screen.getByRole('link', {
+      name: /OPEN STEAM PRIVACY SETTINGS/i,
+    })
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('appends /edit/settings to a provided steamProfileUrl', () => {
+    render(
+      <PrivateProfileBanner steamProfileUrl='https://steamcommunity.com/id/cuatro' />,
+    )
+    const link = screen.getByRole('link', {
+      name: /OPEN STEAM PRIVACY SETTINGS/i,
+    })
+    expect(link).toHaveAttribute(
+      'href',
+      'https://steamcommunity.com/id/cuatro/edit/settings',
+    )
+  })
+
+  it('contains no emoji glyphs in the rendered text', () => {
+    const { container } = render(<PrivateProfileBanner />)
+    const text = container.textContent ?? ''
+    // Guard against the lock (U+1F512) and warning-sign (U+26A0) glyphs;
+    // the warning semantic is carried by StatusBanner's orange tone, not an emoji.
+    expect(text).not.toMatch(/[\u{1F512}\u{26A0}]/u)
+  })
+})

--- a/components/molecules/PrivateProfileBanner/index.ts
+++ b/components/molecules/PrivateProfileBanner/index.ts
@@ -1,0 +1,2 @@
+export { PrivateProfileBanner } from './PrivateProfileBanner'
+export type { PrivateProfileBannerProps } from './PrivateProfileBanner'

--- a/components/organisms/AchievementList/AchievementList.tsx
+++ b/components/organisms/AchievementList/AchievementList.tsx
@@ -1,0 +1,123 @@
+import Image from 'next/image'
+import { PhosphorBar } from '@/components/atoms/PhosphorBar'
+
+export type AchievementListItem = {
+  id: string
+  steam_api_name: string
+  display_name: string
+  description: string | null
+  icon_url: string | null
+  unlocked: boolean
+  unlocked_at: Date | null
+  percent_global: number | null
+}
+
+export type AchievementListProps = {
+  achievements: AchievementListItem[]
+  // gameId is reserved for a future per-row Steam-deeplink action; today the
+  // list is a pure read so it is intentionally not consumed in the render.
+  gameId: string
+}
+
+type RarityChip = { label: string; tone: 'rare' | 'uncommon' | 'common' }
+
+function rarityChip(pct: number | null): RarityChip | null {
+  if (pct === null) return null
+  if (pct < 10) return { label: 'RARE', tone: 'rare' }
+  if (pct < 50) return { label: 'UNCOMMON', tone: 'uncommon' }
+  // Covers >= 50 and the >= 100 soft-clamp (Steam can report slightly above 100
+  // on small player populations; there is no CHECK constraint per Q-CHECK).
+  return { label: 'COMMON', tone: 'common' }
+}
+
+function formatUnlockedDate(d: Date | null): string | null {
+  if (d === null) return null
+  return d.toISOString().slice(0, 10)
+}
+
+function AchievementRow({ item }: { item: AchievementListItem }) {
+  const rarity = rarityChip(item.percent_global)
+  const unlockedDate = formatUnlockedDate(item.unlocked_at)
+  return (
+    <li
+      className='achievement-list-row'
+      data-unlocked={String(item.unlocked)}
+      data-rarity={rarity?.tone ?? 'none'}
+    >
+      {item.icon_url ? (
+        <Image
+          className='achievement-list-row-icon'
+          src={item.icon_url}
+          width={24}
+          height={24}
+          alt=''
+        />
+      ) : (
+        <span className='achievement-list-row-icon-placeholder' aria-hidden='true' />
+      )}
+      <div className='achievement-list-row-text'>
+        <p className='achievement-list-row-name'>{item.display_name}</p>
+        {item.description ? (
+          <p className='achievement-list-row-desc'>{item.description}</p>
+        ) : null}
+      </div>
+      {unlockedDate ? (
+        <span className='achievement-list-row-date'>{unlockedDate}</span>
+      ) : null}
+      {rarity ? (
+        <span className='achievement-list-row-rarity'>{rarity.label}</span>
+      ) : null}
+    </li>
+  )
+}
+
+export function AchievementList({ achievements }: AchievementListProps) {
+  if (achievements.length === 0) {
+    return (
+      <p className='achievement-list-empty'>
+        &gt; NO ACHIEVEMENTS FOR THIS GAME
+      </p>
+    )
+  }
+
+  const unlocked = achievements.filter((a) => a.unlocked)
+  const locked = achievements.filter((a) => !a.unlocked)
+  const pct = Math.round((unlocked.length / achievements.length) * 100)
+
+  return (
+    <div className='achievement-list'>
+      <div className='achievement-list-summary'>
+        {unlocked.length} / {achievements.length} · {pct}%
+      </div>
+      <PhosphorBar
+        value={unlocked.length}
+        max={achievements.length}
+        label={`${unlocked.length} / ${achievements.length} achievements unlocked`}
+      />
+      {unlocked.length > 0 ? (
+        <section className='achievement-list-section' data-state='unlocked'>
+          <h3 className='achievement-list-section-title'>
+            UNLOCKED ({unlocked.length})
+          </h3>
+          <ul>
+            {unlocked.map((a) => (
+              <AchievementRow key={a.id} item={a} />
+            ))}
+          </ul>
+        </section>
+      ) : null}
+      {locked.length > 0 ? (
+        <section className='achievement-list-section' data-state='locked'>
+          <h3 className='achievement-list-section-title'>
+            LOCKED ({locked.length})
+          </h3>
+          <ul>
+            {locked.map((a) => (
+              <AchievementRow key={a.id} item={a} />
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  )
+}

--- a/components/organisms/AchievementList/__tests__/AchievementList.test.tsx
+++ b/components/organisms/AchievementList/__tests__/AchievementList.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import {
+  AchievementList,
+  type AchievementListItem,
+} from '../AchievementList'
+
+function makeItem(
+  overrides: Partial<AchievementListItem> & { id: string },
+): AchievementListItem {
+  return {
+    steam_api_name: overrides.id,
+    display_name: overrides.id,
+    description: null,
+    icon_url: null,
+    unlocked: false,
+    unlocked_at: null,
+    percent_global: null,
+    ...overrides,
+  }
+}
+
+const MIXED: AchievementListItem[] = [
+  makeItem({
+    id: 'a1',
+    display_name: 'Rare Unlocked',
+    unlocked: true,
+    unlocked_at: new Date('2024-03-15T08:00:00Z'),
+    percent_global: 5,
+  }),
+  makeItem({
+    id: 'a2',
+    display_name: 'Uncommon Unlocked',
+    unlocked: true,
+    percent_global: 25,
+  }),
+  makeItem({
+    id: 'a3',
+    display_name: 'Common Locked',
+    unlocked: false,
+    percent_global: 75,
+  }),
+  makeItem({
+    id: 'a4',
+    display_name: 'Clamped Locked',
+    unlocked: false,
+    percent_global: 100,
+  }),
+  makeItem({
+    id: 'a5',
+    display_name: 'Unknown Locked',
+    unlocked: false,
+    percent_global: null,
+  }),
+]
+
+describe('AchievementList', () => {
+  it('derives rarity chips from percent_global at the documented breakpoints', () => {
+    render(<AchievementList achievements={MIXED} gameId='game-1' />)
+    expect(screen.getByText('RARE')).toBeInTheDocument()
+    expect(screen.getByText('UNCOMMON')).toBeInTheDocument()
+    // 75 and the >= 100 soft-clamp both resolve to COMMON.
+    expect(screen.getAllByText('COMMON')).toHaveLength(2)
+  })
+
+  it('soft-clamps percent_global >= 100 to COMMON and renders no chip when null', () => {
+    render(<AchievementList achievements={MIXED} gameId='game-1' />)
+    expect(screen.getByText('Clamped Locked').closest('li')).toHaveAttribute(
+      'data-rarity',
+      'common',
+    )
+    const unknownRow = screen.getByText('Unknown Locked').closest('li')
+    expect(unknownRow).toHaveAttribute('data-rarity', 'none')
+    expect(unknownRow?.textContent).not.toMatch(/RARE|UNCOMMON|COMMON/)
+  })
+
+  it('groups unlocked rows under UNLOCKED and locked rows under LOCKED', () => {
+    const { container } = render(
+      <AchievementList achievements={MIXED} gameId='game-1' />,
+    )
+    const unlockedSection = container.querySelector("[data-state='unlocked']")
+    const lockedSection = container.querySelector("[data-state='locked']")
+    expect(unlockedSection).toHaveTextContent('Rare Unlocked')
+    expect(unlockedSection).toHaveTextContent('Uncommon Unlocked')
+    expect(unlockedSection).not.toHaveTextContent('Common Locked')
+    expect(lockedSection).toHaveTextContent('Common Locked')
+    expect(lockedSection).toHaveTextContent('Unknown Locked')
+    expect(lockedSection).not.toHaveTextContent('Rare Unlocked')
+  })
+
+  it('drives the PhosphorBar from unlocked count over total', () => {
+    render(<AchievementList achievements={MIXED} gameId='game-1' />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '2')
+    expect(bar).toHaveAttribute('aria-valuemax', '5')
+  })
+
+  it('renders the summary line and formats unlocked dates as YYYY-MM-DD (UTC)', () => {
+    const { container } = render(
+      <AchievementList achievements={MIXED} gameId='game-1' />,
+    )
+    expect(container.querySelector('.achievement-list-summary')).toHaveTextContent(
+      '2 / 5 · 40%',
+    )
+    expect(screen.getByText('2024-03-15')).toBeInTheDocument()
+  })
+
+  it('renders an empty-state row and no PhosphorBar for an empty list', () => {
+    render(<AchievementList achievements={[]} gameId='game-1' />)
+    expect(
+      screen.getByText(/NO ACHIEVEMENTS FOR THIS GAME/),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('progressbar')).toBeNull()
+  })
+})

--- a/components/organisms/AchievementList/index.ts
+++ b/components/organisms/AchievementList/index.ts
@@ -1,0 +1,2 @@
+export { AchievementList } from './AchievementList'
+export type { AchievementListItem, AchievementListProps } from './AchievementList'

--- a/e2e/games-detail.spec.ts
+++ b/e2e/games-detail.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+
+// Story 9.5 AC-13: the /games/[id] detail page.
+//
+//   Scenario 1 (private-profile, canonical): a GAME whose
+//   achievement_sync_status is 'private_profile' renders the
+//   PrivateProfileBanner + the WAITING FOR FIRST SYNC placeholder INSTEAD of
+//   the achievement list, and the hero WatchStatusControl still mutates end to
+//   end. A live Steam 403 is not reproducible in CI, so this scenario is gated
+//   on E2E_PRIVATE_PROFILE_GAME_ID: a GAME row pre-seeded and flipped to
+//   achievement_sync_status='private_profile' out of band. It skips cleanly
+//   when that fixture is absent.
+//
+//   Scenario 2 (404 smoke): an unknown id routes to the themed not-found page.
+//   No TMDB/IGDB/Steam dependency, so it gates on ADMIN_PASS alone.
+
+const ADMIN_PASS = process.env.ADMIN_PASS
+const PRIVATE_GAME_ID = process.env.E2E_PRIVATE_PROFILE_GAME_ID
+
+async function login(page: import('@playwright/test').Page): Promise<void> {
+  await page.goto('/login')
+  await page.getByLabel('PASSWORD').fill(ADMIN_PASS!)
+  await page.getByRole('button', { name: '> LOG IN' }).click()
+  await page.waitForURL('/', { timeout: 10_000 })
+}
+
+async function setStatus(
+  api: APIRequestContext,
+  mediaItemId: string,
+  status: string,
+): Promise<void> {
+  const res = await api.fetch('/api/progress', {
+    method: 'PUT',
+    data: { mediaItemId, status, completed_at: null },
+  })
+  expect(res.ok()).toBeTruthy()
+}
+
+test.describe('/games/[id] detail page (Story 9.5)', () => {
+  test('AC-13: private-profile game shows the banner + placeholder, hides the achievement list, and the status control still mutates', async ({
+    page,
+  }) => {
+    test.skip(
+      !ADMIN_PASS || !PRIVATE_GAME_ID,
+      'Requires ADMIN_PASS + E2E_PRIVATE_PROFILE_GAME_ID (a GAME row flipped to achievement_sync_status=private_profile out of band).',
+    )
+
+    await login(page)
+
+    // Reset the entry status so selecting WATCHING below is a real transition
+    // (the control no-ops when the next status equals the current one).
+    const api = page.request
+    await setStatus(api, PRIVATE_GAME_ID!, 'PLAN_TO_WATCH')
+
+    await page.goto(`/games/${PRIVATE_GAME_ID}`)
+
+    // The PrivateProfileBanner renders in place of the achievement list.
+    await expect(page.getByText(/ACHIEVEMENTS LOCKED/i)).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(page.getByText(/WAITING FOR FIRST SYNC/i)).toBeVisible()
+    // The achievement list itself is gated off the page in the private state.
+    await expect(page.locator('.achievement-list')).toHaveCount(0)
+
+    // The hero WatchStatusControl still mutates end to end
+    // (PLAN TO WATCH -> WATCHING). Labels are the raw WatchStatus enum names;
+    // the per-medium relabel (PLAYING) is deferred (Q-LABELS).
+    await page.locator('.watch-status-control-button').click()
+    await page.getByRole('option', { name: /WATCHING/ }).click()
+    await expect(page.getByText(/STATUS.*WATCHING/i)).toBeVisible({
+      timeout: 10_000,
+    })
+
+    // Restore the starting state so the fixture is reusable across runs.
+    await setStatus(api, PRIVATE_GAME_ID!, 'PLAN_TO_WATCH')
+  })
+
+  test('returns the themed not-found page for an unknown game id', async ({
+    page,
+  }) => {
+    test.skip(
+      !ADMIN_PASS,
+      'Requires ADMIN_PASS to authenticate. Asserts page chrome only.',
+    )
+
+    await login(page)
+
+    await page.goto('/games/this-id-does-not-exist')
+    await expect(page.getByText(/GAME NOT IN LIBRARY/i)).toBeVisible()
+    await expect(
+      page.getByRole('link', { name: /BACK TO GAMES LIBRARY/i }),
+    ).toBeVisible()
+  })
+})

--- a/lib/jobs/__tests__/steamAchievementSync.test.ts
+++ b/lib/jobs/__tests__/steamAchievementSync.test.ts
@@ -116,8 +116,8 @@ describe('steamAchievementSync processor (BullMQ integration, mocked db + fetch)
             jsonResponse({
               achievementpercentages: {
                 achievements: [
+                  // ach_02 intentionally omitted so its percent_global degrades to null.
                   { name: 'ach_01', percent: 75.5 },
-                  { name: 'ach_02', percent: 30.0 },
                 ],
               },
             }),
@@ -175,7 +175,23 @@ describe('steamAchievementSync processor (BullMQ integration, mocked db + fetch)
           steam_api_name: 'ach_01',
           display_name: 'First Steps',
           unlocked: true,
+          percent_global: 75.5,
         }),
+        update: expect.objectContaining({ percent_global: 75.5 }),
+      })
+
+      // ach_02 is absent from GetGlobalAchievementPercentagesForApp, so its
+      // percent_global degrades to null on both upsert branches.
+      const secondUpsertArgs = dbMock.achievement.upsert.mock.calls[1]![0]
+      expect(secondUpsertArgs).toMatchObject({
+        where: {
+          game_id_steam_api_name: {
+            game_id: 'game-1',
+            steam_api_name: 'ach_02',
+          },
+        },
+        create: expect.objectContaining({ percent_global: null }),
+        update: expect.objectContaining({ percent_global: null }),
       })
 
       const updateCalls = dbMock.mediaItem.update.mock.calls

--- a/lib/jobs/steamAchievementSync.ts
+++ b/lib/jobs/steamAchievementSync.ts
@@ -135,6 +135,7 @@ export async function steamAchievementSyncProcessor(
             icon_url: meta?.icon ?? null,
             unlocked: ach.unlocked,
             unlocked_at: ach.unlocked_at,
+            percent_global: ach.percent_global,
           },
           update: {
             display_name: meta?.displayName ?? ach.steam_api_name,
@@ -142,6 +143,7 @@ export async function steamAchievementSyncProcessor(
             icon_url: meta?.icon ?? null,
             unlocked: ach.unlocked,
             unlocked_at: ach.unlocked_at,
+            percent_global: ach.percent_global,
           },
         })
       })

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,9 @@ const nextConfig: NextConfig = {
       { protocol: 'https', hostname: 'cdn.cloudflare.steamstatic.com' },
       // E9 games via Steam — secondary host
       { protocol: 'https', hostname: 'media.steampowered.com' },
+      // E9 Steam achievement icons (GetSchemaForGame) can also resolve to Akamai hosts
+      { protocol: 'https', hostname: 'steamcdn-a.akamaihd.net' },
+      { protocol: 'https', hostname: 'cdn.akamai.steamstatic.com' },
       // E9 games via IGDB cover-image CDN
       { protocol: 'https', hostname: 'images.igdb.com' },
     ],

--- a/prisma/migrations/20260528085453_add_achievement_percent_global/migration.sql
+++ b/prisma/migrations/20260528085453_add_achievement_percent_global/migration.sql
@@ -1,0 +1,4 @@
+-- Story 9.5: Achievement.percent_global column for RARE / UNCOMMON / COMMON rarity chips on the /games/[id] detail page.
+-- Nullable: Steam's GetGlobalAchievementPercentagesForApp returns 403/404 for some apps and the adapter swallows that to null.
+-- No CHECK constraint (Q-CHECK): Steam can return values slightly above 100 on small player populations; clamp at render time instead.
+ALTER TABLE "Achievement" ADD COLUMN "percent_global" DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -197,6 +197,7 @@ model Achievement {
   icon_url       String?
   unlocked       Boolean   @default(false)
   unlocked_at    DateTime?
+  percent_global Float? // Steam global achievement percentage (0-100, nullable; null when Steam returns 403/404 from GetGlobalAchievementPercentagesForApp).
 
   @@index([game_id])
   @@unique([game_id, steam_api_name])


### PR DESCRIPTION
## Summary
- Implements Story 9.5, the `/games/[id]` server-rendered detail page (Epic 9 final story), mirroring `/manga/[id]`: notFound guards, best-effort parallel IGDB fetch plus `Achievement.findMany`, per `achievement_sync_status` dispatch, the games metadata row, and the Synopsis / Screenshots / Achievements / Platforms / Genres / Related band stack.
- Adds the `AchievementList` organism (UNLOCKED and LOCKED sub-bands, PhosphorBar, RARE/UNCOMMON/COMMON rarity chips, empty state) and the `PrivateProfileBanner` molecule (reuses `StatusBanner variant=warning`).
- Adds `Achievement.percent_global` (Float?) via migration and persists it on both upsert branches of `steamAchievementSyncProcessor`.
- Folds in BMAD code-review fixes: whitelist the Steam Akamai achievement-icon CDNs in `next.config.ts` (prevents a `next/image` crash on the detail page), suppress the NO ACHIEVEMENTS empty state under a failed sync, floor the playtime display at 1 HRS, and filter empty screenshot image ids.

## Test plan
- [x] `pnpm typecheck` (clean)
- [x] `pnpm lint --max-warnings=0` (zero warnings)
- [x] `pnpm test` (938/938 across 85 files)
- [ ] Browser smoke: log in, open a game detail page, confirm hero + bands + achievement section render (needs auth + a seeded GAME row + live IGDB/Steam creds)
- [ ] `pnpm test:e2e --grep games-detail` (skips locally without ADMIN_PASS / E2E_PRIVATE_PROFILE_GAME_ID; runs in CI)

Story spec: `_bmad-output/implementation-artifacts/9-5-implement-games-id-detail-page-with-achievements-private-profile-banner.md`. Closes Epic 9 (final story; 9.1 through 9.4 already merged). No GitHub issue was created for this story, so there is no `Closes #N` ref; add one before merge if you want auto-close.